### PR TITLE
Add reviewer role mapping to plan-review skill

### DIFF
--- a/claude/.claude/skills/plan-review/SKILL.md
+++ b/claude/.claude/skills/plan-review/SKILL.md
@@ -251,8 +251,11 @@ about attack vectors while a backend reviewer thinks about API contracts.
 | Security | CISO | Threat modeling, auth boundaries, privilege escalation, data exposure, defense in depth |
 | Data | Staff data engineer | Migration safety, schema design, reversibility, deploy-time compatibility, index coverage, access control on new objects |
 | Infrastructure | Staff DevOps engineer | CI/CD pipelines, IaC, deployment ordering, environment parity, secret provisioning |
+| Testing | Senior SDET | Testability of the design, edge cases the plan omits, test strategy coverage vs risk areas, test data requirements |
+| Product | Staff product engineer | Whether the plan solves the actual user problem, UX impact during migrations, feature interactions, user-facing regressions hidden behind technical framing |
 
 For multi-domain plans, evaluate from each relevant persona. Always include the
+Product persona when the plan changes user-facing behavior. Always include the
 CISO persona when the plan touches auth, authorization, secrets, tokens, data
 exposure, logging of sensitive data, third-party data sharing, or infrastructure
 permissions.

--- a/claude/.claude/skills/plan-review/SKILL.md
+++ b/claude/.claude/skills/plan-review/SKILL.md
@@ -200,7 +200,7 @@ K2. **Error handling completeness** — Does the plan cover both success and err
 
 ## Domain: Security
 
-Apply when the plan touches auth, authorization, secrets, or data exposure.
+Apply when the plan touches auth, authorization, secrets, tokens, or data exposure.
 
 S1. **Threat model** — Does the plan identify what an attacker could do if the
     implementation has a bug? Plans that add auth or access control should enumerate
@@ -247,7 +247,7 @@ about attack vectors while a backend reviewer thinks about API contracts.
 | Domain | Reviewer role | Focus |
 |--------|--------------|-------|
 | Backend | Staff backend engineer | API contracts, error handling, service boundaries, SDK behavior |
-| Frontend | Staff frontend engineer | React/hooks patterns, state management, query cache invalidation, UX impact |
+| Frontend | Staff frontend engineer | Component patterns, state management, query cache invalidation, UX impact |
 | Security | CISO | Threat modeling, auth boundaries, privilege escalation, data exposure, defense in depth |
 | Data | Staff data engineer | Migration safety, schema design, index coverage, access control on new objects |
 | Infrastructure | Staff DevOps engineer | CI/CD pipelines, IaC, deployment ordering, environment parity, secret provisioning |

--- a/claude/.claude/skills/plan-review/SKILL.md
+++ b/claude/.claude/skills/plan-review/SKILL.md
@@ -238,6 +238,27 @@ S6. **Secret lifecycle** — If the plan introduces, rotates, or references secr
 - Generic "add more tests" suggestions, **except** for security controls where
   untested invariants are indistinguishable from absent ones (see S1)
 
+## Reviewer roles
+
+When spawning reviewer agents, adopt the persona that matches each detected
+domain. Different personas catch different things — a security reviewer thinks
+about attack vectors while a backend reviewer thinks about API contracts.
+
+| Domain | Reviewer role | Focus |
+|--------|--------------|-------|
+| Backend | Staff backend engineer | API contracts, error handling, service boundaries, SDK behavior |
+| Frontend | Staff frontend engineer | React/hooks patterns, state management, query cache invalidation, UX impact |
+| Security | CISO | Threat modeling, auth boundaries, privilege escalation, data exposure, defense in depth |
+| Data | Staff data engineer | Migration safety, schema design, index coverage, access control on new objects |
+| Infrastructure | Staff DevOps engineer | CI/CD pipelines, IaC, deployment ordering, environment parity, secret provisioning |
+
+For multi-domain plans, evaluate from each relevant persona. Always include the
+CISO persona when the plan touches auth, authorization, secrets, tokens, or data
+exposure.
+
+Project-level plan-review skills may override or extend this table with
+project-specific reviewer roles and focus areas.
+
 ## Output format
 
 Start with which domains were detected and which plan sections/phases were reviewed.

--- a/claude/.claude/skills/plan-review/SKILL.md
+++ b/claude/.claude/skills/plan-review/SKILL.md
@@ -246,18 +246,20 @@ about attack vectors while a backend reviewer thinks about API contracts.
 
 | Domain | Reviewer role | Focus |
 |--------|--------------|-------|
-| Backend | Staff backend engineer | API contracts, error handling, service boundaries, SDK behavior |
-| Frontend | Staff frontend engineer | Component patterns, state management, query cache invalidation, UX impact |
+| Backend | Staff backend engineer | API contracts, error handling, idempotency, retry semantics, service boundaries, SDK behavior |
+| Frontend | Staff frontend engineer | Component patterns, state management, data fetching and cache consistency, accessibility, UX impact |
 | Security | CISO | Threat modeling, auth boundaries, privilege escalation, data exposure, defense in depth |
-| Data | Staff data engineer | Migration safety, schema design, index coverage, access control on new objects |
+| Data | Staff data engineer | Migration safety, schema design, reversibility, deploy-time compatibility, index coverage, access control on new objects |
 | Infrastructure | Staff DevOps engineer | CI/CD pipelines, IaC, deployment ordering, environment parity, secret provisioning |
 
 For multi-domain plans, evaluate from each relevant persona. Always include the
-CISO persona when the plan touches auth, authorization, secrets, tokens, or data
-exposure.
+CISO persona when the plan touches auth, authorization, secrets, tokens, data
+exposure, logging of sensitive data, third-party data sharing, or infrastructure
+permissions.
 
-Project-level plan-review skills may override or extend this table with
-project-specific reviewer roles and focus areas.
+Project-level plan-review skills may extend this table with project-specific
+reviewer roles and focus areas, but must not remove or narrow the CISO trigger
+conditions.
 
 ## Output format
 


### PR DESCRIPTION
## Summary

- Adds a default reviewer role mapping table to the global plan-review skill
- Maps each domain (Backend, Frontend, Security, Data, Infrastructure) to a specific reviewer persona with focused concerns
- Notes that project-level skills can override or extend the table

## Context

The global plan-review skill told Claude *what to check* (30 checklist items across 5 domains) but not *who to be* when checking. A CISO thinks about attack vectors while a backend engineer thinks about API contracts — the persona matters for catching domain-specific issues.

Identified during DayTag PR #44 review: the DayTag project had a reviewer role mapping but the global skill didn't, which meant the mapping only worked for DayTag projects.

## Test plan

- [x] Verified the table renders correctly in markdown
- [x] Confirmed project-level override language aligns with DayTag's existing table in `daytag-co/daytag` PR #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)