### PR TITLE
Add ripple effect triage to code-review skill

### DIFF
--- a/claude/.claude/skills/code-review/SKILL.md
+++ b/claude/.claude/skills/code-review/SKILL.md
@@ -6,6 +6,17 @@ allowed-tools: Read, Grep, Glob
 
 Review the code that was just written or modified. Act as a principal engineer reviewing a junior engineer's work. Be thorough but not pedantic.
 
+**Core principle: review the ripple effects, not just the change.** Code
+changes don't exist in isolation — they affect callers, consumers, and
+adjacent systems. A migration that restricts column access can break
+frontend workflows. A new API response shape can break every consumer.
+A renamed function can break callers in a different domain. Your job is
+to review both the change AND its impact across system boundaries.
+
+The checklist below catches issues within the change. The ripple effect
+triage step (at the end) identifies cross-boundary impacts that need
+specialist follow-up.
+
 ## Step 0 — Detect changed domains
 
 Before reviewing, determine which files were changed (from context, git diff, or the conversation). Classify each changed file into one or more domains:
@@ -156,3 +167,37 @@ For each finding, state:
 5. **Suggested fix** (concrete, not "consider improving")
 
 If no issues are found, say: "No issues found" — do not pad with praise or generic observations.
+
+## Ripple effect triage
+
+After the checklist review, identify whether the change crosses system
+boundaries and recommend specialist follow-up reviews. This step is
+**always required** — even if the checklist found no issues, ripple
+effects may exist that only a domain specialist would catch.
+
+Evaluate the change against these cross-boundary patterns:
+
+| Change type | Ripple risk | Recommended reviewer |
+|-------------|------------|---------------------|
+| Restricts database access (RLS, GRANT, triggers, validation) | Frontend workflows may break, edge functions may fail | **Product Engineer** — trace each restriction against actual caller code |
+| Changes API response shape (edge functions, RPCs) | Frontend consumers may break | **Product Engineer** — verify all consumers handle the new shape |
+| Adds/modifies security controls | Tests may be inadequate or at wrong layer | **Senior SDET** — verify test pyramid and coverage |
+| Changes auth model (JWT, roles, permissions) | Multiple systems may be affected | **Security Engineer** — trace all auth paths |
+| Modifies shared utilities (`_shared/`, hooks, contexts) | All importers may be affected | **Backend/Frontend Engineer** — verify all call sites |
+| Changes data model (columns, types, defaults) | Queries, types, and UI may be affected | **Product Engineer** + **Backend Engineer** |
+| Modifies infrastructure (CI, deploy, config) | Build/deploy pipelines may break | **DevOps/Infra Engineer** |
+
+**Output format for this section:**
+
+If no cross-boundary impacts are detected:
+> No cross-boundary ripple effects identified.
+
+If impacts are detected, add a **"Recommended follow-up reviews"** section:
+
+> **Recommended follow-up reviews:**
+> - **Product Engineer:** This change restricts [what] — verify [which workflows] still work by tracing [specific code paths].
+> - **Senior SDET:** This change adds [security controls] — verify test pyramid covers [specific properties].
+
+Be specific about WHAT to check, not just WHO should check it. "PE review
+recommended" is useless; "PE should verify that the counter-offer workflow
+still works after the status restriction" is actionable.

--- a/claude/.claude/skills/code-review/SKILL.md
+++ b/claude/.claude/skills/code-review/SKILL.md
@@ -6,16 +6,11 @@ allowed-tools: Read, Grep, Glob
 
 Review the code that was just written or modified. Act as a principal engineer reviewing a junior engineer's work. Be thorough but not pedantic.
 
-**Core principle: review the ripple effects, not just the change.** Code
-changes don't exist in isolation — they affect callers, consumers, and
-adjacent systems. A migration that restricts column access can break
-frontend workflows. A new API response shape can break every consumer.
-A renamed function can break callers in a different domain. Your job is
-to review both the change AND its impact across system boundaries.
-
-The checklist below catches issues within the change. The ripple effect
-triage step (at the end) identifies cross-boundary impacts that need
-specialist follow-up.
+**Core principle: review the ripple effects, not just the change.** The
+checklist below catches issues within the change. The ripple effect triage
+step (at the end) catches cross-boundary impacts — a migration breaking
+frontend workflows, an API shape change breaking consumers, a rename
+breaking callers in another domain.
 
 ## Step 0 — Detect changed domains
 
@@ -175,29 +170,26 @@ boundaries and recommend specialist follow-up reviews. This step is
 **always required** — even if the checklist found no issues, ripple
 effects may exist that only a domain specialist would catch.
 
-Evaluate the change against these cross-boundary patterns:
+Evaluate the change against these cross-boundary patterns. These are
+review *perspectives*, not org chart roles — one person may wear multiple
+hats. Update this table as new patterns emerge.
 
-| Change type | Ripple risk | Recommended reviewer |
-|-------------|------------|---------------------|
-| Restricts database access (RLS, GRANT, triggers, validation) | Frontend workflows may break, edge functions may fail | **Product Engineer** — trace each restriction against actual caller code |
-| Changes API response shape (edge functions, RPCs) | Frontend consumers may break | **Product Engineer** — verify all consumers handle the new shape |
-| Adds/modifies security controls | Tests may be inadequate or at wrong layer | **Senior SDET** — verify test pyramid and coverage |
-| Changes auth model (JWT, roles, permissions) | Multiple systems may be affected | **Security Engineer** — trace all auth paths |
-| Modifies shared utilities (`_shared/`, hooks, contexts) | All importers may be affected | **Backend/Frontend Engineer** — verify all call sites |
-| Changes data model (columns, types, defaults) | Queries, types, and UI may be affected | **Product Engineer** + **Backend Engineer** |
-| Modifies infrastructure (CI, deploy, config) | Build/deploy pipelines may break | **DevOps/Infra Engineer** |
+| Change type | Follow-up |
+|-------------|-----------|
+| Restricts DB access (RLS, GRANT, triggers) | **Product Engineer** — trace restrictions against caller code |
+| Changes API response shape | **Product Engineer** — verify all consumers handle new shape |
+| Adds/modifies security controls | **Senior SDET** — verify test pyramid and coverage |
+| Changes auth model (JWT, roles, permissions) | **Security Engineer** — trace all auth paths |
+| Modifies shared utilities (`_shared/`, hooks) | **Backend/Frontend Engineer** — verify all call sites |
+| Changes data model (columns, types, defaults) | **Product + Backend Engineer** — check queries, types, UI |
+| Modifies infrastructure (CI, deploy, config) | **DevOps/Infra Engineer** — verify pipelines |
 
-**Output format for this section:**
+**Output:** If no impacts, state which boundaries you checked and why none
+are affected. If impacts exist, add a **"Recommended follow-up reviews"**
+section with entries like:
+- **[Reviewer]:** This change [does what] — verify [specific workflows]
+  by tracing [specific code paths].
 
-If no cross-boundary impacts are detected:
-> No cross-boundary ripple effects identified.
-
-If impacts are detected, add a **"Recommended follow-up reviews"** section:
-
-> **Recommended follow-up reviews:**
-> - **Product Engineer:** This change restricts [what] — verify [which workflows] still work by tracing [specific code paths].
-> - **Senior SDET:** This change adds [security controls] — verify test pyramid covers [specific properties].
-
-Be specific about WHAT to check, not just WHO should check it. "PE review
-recommended" is useless; "PE should verify that the counter-offer workflow
-still works after the status restriction" is actionable.
+Be specific about WHAT to check, not just WHO. "PE review recommended" is
+useless; "PE should verify the counter-offer workflow still works after the
+status restriction" is actionable.

--- a/claude/.claude/skills/code-review/SKILL.md
+++ b/claude/.claude/skills/code-review/SKILL.md
@@ -33,90 +33,100 @@ Evaluate the code against each item. Only flag items where there is a concrete i
 
 1. **API misuse** — Are libraries, frameworks, and language APIs used as designed? Flag any reliance on accidental or undocumented behavior (e.g., passing invalid arguments that happen to work, using internal methods, relying on side effects of unrelated calls).
 
-2. **Silent error swallowing** — Are there catch blocks, fallback defaults, or error handlers that hide failures the caller would want to know about? Empty catch blocks, catch-and-return-null, and catch-and-log-only are all suspects.
+2. **Error handling changes** — Are there catch blocks, fallback defaults, or error handlers that hide failures the caller would want to know about? Empty catch blocks, catch-and-return-null, and catch-and-log-only are all suspects. If this change modifies error/fallback behavior, trace the error paths — most production incidents come from changed catch blocks and silent fallbacks, not from happy-path logic.
 
 3. **Race conditions** — Is shared mutable state accessed concurrently without synchronization? Check module-level variables, singletons, caches, and lazy-init patterns.
 
 4. **Silent defaults for unexpected values** — Does the code silently substitute a default when it encounters an unexpected value (e.g., unknown enum variant, unrecognized config key)? In infrastructure and test code, prefer throwing over guessing.
 
+5. **Feature flag coverage** — If the change adds or modifies feature flags or conditional rollout logic, are all flag states tested? Check for stale flags that are always-on/always-off and should be removed, and verify the default-off state doesn't break existing behavior.
+
 ### Hygiene
 
-5. **Dead exports** — Are there exported types, functions, or constants that are not imported by any other file? Check with grep before flagging.
+6. **Dead exports** — Are there exported types, functions, or constants that are not imported by any other file? Check with grep before flagging.
 
-6. **Unnecessary wrappers** — Are there functions that simply delegate to another function without adding any logic, type narrowing, or meaningful naming? These add indirection without value.
+7. **Unnecessary wrappers** — Are there functions that simply delegate to another function without adding any logic, type narrowing, or meaningful naming? These add indirection without value.
 
-7. **Inline business logic where a library method exists** — Is there hand-rolled logic (regex parsing, string manipulation, date math, data structure operations) where the project's existing dependencies already provide a tested, maintained function for the same thing?
+8. **Inline business logic where a library method exists** — Is there hand-rolled logic (regex parsing, string manipulation, date math, data structure operations) where the project's existing dependencies already provide a tested, maintained function for the same thing?
 
 ### Clarity
 
-8. **Undocumented limitations** — Does the code make assumptions or have known constraints that aren't visible to future readers? Examples: only handling the first element of a list, assuming single-tenant usage, ignoring edge cases by design.
+9. **Undocumented limitations** — Does the code make assumptions or have known constraints that aren't visible to future readers? Examples: only handling the first element of a list, assuming single-tenant usage, ignoring edge cases by design.
 
-9. **Misleading names** — Do function or variable names promise more or less than they deliver? A function called `validateUser` that only checks one field, or a variable called `allItems` that contains a filtered subset.
+10. **Misleading names** — Do function or variable names promise more or less than they deliver? A function called `validateUser` that only checks one field, or a variable called `allItems` that contains a filtered subset.
 
 ### Security
 
-10. **Test adequacy for security controls** — For code that enforces security invariants (access control, input validation, privilege boundaries), are there tests that verify both the allow and deny paths? This overrides the general "add tests" exclusion — untested security controls are indistinguishable from absent ones. Check: for each security boundary, is there a test that an unauthorized caller is rejected AND an authorized caller succeeds?
+11. **Test adequacy for security controls** — For code that enforces security invariants (access control, input validation, privilege boundaries), are there tests that verify both the allow and deny paths? This overrides the general "add tests" exclusion — untested security controls are indistinguishable from absent ones. Check: for each security boundary, is there a test that an unauthorized caller is rejected AND an authorized caller succeeds?
 
 ### Scope discipline
 
-11. **Pre-existing issues in unchanged code** — If you notice issues in code that was NOT written or modified in this change, flag them in a separate "Pre-existing issues" section. Do NOT fix them — they are informational only and out of scope.
+12. **Pre-existing issues in unchanged code** — If you notice issues in code that was NOT written or modified in this change, flag them in a separate "Pre-existing issues" section. Do NOT fix them — they are informational only and out of scope.
 
 ## Domain: Infrastructure
 
-12. **Concurrency and parallelism scoping** — Do concurrency groups, mutex locks, or job dependencies match their intended scope? A workflow-level concurrency group affects all jobs, including no-op or unrelated ones. Check that cancel-in-progress won't kill an important job due to an unrelated trigger.
+13. **Concurrency and parallelism scoping** — Do concurrency groups, mutex locks, or job dependencies match their intended scope? A workflow-level concurrency group affects all jobs, including no-op or unrelated ones. Check that cancel-in-progress won't kill an important job due to an unrelated trigger.
 
-13. **Secret exposure** — Are secrets used in contexts that could log them? Check for secrets in `run:` commands that echo or pipe output, in `env:` blocks visible to steps that don't need them, and in artifact uploads. Ensure secrets are not passed as command-line arguments (visible in process lists).
+14. **Secret exposure** — Are secrets used in contexts that could log them? Check for secrets in `run:` commands that echo or pipe output, in `env:` blocks visible to steps that don't need them, and in artifact uploads. Ensure secrets are not passed as command-line arguments (visible in process lists).
 
-14. **Permissions least privilege** — Are workflow permissions, IAM roles, or service accounts scoped to what's actually needed? Flag `contents: write` when only `read` is required, `admin` when `write` suffices, or wildcard permissions.
+15. **Permissions least privilege** — Are workflow permissions, IAM roles, or service accounts scoped to what's actually needed? Flag `contents: write` when only `read` is required, `admin` when `write` suffices, or wildcard permissions.
 
-15. **Idempotency** — Is the workflow/script safe to re-run? Check for unconditional creates (without "if not exists"), non-atomic operations that leave partial state on failure, and missing cleanup on retry.
+16. **Idempotency** — Is the workflow/script safe to re-run? Check for unconditional creates (without "if not exists"), non-atomic operations that leave partial state on failure, and missing cleanup on retry.
 
-16. **Trigger-condition alignment** — Do trigger filters (branch, path, actor, event type) match the job's purpose? A job intended only for bot commits but triggered on all pushes is a mismatch even if individual steps have `if` guards.
+17. **Trigger-condition alignment** — Do trigger filters (branch, path, actor, event type) match the job's purpose? A job intended only for bot commits but triggered on all pushes is a mismatch even if individual steps have `if` guards.
 
 ## Domain: Data
 
-17. **Migration reversibility** — Can this migration be rolled back without data loss? Flag destructive operations (`DROP COLUMN`, `DROP TABLE`, type narrowing) that have no corresponding backup or reversal strategy.
+18. **Migration reversibility** — Can this migration be rolled back without data loss? Flag destructive operations (`DROP COLUMN`, `DROP TABLE`, type narrowing) that have no corresponding backup or reversal strategy.
 
-18. **Index coverage** — Do new queries or new foreign keys have supporting indexes? Flag new columns used in WHERE, JOIN, or ORDER BY clauses that lack indexes, especially on tables expected to grow.
+19. **Index coverage** — Do new queries or new foreign keys have supporting indexes? Flag new columns used in WHERE, JOIN, or ORDER BY clauses that lack indexes, especially on tables expected to grow.
 
-19. **Lock safety** — Could this migration take a long-running lock on a large table? `ALTER TABLE` with defaults, `CREATE INDEX` without `CONCURRENTLY`, and backfills inside the migration are suspects.
+20. **Lock safety** — Could this migration take a long-running lock on a large table? `ALTER TABLE` with defaults, `CREATE INDEX` without `CONCURRENTLY`, and backfills inside the migration are suspects.
 
-20. **RLS and access control on new tables** — Do new tables have RLS enabled and appropriate policies? A new table with no RLS is accessible to any authenticated user via the PostgREST API.
+21. **RLS and access control on new tables** — Do new tables have RLS enabled and appropriate policies? A new table with no RLS is accessible to any authenticated user via the PostgREST API.
 
 ## Domain: Frontend
 
-21. **Accessibility** — Do interactive elements have accessible names (aria-label, visible label, alt text)? Are click handlers on non-button elements keyboard-accessible? Check for missing focus management in modals and drawers.
+22. **Accessibility** — Do interactive elements have accessible names (aria-label, visible label, alt text)? Are click handlers on non-button elements keyboard-accessible? Check for missing focus management in modals and drawers.
 
-22. **Render performance** — Are there new inline object/array/function literals in JSX props that would cause child re-renders on every parent render? Check for missing `key` props on list items and expensive computations not wrapped in `useMemo`/`useCallback` where the component re-renders frequently.
+23. **Render performance** — Are there new inline object/array/function literals in JSX props that would cause child re-renders on every parent render? Check for missing `key` props on list items and expensive computations not wrapped in `useMemo`/`useCallback` where the component re-renders frequently.
 
-23. **Bundle impact** — Does the change add a large new dependency where a smaller alternative or existing utility exists? Flag full-library imports (e.g., all of lodash) when only one function is used.
+24. **Bundle impact** — Does the change add a large new dependency where a smaller alternative or existing utility exists? Flag full-library imports (e.g., all of lodash) when only one function is used.
 
-24. **State-dependent rendering coverage** — Does the change modify which UI state a component enters (conditional branches, state machines, context-driven rendering)? If so, check whether component tests exist that verify the affected states render correctly. For each new or changed condition, is there a test that the component renders the expected output for each branch?
+25. **State-dependent rendering coverage** — Does the change modify which UI state a component enters (conditional branches, state machines, context-driven rendering)? If so, check whether component tests exist that verify the affected states render correctly. For each new or changed condition, is there a test that the component renders the expected output for each branch?
 
 ## Domain: Backend
 
-25. **Auth boundary coverage** — Does every new endpoint or RPC have both authentication (who is the caller?) and authorization (can they do this?)? Check that auth checks are not bypassable by hitting the endpoint directly rather than through the expected UI flow.
+26. **Auth boundary coverage** — Does every new endpoint or RPC have both authentication (who is the caller?) and authorization (can they do this?)? Check that auth checks are not bypassable by hitting the endpoint directly rather than through the expected UI flow.
 
-26. **Input validation at system boundaries** — Is user input validated/sanitized before use in SQL queries, shell commands, file paths, or external API calls? Framework-provided parameterization counts; string concatenation does not.
+27. **Input validation at system boundaries** — Is user input validated/sanitized before use in SQL queries, shell commands, file paths, or external API calls? Framework-provided parameterization counts; string concatenation does not.
 
-27. **Error response leakage** — Do error responses expose internal details (stack traces, internal IDs, database error messages, file paths) to the caller? Internal errors should be logged server-side and return a generic message to the client.
+28. **Error response leakage** — Do error responses expose internal details (stack traces, internal IDs, database error messages, file paths) to the caller? Internal errors should be logged server-side and return a generic message to the client.
+
+29. **Dependency upgrades** — Does the change upgrade a runtime or build dependency? Read the changelog for breaking changes and behavioral differences. Check for peer dependency conflicts and, for frontend dependencies, bundle size regression.
+
+30. **Third-party API integration** — Does the change add or modify a third-party API call? Verify retry/timeout behavior, credential scoping (least-privilege API keys), and failure modes (what happens when the API is down or returns unexpected data).
+
+31. **Sensitive data in logs** — Does the change add or modify logging? Verify that logs do not include tokens, credentials, PII, or full API responses from auth/OAuth endpoints. Extract only the fields needed for debugging.
+
+32. **Performance-sensitive code paths** — Does the change modify a hot path (queries in loops, N+1 patterns, cache read/write, large list operations)? Verify with representative data volumes, not just test fixtures.
 
 ## Domain: Claude Code config
 
-28. **Skill trigger accuracy** — Do TRIGGER and DO NOT TRIGGER conditions
+33. **Skill trigger accuracy** — Do TRIGGER and DO NOT TRIGGER conditions
     match the skill's actual purpose? A skill that triggers too broadly wastes
     context; one that triggers too narrowly gets skipped when needed.
 
-29. **Context budget** — Are skill files, plan files, and settings concise enough
+34. **Context budget** — Are skill files, plan files, and settings concise enough
     to fit within the AI's working context without displacing active task
     instructions? Long files dilute attention on the actual task. Flag files that
     could be shortened without losing actionable information.
 
-30. **Permission scope** — Do `permissions.allow` rules in settings.json follow
+35. **Permission scope** — Do `permissions.allow` rules in settings.json follow
     least-privilege? Flag blanket allows (`"Bash"`) where scoped allows
     (`"Bash(git:*)"`) would suffice.
 
-31. **Hook correctness** — Do PreToolUse/PostToolUse hooks block the right
+36. **Hook correctness** — Do PreToolUse/PostToolUse hooks block the right
     operations without false positives? A hook that blocks legitimate work
     is worse than no hook — it trains users to bypass the system.
 
@@ -124,21 +134,21 @@ Evaluate the code against each item. Only flag items where there is a concrete i
 
 Apply when changed files match `.lovable/**`.
 
-32. **Perspective** — Are instructions written from Lovable's perspective
+37. **Perspective** — Are instructions written from Lovable's perspective
     (second person, addressed to Lovable)? Knowledge files that read as
     internal engineering notes will confuse Lovable.
 
-33. **Specificity** — Are instructions specific enough to prevent unintended
+38. **Specificity** — Are instructions specific enough to prevent unintended
     behavior? Lovable follows instructions literally and may over-apply vague
     guidance (e.g., "be careful with auth" → Lovable adds auth checks to
     public endpoints).
 
-34. **Context budget** — Are knowledge files concise enough to fit within
+39. **Context budget** — Are knowledge files concise enough to fit within
     Lovable's working context without displacing active task instructions?
     Same principle as Claude Code skills — long knowledge files dilute
     attention.
 
-35. **Sync status** — If project-knowledge.md or workspace-knowledge.md
+40. **Sync status** — If project-knowledge.md or workspace-knowledge.md
     changed, does the PR description mention syncing to the Lovable UI?
     The file is the source of truth, but Lovable reads from the UI field.
 
@@ -146,7 +156,7 @@ Apply when changed files match `.lovable/**`.
 
 - Issues that a linter, typechecker, or compiler would catch (imports, type errors, formatting)
 - Stylistic nitpicks in unchanged code (naming conventions, whitespace, comment style)
-- Generic improvement suggestions ("add tests," "add docs," "improve error messages") not tied to a specific finding from the checklist above, **except** for security controls (see item 10)
+- Generic improvement suggestions ("add tests," "add docs," "improve error messages") not tied to a specific finding from the checklist above, **except** for security controls (see item 11)
 - Domain checklist items for domains where no files were changed
 
 ## Output format
@@ -176,13 +186,14 @@ hats. Update this table as new patterns emerge.
 
 | Change type | Follow-up |
 |-------------|-----------|
-| Restricts DB access (RLS, GRANT, triggers) | **Product + Fullstack Engineer** — trace restrictions against caller code |
+| Restricts DB access (RLS, GRANT, triggers) | **Security + Fullstack Engineer** — trace restrictions against caller code and check for privilege escalation |
 | Changes API response shape | **Product + Fullstack Engineer** — verify all consumers handle new shape |
 | Adds/modifies security controls | **Senior SDET + Security Engineer** — verify test pyramid, coverage, and threat model |
-| Changes auth model (JWT, roles, permissions) | **Security + Backend Engineer** — trace all auth paths |
-| Modifies shared utilities (helpers, hooks, contexts) | **Backend + Frontend Engineer** — verify all call sites |
-| Changes data model (columns, types, defaults) | **Product + Backend Engineer** — check queries, types, UI |
-| Modifies infrastructure (CI, deploy, config) | **DevOps/Infra Engineer** — verify pipelines |
+| Changes auth model (JWT, roles, permissions) | **Security + Backend Engineer** — trace all auth paths including token refresh, session expiry, and error fallbacks |
+| Modifies shared utilities (helpers, hooks, contexts) | **Backend + Frontend Engineer** — verify all call sites and check for behavioral assumptions |
+| Changes data model (columns, types, defaults, migrations) | **Product + Backend Engineer** — verify generated types, check queries and UI for broken nullability/default assumptions, verify migration idempotency |
+| Modifies CI/CD pipelines or deploy config | **DevOps/Infra + Backend Engineer** — verify pipelines and environment consistency |
+| Changes runtime config (env vars, secrets, feature flags) | **Backend + Security Engineer** — verify config is consistent across environments, check for leaked secrets |
 
 **Output:** If no impacts, state which boundaries you checked and why none
 are affected. If impacts exist, add a **"Recommended follow-up reviews"**

--- a/claude/.claude/skills/code-review/SKILL.md
+++ b/claude/.claude/skills/code-review/SKILL.md
@@ -176,11 +176,11 @@ hats. Update this table as new patterns emerge.
 
 | Change type | Follow-up |
 |-------------|-----------|
-| Restricts DB access (RLS, GRANT, triggers) | **Product Engineer** — trace restrictions against caller code |
-| Changes API response shape | **Product Engineer** — verify all consumers handle new shape |
-| Adds/modifies security controls | **Senior SDET** — verify test pyramid and coverage |
-| Changes auth model (JWT, roles, permissions) | **Security Engineer** — trace all auth paths |
-| Modifies shared utilities (helpers, hooks, contexts) | **Backend/Frontend Engineer** — verify all call sites |
+| Restricts DB access (RLS, GRANT, triggers) | **Product + Fullstack Engineer** — trace restrictions against caller code |
+| Changes API response shape | **Product + Fullstack Engineer** — verify all consumers handle new shape |
+| Adds/modifies security controls | **Senior SDET + Security Engineer** — verify test pyramid, coverage, and threat model |
+| Changes auth model (JWT, roles, permissions) | **Security + Backend Engineer** — trace all auth paths |
+| Modifies shared utilities (helpers, hooks, contexts) | **Backend + Frontend Engineer** — verify all call sites |
 | Changes data model (columns, types, defaults) | **Product + Backend Engineer** — check queries, types, UI |
 | Modifies infrastructure (CI, deploy, config) | **DevOps/Infra Engineer** — verify pipelines |
 

--- a/claude/.claude/skills/code-review/SKILL.md
+++ b/claude/.claude/skills/code-review/SKILL.md
@@ -180,7 +180,7 @@ hats. Update this table as new patterns emerge.
 | Changes API response shape | **Product Engineer** — verify all consumers handle new shape |
 | Adds/modifies security controls | **Senior SDET** — verify test pyramid and coverage |
 | Changes auth model (JWT, roles, permissions) | **Security Engineer** — trace all auth paths |
-| Modifies shared utilities (`_shared/`, hooks) | **Backend/Frontend Engineer** — verify all call sites |
+| Modifies shared utilities (helpers, hooks, contexts) | **Backend/Frontend Engineer** — verify all call sites |
 | Changes data model (columns, types, defaults) | **Product + Backend Engineer** — check queries, types, UI |
 | Modifies infrastructure (CI, deploy, config) | **DevOps/Infra Engineer** — verify pipelines |
 
@@ -191,5 +191,5 @@ section with entries like:
   by tracing [specific code paths].
 
 Be specific about WHAT to check, not just WHO. "PE review recommended" is
-useless; "PE should verify the counter-offer workflow still works after the
-status restriction" is actionable.
+useless; "PE should verify the checkout flow in CheckoutPage.tsx still works
+after the new validation constraint" is actionable.


### PR DESCRIPTION
## Summary
- Adds core principle at the top: review ripple effects, not just the change
- Adds ripple effect triage step after the checklist with cross-boundary pattern table
- Maps change types to ripple risks and recommended specialist reviewers
- Requires specific, actionable follow-up recommendations

## Why
Code review skill caught correctness issues within files but missed cross-boundary impacts — e.g., a database policy restriction that broke a frontend workflow. A specialist reviewer caught it by tracing the policy against actual frontend code. The skill should have flagged the need for that specialist review.

## Test plan
- [x] Verified the updated skill file is valid markdown
- [x] Confirmed the ripple effect triage section would have caught the original miss