### PR TITLE
Always run hooks workflow; gate pytest on internal diff check

### DIFF
--- a/.github/workflows/hooks.yml
+++ b/.github/workflows/hooks.yml
@@ -1,10 +1,12 @@
-# WARNING: The workflow name ("hooks") and job ID ("test") form the status
-# check context string "hooks / test" that is referenced by branch protection.
-# Renaming either silently breaks the required-check match. If you rename,
-# also update the required_status_checks.contexts list via:
+# WARNING: The job id ("hook-tests") is the status check context string
+# referenced by branch protection on main. Renaming the job silently breaks
+# the required-check match. If you rename the job, also update the
+# required_status_checks.contexts list via:
 #   gh api -X PUT repos/jcdendrite/claude-config/branches/main/protection
+# (The workflow-level "name:" does NOT affect the context string for GitHub
+# Actions checks — only the job id does.)
 
-name: hooks
+name: Hook tests
 
 on:
   push:
@@ -19,7 +21,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  hook-tests:
     runs-on: ubuntu-24.04
     timeout-minutes: 2
     steps:

--- a/.github/workflows/hooks.yml
+++ b/.github/workflows/hooks.yml
@@ -1,15 +1,15 @@
+# WARNING: The workflow name ("hooks") and job ID ("test") form the status
+# check context string "hooks / test" that is referenced by branch protection.
+# Renaming either silently breaks the required-check match. If you rename,
+# also update the required_status_checks.contexts list via:
+#   gh api -X PUT repos/jcdendrite/claude-config/branches/main/protection
+
 name: hooks
 
 on:
   push:
     branches: [main]
-    paths:
-      - 'claude/.claude/hooks/**'
-      - '.github/workflows/hooks.yml'
   pull_request:
-    paths:
-      - 'claude/.claude/hooks/**'
-      - '.github/workflows/hooks.yml'
 
 permissions:
   contents: read
@@ -24,13 +24,49 @@ jobs:
     timeout-minutes: 2
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect hook-relevant changes
+        id: detect
+        run: |
+          set -e
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            HEAD="${{ github.event.pull_request.head.sha }}"
+          else
+            BASE="${{ github.event.before }}"
+            HEAD="${{ github.sha }}"
+          fi
+
+          # Fail open: if BASE is the zero SHA (first push, some force-push
+          # scenarios) or unresolvable locally, run the test suite.
+          ZERO_SHA="0000000000000000000000000000000000000000"
+          if [ "$BASE" = "$ZERO_SHA" ] || ! git cat-file -e "$BASE" 2>/dev/null; then
+            echo "BASE unresolvable ($BASE); running tests."
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if git diff --name-only "$BASE" "$HEAD" | grep -qE '^(claude/\.claude/hooks/|\.github/workflows/hooks\.yml)'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip — no hook-relevant changes
+        if: steps.detect.outputs.changed != 'true'
+        run: echo "No hook-relevant files changed; skipping pytest."
 
       - uses: actions/setup-python@v5
+        if: steps.detect.outputs.changed == 'true'
         with:
           python-version: '3.12'
 
       - name: Install pytest
+        if: steps.detect.outputs.changed == 'true'
         run: pip install 'pytest==8.*'
 
       - name: Run hook tests
+        if: steps.detect.outputs.changed == 'true'
         run: pytest claude/.claude/hooks/tests/ -v


### PR DESCRIPTION
## Summary

- Remove workflow-level `paths:` filter so the status check always reports, fixing GitHub's "required check with path filter" gotcha (required check never completes on PRs that touch only unfiltered paths → merge blocked forever).
- Add an internal diff-detection step that gates `setup-python` / `pip install` / `pytest` on whether any hook-relevant file changed. Non-hook PRs finish the job in ~5s; hook-touching PRs run the full pytest suite.
- Add fail-open guard for zero-SHA `github.event.before` (first push, some force-push) and for cases where the BASE commit isn't present locally.
- Rename job id `test` → `hook-tests` and workflow name `hooks` → `Hook tests`. Generic `test` job id would collide with any future workflow with a same-named job, since branch protection's `contexts` list is a plain string match.
- Header comment warns that renaming the job id silently breaks the `required_status_checks.contexts` match branch protection relies on.

Precursor to enabling branch protection on `main` that requires `hook-tests` to pass.

## Test plan

- [ ] Workflow runs on this PR (no hook files touched — should show the "Skip" step and complete in ~5s, reporting `hook-tests` as success).
- [ ] After merge, push to `main` triggers the workflow (single commit in push → detect compares against `github.event.before`).
- [ ] Follow-up PR that touches `claude/.claude/hooks/**` should actually execute pytest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)