### PR TITLE
Add /plan-review rule to global CLAUDE.md

### DIFF
--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -27,6 +27,10 @@
 
 - After writing or modifying code, run `/code-review` before presenting the code to the user. If the review finds issues, fix them first, then present the final version.
 
+## Plan Review
+
+- After writing or modifying an implementation plan, run `/plan-review` before presenting the plan to the user. If the review finds issues, address them first, then present the final version.
+
 ## Safety
 
 - Never run sudo commands directly.


### PR DESCRIPTION
## Summary
- Adds a `## Plan Review` section to global CLAUDE.md, symmetric with the existing `## Code Review` rule.
- Centralizes the `/plan-review` reminder so project-level CLAUDE.md files don't need to list it themselves.
- No hook added — plans lack a single choke point like `git commit`, so enforcement stays at the skill's frontmatter auto-trigger (see plan non-goals).

## Test plan
- [x] Edit lands in `claude/.claude/CLAUDE.md` with correct formatting
- [x] `~/.claude/CLAUDE.md` symlink still resolves to the edited source

🤖 Generated with [Claude Code](https://claude.com/claude-code)