### PR TITLE
Fix respond-pr hook false-positive on cross-repo gh commands

### DIFF
--- a/claude/.claude/hooks/require-respond-pr.sh
+++ b/claude/.claude/hooks/require-respond-pr.sh
@@ -45,4 +45,32 @@ else
   exit 0
 fi
 
+# Cross-repo bypass: if the command explicitly targets a repo that differs
+# from the current git origin, it is research on an external repo (e.g.
+# reading anthropics/claude-code issues while working in the user's project),
+# not a PR response in the current repo. Two explicit forms are recognized:
+#   gh api repos/OWNER/REPO/...
+#   gh pr <cmd> ... -R OWNER/REPO      (also --repo OWNER/REPO, --repo=OWNER/REPO)
+# Implicit commands (no repo specified) still gate — gh resolves those
+# against the current repo. Caveats: (1) in-repo reads of an actual Issue
+# (not a PR) still false-positive; accepted because the user does not track
+# work in GitHub Issues. (2) the -R/--repo regex scans raw command text, so
+# a flag-shaped substring inside a quoted body could spoof a cross-repo
+# match and bypass the gate — unlikely for Claude-written commands, but
+# worth knowing.
+COMMAND_REPO=$(printf '%s\n' "$COMMAND" | sed -nE 's#.*repos/([^/]+/[^/]+)/(pulls|issues)/[0-9]+/(comments|reviews).*#\1#p' | head -1)
+if [ -z "$COMMAND_REPO" ]; then
+  COMMAND_REPO=$(printf '%s\n' "$COMMAND" | sed -nE 's#.*[[:space:]](-R|--repo)[[:space:]=]+([^[:space:]=]+/[^[:space:]]+).*#\2#p' | head -1)
+fi
+
+if [ -n "$COMMAND_REPO" ]; then
+  CURRENT_URL=$(git config --get remote.origin.url 2>/dev/null)
+  if [ -n "$CURRENT_URL" ]; then
+    CURRENT_REPO=$(printf '%s\n' "$CURRENT_URL" | sed -nE 's#.*[:/]([^/:]+/[^/]+)$#\1#p' | sed 's#\.git$##')
+    if [ -n "$CURRENT_REPO" ] && [ "$COMMAND_REPO" != "$CURRENT_REPO" ]; then
+      exit 0
+    fi
+  fi
+fi
+
 echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"PR comment access blocked by respond-pr gate. Run the /respond-pr skill instead — it fetches inline file comments, top-level review bodies, AND issue-level comments (Claude habitually fetches only the first and misses real feedback), and it enforces the [Claude Code] attribution prefix on replies so comments posted through the GitHub token are clearly labeled as AI-generated. Do not ask the user for permission — run /respond-pr and let it handle this operation."}}'

--- a/claude/.claude/hooks/tests/test_hooks.py
+++ b/claude/.claude/hooks/tests/test_hooks.py
@@ -228,6 +228,26 @@ class TestRequireCodeReview:
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture
+def current_repo_foo_bar(tmp_path):
+    """Git repo whose origin is https://github.com/foo/bar.git.
+
+    Most respond-pr tests target `foo/bar` in the command URL. The
+    cross-repo bypass compares COMMAND_REPO against the current git origin,
+    so we need the current repo to also be `foo/bar` for the gate to fire
+    as expected on same-repo commands.
+    """
+    repo = tmp_path / "foo-bar-repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "remote", "add", "origin", "https://github.com/foo/bar.git"],
+        cwd=repo,
+        check=True,
+    )
+    return repo
+
+
 class TestRequireRespondPr:
     @pytest.mark.parametrize(
         "command",
@@ -240,8 +260,8 @@ class TestRequireRespondPr:
             "gh api repos/foo/bar/pulls/5/comments -F body=hi",
         ],
     )
-    def test_matching_commands_denied(self, isolated_home, command):
-        assert run_hook(RESPOND_PR_HOOK, bash_input(command)) == "deny"
+    def test_matching_commands_denied(self, isolated_home, current_repo_foo_bar, command):
+        assert run_hook(RESPOND_PR_HOOK, bash_input(command), cwd=current_repo_foo_bar) == "deny"
 
     @pytest.mark.parametrize(
         "command",
@@ -254,8 +274,8 @@ class TestRequireRespondPr:
             "git status",
         ],
     )
-    def test_non_matching_commands_allowed(self, isolated_home, command):
-        assert run_hook(RESPOND_PR_HOOK, bash_input(command)) == "allow"
+    def test_non_matching_commands_allowed(self, isolated_home, current_repo_foo_bar, command):
+        assert run_hook(RESPOND_PR_HOOK, bash_input(command), cwd=current_repo_foo_bar) == "allow"
 
     @pytest.mark.parametrize(
         "command",
@@ -264,22 +284,84 @@ class TestRequireRespondPr:
             "gh pr comment 5 --body test",
         ],
     )
-    def test_fresh_bypass_marker_allows(self, isolated_home, command):
+    def test_fresh_bypass_marker_allows(self, isolated_home, current_repo_foo_bar, command):
         (isolated_home / ".claude" / ".respond-pr-active").touch()
-        assert run_hook(RESPOND_PR_HOOK, bash_input(command)) == "allow"
+        assert run_hook(RESPOND_PR_HOOK, bash_input(command), cwd=current_repo_foo_bar) == "allow"
 
-    def test_stale_bypass_marker_denies(self, isolated_home):
+    def test_stale_bypass_marker_denies(self, isolated_home, current_repo_foo_bar):
         marker = isolated_home / ".claude" / ".respond-pr-active"
         marker.touch()
         # Backdate 90 minutes — past the hook's 60-minute staleness cutoff.
         ninety_min_ago = time.time() - 90 * 60
         os.utime(marker, (ninety_min_ago, ninety_min_ago))
         assert (
-            run_hook(RESPOND_PR_HOOK, bash_input("gh api repos/foo/bar/pulls/5/comments")) == "deny"
+            run_hook(
+                RESPOND_PR_HOOK,
+                bash_input("gh api repos/foo/bar/pulls/5/comments"),
+                cwd=current_repo_foo_bar,
+            )
+            == "deny"
         )
 
     def test_non_bash_tool_allowed(self, isolated_home):
         assert run_hook(RESPOND_PR_HOOK, edit_input("/tmp/foo.txt")) == "allow"
+
+    # -- Cross-repo bypass --------------------------------------------------
+    # Regression: the gate originally fired on any `(pulls|issues)/N/...`
+    # URL regardless of repo, which false-positived on cross-repo research
+    # reads like `gh api repos/anthropics/claude-code/issues/12962/comments`
+    # from inside an unrelated project.
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "gh api repos/other/repo/pulls/5/comments",
+            "gh api repos/other/repo/pulls/5/reviews",
+            "gh api repos/other/repo/issues/5/comments",
+            "gh pr comment 5 -R other/repo --body test",
+            "gh pr review 5 --repo other/repo --approve",
+            "gh pr comment 5 --repo=other/repo --body test",
+        ],
+    )
+    def test_cross_repo_commands_allowed(self, isolated_home, current_repo_foo_bar, command):
+        assert run_hook(RESPOND_PR_HOOK, bash_input(command), cwd=current_repo_foo_bar) == "allow"
+
+    def test_ssh_origin_cross_repo_allowed(self, isolated_home, tmp_path):
+        """SSH-form origin (git@github.com:owner/repo.git) must parse too."""
+        repo = tmp_path / "ssh-repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        subprocess.run(
+            ["git", "remote", "add", "origin", "git@github.com:foo/bar.git"],
+            cwd=repo,
+            check=True,
+        )
+        assert (
+            run_hook(
+                RESPOND_PR_HOOK,
+                bash_input("gh api repos/other/repo/issues/5/comments"),
+                cwd=repo,
+            )
+            == "allow"
+        )
+
+    def test_ssh_origin_same_repo_denied(self, isolated_home, tmp_path):
+        repo = tmp_path / "ssh-repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        subprocess.run(
+            ["git", "remote", "add", "origin", "git@github.com:foo/bar.git"],
+            cwd=repo,
+            check=True,
+        )
+        assert (
+            run_hook(
+                RESPOND_PR_HOOK,
+                bash_input("gh api repos/foo/bar/issues/5/comments"),
+                cwd=repo,
+            )
+            == "deny"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- The respond-pr gate matched any `(pulls|issues)/N/(comments|reviews)` URL regardless of repo, blocking legitimate cross-repo research reads (e.g. `gh api repos/anthropics/claude-code/issues/12962/comments` from inside an unrelated project).
- Now extracts `OWNER/REPO` from explicit forms (`repos/OWNER/REPO/...` URL path, `-R`/`--repo`/`--repo=` flag) and bypasses the gate when it differs from the current git origin. Implicit commands (no repo specified) still gate — gh resolves those against the current repo.
- In-repo reads of actual GitHub Issues (not PRs) still false-positive; accepted because the user does not track work in GitHub Issues.

## Test plan
- [x] `python3 -m pytest claude/.claude/hooks/tests/test_hooks.py` — all 45 tests pass
- [x] New `TestRequireRespondPr` cases cover: cross-repo `gh api` URL forms, `-R`, `--repo`, `--repo=` variants, HTTPS and SSH origin parsing, same-repo denial under SSH origin
- [x] Existing denial tests re-scoped to a matching-origin fixture (`current_repo_foo_bar`) so they exercise the same-repo gate path after the bypass is in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)