### PR TITLE
Add git-feature-branch-sync skill

### DIFF
--- a/claude/.claude/skills/git-feature-branch-sync/SKILL.md
+++ b/claude/.claude/skills/git-feature-branch-sync/SKILL.md
@@ -31,9 +31,11 @@ Keeping a feature branch current with `main` has two shapes:
 - **Merge** — `git merge origin/main`. Creates a merge commit on the
   feature branch. Preserves SHAs. No force-push needed.
 
-**Default: rebase on personal feature branches.** Switch to merge when any
+**This skill's default is rebase on personal feature branches** — a
+reasonable and common choice, but not universal (many shops default to
+merge even on personal branches). Switch to merge when any
 *merge-required condition* below applies. Always defer to per-client
-policy if it contradicts this default.
+policy when it contradicts this default.
 
 ## Merge-required conditions
 
@@ -72,19 +74,33 @@ git push --force-with-lease --force-if-includes
 `--force-with-lease` alone has a known gap: a stray `git fetch` updates
 the remote-tracking ref, which makes the lease look held even though you
 haven't integrated the remote's new commits. `--force-if-includes` closes
-that gap. Use both.
+that gap by checking your local reflog against the remote-tracking ref.
+Use both. Note: `--force-if-includes` silently no-ops if reflogs are
+disabled (`core.logAllRefUpdates=false`) — uncommon but seen in some CI
+images.
 
 ## Never-force-push targets
 
 Refuse to force-push to any of these regardless of flavor:
 
-- `main`, `master`, `trunk`, `develop`, or any default branch
-- `release/*`, `hotfix/*`, or any other protected / shared branch
+- `main`, `master`, `trunk`, `develop`, or **the remote's default branch**
+  (check `git symbolic-ref refs/remotes/origin/HEAD` —
+  `init.defaultBranch` is the local default, not authoritative)
+- `release/*`, `hotfix/*`, `staging`, `production`, `qa`, `uat`, or any
+  other shared / environment-tracking branch
+- **Tags** (`refs/tags/*`) — never force-push. Tags are the
+  supply-chain anchor for releases and SBOMs; signed tags especially
+  must never be rewritten.
 - Any branch the user has not explicitly said is personal
 
 For those branches, rebasing the branch itself is also off the table —
 they keep merge history. Bringing `main` into them (when it even makes
 sense) is a merge, not a rebase.
+
+**Do not rely on server-side branch protection** to catch mistakes. On
+GitHub Free private repos the branch-protection API is inaccessible; on
+other repos the rules may simply not be configured. Treat the list above
+as the last line of defense, not the only one.
 
 ## Interaction with PR merge strategy
 
@@ -111,24 +127,40 @@ CLAUDE.md should state the policy.
 Before running `git push --force-with-lease` on a feature branch:
 
 1. Is this branch personal (only you committing)? If no → merge instead.
+   Verify with `git log --format='%ae' origin/<branch> | sort -u` if
+   uncertain — don't rely solely on a "yes it's mine" claim.
 2. Has anyone stacked a branch on this one? If yes → coordinate or merge.
 3. Is PR review in flight where comments anchor to SHAs? If yes → rework
    commits, not rebase.
-4. Is the branch one of `main` / `master` / `develop` / `release/*` /
-   any protected branch? → stop. Force-push is forbidden here.
-5. Using `--force-with-lease --force-if-includes`? → proceed.
+4. Is the branch in the never-force-push list above (default branch,
+   environment branches, tags, shared branches)? → stop. Force-push is
+   forbidden regardless of flavor.
+5. Does the repo require signed commits? Rebase drops signatures.
+   Either (a) ensure `commit.gpgsign=true` so the rebase re-signs, or
+   (b) skip rebase and merge instead. Check `git config commit.gpgsign`
+   and the repo's branch-protection `required_signatures` rule.
+6. Using `--force-with-lease --force-if-includes`? → proceed.
 
 ## Recovery from a bad force-push
 
 `--force-with-lease --force-if-includes` will catch most of these. If
 one slips through and you clobber a teammate's commits:
 
-1. Find the pre-force SHA. Your local `git reflog` has it if you were
-   the one who force-pushed. Otherwise ask the displaced teammate —
-   their local reflog or branch still points at it.
-2. Restore: `git push --force-with-lease origin <recovered-sha>:<branch>`
-3. Coordinate. The teammate may have local work that now needs rebasing
-   onto the restored tip.
+1. Find the pre-force SHA. Your local `git reflog` has it if you
+   force-pushed; any teammate's `git reflog show origin/<branch>` in a
+   recently-fetched clone also has it. If no local reflog survives,
+   `git fsck --lost-found` may surface the dangling commits.
+2. **Pin it immediately**, before doing anything else. Reflog expiry and
+   `git gc` can reap unreachable commits; `gc.reflogExpireUnreachable`
+   defaults to 90 days but teams sometimes tighten it. Create a backup
+   ref: `git branch backup/<branch>-<date> <recovered-sha>`.
+3. **`git fetch origin` before restoring.** Someone may have pushed
+   legitimate reconciliation work on top of the clobbered tip. If so,
+   merge those commits onto the recovered SHA before pushing — do not
+   overwrite reconciliation work.
+4. Restore: `git push --force-with-lease origin <recovered-sha>:<branch>`
+5. Coordinate. The displaced teammate may have local work that now
+   needs rebasing onto the restored tip.
 
 For recovery from a bad *merge* (not force-push) that already landed,
 see `git-state-safety`.

--- a/claude/.claude/skills/git-feature-branch-sync/SKILL.md
+++ b/claude/.claude/skills/git-feature-branch-sync/SKILL.md
@@ -1,40 +1,50 @@
 ---
 name: git-feature-branch-sync
 description: >
-  Decision framework for keeping a feature branch up to date with main:
-  when to rebase-and-force-push vs merge-main-in, how to force-push
-  safely (`--force-with-lease` / `--force-if-includes` / plain `--force`),
-  and when the "never force-push" instinct is correct vs overcautious.
-  This is the global framework — per-client policy (squash-merge vs
-  merge-commit, rebase-after-review rules, branch-protection specifics)
-  lives in that repo's CLAUDE.md or a client-scoped skill.
-  TRIGGER when: deciding how to integrate `main` into a feature branch,
-  whether/how to force-push a feature branch, or picking between
-  `--force-with-lease` and `--force-if-includes`.
+  Decision framework for keeping a feature branch up to date with the
+  repo's default branch: when to rebase-and-force-push vs merge-in,
+  how to force-push safely (`--force-with-lease` / `--force-if-includes`
+  / plain `--force`), and when the "never force-push" instinct is
+  correct vs overcautious. This is the global framework — per-project
+  policy (squash-merge vs merge-commit, rebase-after-review rules,
+  branch-protection specifics) lives in that repo's CLAUDE.md or a
+  project-scoped skill.
+  TRIGGER when: deciding how to integrate the default branch into a
+  feature branch, whether/how to force-push a feature branch, or
+  picking between `--force-with-lease` and `--force-if-includes`.
   DO NOT TRIGGER when: routine work on a clean feature branch with no
-  integration question, operations on `main` / `release/*` / protected
-  branches (those are always protected — never force-push them), or
-  mid-merge / mid-rebase / mid-cherry-pick state (use `git-state-safety`
-  instead).
+  integration question, operations on the default / release / other
+  shared branches (those are always protected — never force-push them),
+  or mid-merge / mid-rebase / mid-cherry-pick state (use
+  `git-state-safety` instead).
 user-invocable: false
 ---
 
 # Feature-Branch Sync: Rebase, Merge, and Force-Push
 
+Examples below use `main` / `origin/main` as the default-branch
+placeholder. If the repo's default is `master`, `trunk`, `develop`, or
+something else, substitute accordingly — check with
+`git symbolic-ref refs/remotes/origin/HEAD`.
+
 ## The decision
 
-Keeping a feature branch current with `main` has two shapes:
+Keeping a feature branch current with the default branch has two shapes:
 
 - **Rebase** — `git fetch origin && git rebase origin/main`. Replays your
-  commits on top of current `main`. Linear history. Rewrites commit SHAs,
-  so the next push must be a force-push.
-- **Merge** — `git merge origin/main`. Creates a merge commit on the
-  feature branch. Preserves SHAs. No force-push needed.
+  commits on top of the current default-branch tip. Linear history.
+  Rewrites commit SHAs, so the next push must be a force-push.
+- **Merge** — `git merge --no-ff origin/main`. Creates a merge commit on
+  the feature branch. Preserves SHAs. No force-push needed. (`--no-ff`
+  matters: a plain `git merge origin/main` will fast-forward if the
+  feature branch is strictly behind, which is not what "merge main in"
+  implies.) `git pull --rebase` is equivalent to `fetch + rebase`;
+  prefer the explicit two-step form so the fetch result is auditable.
 
 **This skill's default is rebase on personal feature branches** — a
 reasonable and common choice, but not universal (many shops default to
 merge even on personal branches). Switch to merge when any
-*merge-required condition* below applies. Always defer to per-client
+*merge-required condition* below applies. Always defer to per-project
 policy when it contradicts this default.
 
 ## Merge-required conditions
@@ -44,15 +54,23 @@ Any one of these → merge-main, do not rebase:
 - **Another active committer** on the branch. Rebasing rewrites history
   they have based work on; they will need a recovery dance.
 - **Another branch is stacked on this one.** Rebase invalidates the
-  child's base. If the stack is intentional and you must rebase, use
-  `git rebase --update-refs` and coordinate.
+  child's base. For stacked-PR workflows (Graphite, spr, stgit, or
+  hand-rolled), use `git rebase --update-refs` to update every
+  ancestor branch ref in one pass — or set `rebase.updateRefs=true` to
+  make this default. Then force-push each stacked branch separately,
+  leaf-to-root; a lease failure mid-stack leaves the stack half-rewritten.
 - **Review is already in flight** in a culture that anchors comments to
   specific commit SHAs. Rebasing detaches comments from their anchors.
   Some teams forbid rebase post-review; prefer "rework" commits.
-- **Per-client policy says merge-only.** Check the repo's CLAUDE.md /
-  skills before recommending rebase.
+- **The repo's per-project policy mandates merge-only.** Example: the
+  repo's CLAUDE.md says "squash-merge PRs and use merge-main to stay
+  current" — defer to that. Check the project's CLAUDE.md or
+  project-scoped skill before recommending rebase.
 
-Otherwise, rebase.
+Otherwise, rebase. For long-lived branches that rebase repeatedly, set
+`rerere.enabled=true` — `rerere` caches conflict resolutions and replays
+them on re-conflict, which is the highest-ROI configuration for a
+weeks-old feature branch that eats main conflicts every few days.
 
 ## Force-push flavors
 
@@ -75,17 +93,37 @@ git push --force-with-lease --force-if-includes
 the remote-tracking ref, which makes the lease look held even though you
 haven't integrated the remote's new commits. `--force-if-includes` closes
 that gap by checking your local reflog against the remote-tracking ref.
-Use both. Note: `--force-if-includes` silently no-ops if reflogs are
-disabled (`core.logAllRefUpdates=false`) — uncommon but seen in some CI
-images.
+Use both. Setting `push.useForceIfIncludes=true` makes the flag apply
+automatically whenever `--force-with-lease` is used.
+
+**Critical gotcha for automation and fresh clones:**
+`--force-with-lease` without an explicit expected value requires a
+*remote-tracking ref* (`refs/remotes/origin/<branch>`) to compute the
+lease against. In a shallow clone, `--single-branch` clone, or first
+push on a branch, that ref is missing or stale, and `--force-with-lease`
+silently degrades to `--force` semantics. In CI or any automated
+context, use the explicit form, which fails loudly if the ref is absent:
+
+```
+git fetch origin <branch>
+git push --force-with-lease="<branch>:$(git rev-parse origin/<branch>)" \
+         --force-if-includes origin <branch>
+```
+
+`--force-if-includes` also depends on the local branch's reflog, which
+is empty on fresh/shallow clones — ephemeral CI runners hit this
+routinely. If reflogs are disabled (`core.logAllRefUpdates=false`),
+`--force-if-includes` silently no-ops.
 
 ## Never-force-push targets
 
 Refuse to force-push to any of these regardless of flavor:
 
-- `main`, `master`, `trunk`, `develop`, or **the remote's default branch**
-  (check `git symbolic-ref refs/remotes/origin/HEAD` —
-  `init.defaultBranch` is the local default, not authoritative)
+- **The remote's default branch** — check
+  `git symbolic-ref refs/remotes/origin/HEAD` rather than assuming.
+  `main` is common but not universal (`master`, `trunk`, `develop`, or
+  anything else is possible); `init.defaultBranch` is the local default,
+  not authoritative.
 - `release/*`, `hotfix/*`, `staging`, `production`, `qa`, `uat`, or any
   other shared / environment-tracking branch
 - **Tags** (`refs/tags/*`) — never force-push. Tags are the
@@ -94,13 +132,31 @@ Refuse to force-push to any of these regardless of flavor:
 - Any branch the user has not explicitly said is personal
 
 For those branches, rebasing the branch itself is also off the table —
-they keep merge history. Bringing `main` into them (when it even makes
-sense) is a merge, not a rebase.
+they keep merge history. Bringing the default branch into them (when it
+even makes sense) is a merge, not a rebase.
 
 **Do not rely on server-side branch protection** to catch mistakes. On
 GitHub Free private repos the branch-protection API is inaccessible; on
 other repos the rules may simply not be configured. Treat the list above
 as the last line of defense, not the only one.
+
+**Protected-branch rules may further constrain strategy.** Configurations
+that change the decision tree:
+- **Required linear history** — rebase-merge or squash-merge only; a
+  merge commit from "merge-main-in" will be rejected at PR merge.
+- **Required signed commits** — see the signed-commits check in pre-flight.
+- **Required status checks** — force-pushing to a feature branch
+  invalidates in-flight check runs, re-enters the PR into pending, and
+  can knock it out of an auto-merge queue.
+- **Actor-specific rules (GitHub rulesets, GitLab push rules)** — bot
+  or app tokens may be excluded from force-push even when humans are
+  allowed. If an automated agent sees a 403 from `--force-with-lease`
+  but humans can push, this is likely the cause.
+
+Query the relevant protection API before acting on non-personal
+branches (GitHub: `GET /repos/:owner/:repo/rulesets/rules/branches/<branch>`).
+If the API is unreachable or the rules are ambiguous in an automated
+context, fail closed — merge instead.
 
 ## Interaction with PR merge strategy
 
@@ -119,27 +175,39 @@ at PR-merge time, depending on the repo's merge strategy:
 
 **Before recommending rebase-only on history-cleanliness grounds, check
 the PR merge strategy.** On a squash-merge repo, the argument mostly
-dissolves; on a merge-commit repo, it's at its strongest. Per-client
-CLAUDE.md should state the policy.
+dissolves; on a merge-commit repo, it's at its strongest. The project's
+CLAUDE.md should state the merge strategy.
 
 ## Pre-flight checklist
 
 Before running `git push --force-with-lease` on a feature branch:
 
 1. Is this branch personal (only you committing)? If no → merge instead.
-   Verify with `git log --format='%ae' origin/<branch> | sort -u` if
-   uncertain — don't rely solely on a "yes it's mine" claim.
+   Verify with `git log --format='%ae %ce' origin/<branch> | sort -u` if
+   uncertain — include committer (`%ce`), not just author (`%ae`), so
+   rebases and cherry-picks don't hide a second contributor. On a
+   shallow clone, `git fetch --unshallow` first; the verification is
+   worthless against truncated history. Don't rely solely on a "yes
+   it's mine" claim.
 2. Has anyone stacked a branch on this one? If yes → coordinate or merge.
 3. Is PR review in flight where comments anchor to SHAs? If yes → rework
    commits, not rebase.
 4. Is the branch in the never-force-push list above (default branch,
    environment branches, tags, shared branches)? → stop. Force-push is
    forbidden regardless of flavor.
-5. Does the repo require signed commits? Rebase drops signatures.
-   Either (a) ensure `commit.gpgsign=true` so the rebase re-signs, or
-   (b) skip rebase and merge instead. Check `git config commit.gpgsign`
-   and the repo's branch-protection `required_signatures` rule.
-6. Using `--force-with-lease --force-if-includes`? → proceed.
+5. Does the repo require signed commits? Rebase drops signatures and
+   recreates commits. Either (a) ensure `commit.gpgsign=true` **and the
+   signing key is available non-interactively** (critical on CI — a
+   headless runner without a provisioned key silently produces unsigned
+   commits that then fail `required_signatures`), or (b) skip rebase
+   and merge instead. Check `git config commit.gpgsign`, verify the key
+   is accessible, and confirm the repo's branch-protection
+   `required_signatures` rule.
+6. Running in CI / automation without a live human? Any ambiguous
+   "personal branch?" or "rebase safe?" answer → **fail closed, merge
+   instead**. Do not rebase when there's no one to escalate to.
+7. Using `--force-with-lease --force-if-includes` (with explicit
+   `<branch>:<expected-sha>` if on a fresh or shallow clone)? → proceed.
 
 ## Recovery from a bad force-push
 
@@ -164,6 +232,23 @@ one slips through and you clobber a teammate's commits:
 
 For recovery from a bad *merge* (not force-push) that already landed,
 see `git-state-safety`.
+
+## After a legitimate force-push: communicate
+
+Even a correct force-push invalidates commit SHAs, which breaks PR
+review-comment anchors, CI artifact links, external references, and
+bookmarks. After a rebase + force-push on a branch that has review
+activity, post a PR comment with:
+
+- The pre- and post-force SHAs, so reviewers can locate their prior
+  comments in their own checkouts.
+- A `git range-diff <old-sha>..<old-head> <new-sha>..<new-head>`
+  summary that shows which commits moved and what changed commit-by-
+  commit (not just the combined diff).
+
+This costs one comment and saves reviewers from guessing whether their
+prior feedback is addressed. Skip it only on branches with no active
+reviewers.
 
 ## Rule of thumb
 

--- a/claude/.claude/skills/git-feature-branch-sync/SKILL.md
+++ b/claude/.claude/skills/git-feature-branch-sync/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: git-feature-branch-sync
+description: >
+  Decision framework for keeping a feature branch up to date with main:
+  when to rebase-and-force-push vs merge-main-in, how to force-push
+  safely (`--force-with-lease` / `--force-if-includes` / plain `--force`),
+  and when the "never force-push" instinct is correct vs overcautious.
+  This is the global framework — per-client policy (squash-merge vs
+  merge-commit, rebase-after-review rules, branch-protection specifics)
+  lives in that repo's CLAUDE.md or a client-scoped skill.
+  TRIGGER when: deciding how to integrate `main` into a feature branch,
+  whether/how to force-push a feature branch, or picking between
+  `--force-with-lease` and `--force-if-includes`.
+  DO NOT TRIGGER when: routine work on a clean feature branch with no
+  integration question, operations on `main` / `release/*` / protected
+  branches (those are always protected — never force-push them), or
+  mid-merge / mid-rebase / mid-cherry-pick state (use `git-state-safety`
+  instead).
+user-invocable: false
+---
+
+# Feature-Branch Sync: Rebase, Merge, and Force-Push
+
+## The decision
+
+Keeping a feature branch current with `main` has two shapes:
+
+- **Rebase** — `git fetch origin && git rebase origin/main`. Replays your
+  commits on top of current `main`. Linear history. Rewrites commit SHAs,
+  so the next push must be a force-push.
+- **Merge** — `git merge origin/main`. Creates a merge commit on the
+  feature branch. Preserves SHAs. No force-push needed.
+
+**Default: rebase on personal feature branches.** Switch to merge when any
+*merge-required condition* below applies. Always defer to per-client
+policy if it contradicts this default.
+
+## Merge-required conditions
+
+Any one of these → merge-main, do not rebase:
+
+- **Another active committer** on the branch. Rebasing rewrites history
+  they have based work on; they will need a recovery dance.
+- **Another branch is stacked on this one.** Rebase invalidates the
+  child's base. If the stack is intentional and you must rebase, use
+  `git rebase --update-refs` and coordinate.
+- **Review is already in flight** in a culture that anchors comments to
+  specific commit SHAs. Rebasing detaches comments from their anchors.
+  Some teams forbid rebase post-review; prefer "rework" commits.
+- **Per-client policy says merge-only.** Check the repo's CLAUDE.md /
+  skills before recommending rebase.
+
+Otherwise, rebase.
+
+## Force-push flavors
+
+A rebased feature branch has commits whose SHAs no longer match the
+remote's. The push must be a force-push. The flavor matters:
+
+| Flag | Safety check | When to use |
+|---|---|---|
+| `--force` | None. Unconditionally overwrites the remote ref. | Never on its own. |
+| `--force-with-lease` | Fails if the remote ref moved since your last fetch. | Default for rebased feature branches. |
+| `--force-if-includes` | Additionally fails if the local branch doesn't contain the remote's tip. | Git ≥ 2.30. Pair with `--force-with-lease`. |
+
+Recommended command after rebasing a personal branch:
+
+```
+git push --force-with-lease --force-if-includes
+```
+
+`--force-with-lease` alone has a known gap: a stray `git fetch` updates
+the remote-tracking ref, which makes the lease look held even though you
+haven't integrated the remote's new commits. `--force-if-includes` closes
+that gap. Use both.
+
+## Never-force-push targets
+
+Refuse to force-push to any of these regardless of flavor:
+
+- `main`, `master`, `trunk`, `develop`, or any default branch
+- `release/*`, `hotfix/*`, or any other protected / shared branch
+- Any branch the user has not explicitly said is personal
+
+For those branches, rebasing the branch itself is also off the table —
+they keep merge history. Bringing `main` into them (when it even makes
+sense) is a merge, not a rebase.
+
+## Interaction with PR merge strategy
+
+The feature branch's internal history is either discarded or preserved
+at PR-merge time, depending on the repo's merge strategy:
+
+- **Squash-merge** — feature history collapses into one commit on `main`.
+  Rebase vs merge-main becomes purely about *your* dev experience during
+  the PR (reviewer diff cleanliness, conflict ergonomics). `main`'s
+  history is unaffected either way.
+- **Rebase-merge** — feature commits replay onto `main`. Internal
+  history survives. Keeping the branch rebased keeps `main` clean;
+  merge-main leaves merge commits in the replayed series.
+- **Merge-commit** — feature history plus a merge commit land on `main`.
+  Merge-main noise becomes permanent `main` history.
+
+**Before recommending rebase-only on history-cleanliness grounds, check
+the PR merge strategy.** On a squash-merge repo, the argument mostly
+dissolves; on a merge-commit repo, it's at its strongest. Per-client
+CLAUDE.md should state the policy.
+
+## Pre-flight checklist
+
+Before running `git push --force-with-lease` on a feature branch:
+
+1. Is this branch personal (only you committing)? If no → merge instead.
+2. Has anyone stacked a branch on this one? If yes → coordinate or merge.
+3. Is PR review in flight where comments anchor to SHAs? If yes → rework
+   commits, not rebase.
+4. Is the branch one of `main` / `master` / `develop` / `release/*` /
+   any protected branch? → stop. Force-push is forbidden here.
+5. Using `--force-with-lease --force-if-includes`? → proceed.
+
+## Recovery from a bad force-push
+
+`--force-with-lease --force-if-includes` will catch most of these. If
+one slips through and you clobber a teammate's commits:
+
+1. Find the pre-force SHA. Your local `git reflog` has it if you were
+   the one who force-pushed. Otherwise ask the displaced teammate —
+   their local reflog or branch still points at it.
+2. Restore: `git push --force-with-lease origin <recovered-sha>:<branch>`
+3. Coordinate. The teammate may have local work that now needs rebasing
+   onto the restored tip.
+
+For recovery from a bad *merge* (not force-push) that already landed,
+see `git-state-safety`.
+
+## Rule of thumb
+
+On a personal branch with no stacked dependents and no in-flight review
+anchoring: `git fetch origin && git rebase origin/main && git push
+--force-with-lease --force-if-includes`. Anywhere else: merge, or stop
+and ask.


### PR DESCRIPTION
## Summary

- Adds a global auto-triggering skill (`user-invocable: false`) that gives Claude a decision framework for keeping a feature branch current with `main`: when to rebase-and-force-push vs merge-main-in, and how to force-push safely via `--force-with-lease --force-if-includes`.
- Deliberately scoped as the *global framework*. Per-client policy — squash-merge vs merge-commit, rebase-after-review rules, protected-branch specifics — lives in each repo's CLAUDE.md or a client-scoped skill, not in this skill.
- Cross-references the existing `git-state-safety` skill for bad-merge recovery.

## Review process

Initial draft was reviewed via `/code-review` + two specialist agents (staff DevOps engineer, security engineer). Their findings drove the second commit on this branch, which:

- Expands the never-force-push list to include tags and environment branches (`staging`, `production`, `qa`, `uat`), and clarifies that the *remote's* default branch (`git symbolic-ref refs/remotes/origin/HEAD`) is authoritative, not `init.defaultBranch`.
- Warns that server-side branch protection may be absent (GitHub Free private repos, or simply unconfigured) and must not be the only guardrail.
- Adds a signed-commits check to the pre-flight (rebase drops signatures unless `commit.gpgsign=true`).
- Adds an independent-verification step for "personal branch" claims (`git log --format=%ae`), so the agent doesn't rely solely on an unverified user claim.
- Fixes the recovery recipe: pin the recovered SHA in a backup ref *before* anything else, fetch and merge reconciliation commits *before* force-pushing, and corrects the reflog unreachable-expiry default (90 days, not 30).
- Notes that `--force-if-includes` silently no-ops when reflogs are disabled (`core.logAllRefUpdates=false`).
- Reframes "rebase default" as opinionated rather than universal.

A verification pass by the same two specialists confirmed the fixes were adequate and flagged no regressions.

## Test plan

- [ ] Review the skill's frontmatter TRIGGER / DO NOT TRIGGER conditions — does the scope feel right (fires on rebase/merge/force-push decisions, defers to `git-state-safety` for mid-merge state)?
- [ ] Sanity-check the recovery recipe ordering: find SHA → pin → fetch + reconcile → restore → coordinate.
- [ ] Spot-check `git symbolic-ref refs/remotes/origin/HEAD` behavior on a repo where local `init.defaultBranch` differs from the remote default, to confirm the guidance is accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)