### PR TITLE
Add repo-wide CLAUDE.md: client-identifier redaction rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,51 +7,83 @@ govern any contribution (human or agent).
 ## Redact client-identifying content
 
 Never commit anything that ties a skill, rule, or example back to a
-specific client, engagement, or private codebase. That includes:
+specific client, engagement, or private codebase. Categories:
 
 - **Client / company names** (including the repo owner's own clients).
 - **Project codenames** unique to a client codebase.
-- **Issue or ticket IDs from client trackers** (e.g., `DAY-484`,
-  `ACME-123`, anything matching `[A-Z]{2,}-\d+` that is not a
-  well-known open-source reference).
-- **Internal URLs or hostnames** (private repo paths, internal
-  services, Slack channel names, client-specific domains).
+- **Internal tool or product names** (bespoke CLIs, in-house services)
+  beyond those generally known in open source.
+- **Issue or ticket IDs from client trackers** — anything matching
+  `[A-Z]{2,}-\d+` that is *not* on this allowlist of standard
+  open-source references: `CVE-`, `RFC-`, `PEP-`, `ISO-`, `GH-`,
+  `BUG-` / bugzilla-style, and clearly-public project prefixes.
+  Default: if in doubt, strip it.
+- **Internal URLs, hostnames, Slack channels, client domains**.
+- **Absolute filesystem paths** that embed client names
+  (`~/Code/acme-platform/...`, `/home/foo/WorkForClient/...`).
+- **Environment variable names** that encode a client (`ACME_API_URL`,
+  `PROD_FOOCO_DB_URL`).
+- **Commit SHAs or PR numbers from private repos** — pastes like
+  `see abc1234 in the main repo` are useless publicly and correlatable.
 - **Person names** other than the repo owner's own commit-author
   identity.
 
-**Check all three surfaces before committing:**
+### Also redact structural fingerprints
 
-1. File content being committed.
-2. Commit message body — the most common leak site, because it's where
-   motivation-context gets narrated.
-3. PR title and description.
+Identifiers aren't the only leak. Structural shapes can identify a
+client even without names — a verbatim RLS policy copied from a
+client codebase, a rare column-naming pattern, an unusual error-code
+namespace. When an example would reveal the client via shape alone,
+generalize the example.
+
+### Secrets, tokens, credentials
+
+Not a redaction concern — a do-not-commit-ever concern. API keys,
+OAuth tokens, service-role keys, `.env` contents, database URLs with
+credentials, private-key material. The repo has no legitimate use for
+any of these. If one ever lands, rotate it *then* rewrite history.
+
+## Check all three surfaces before committing
+
+1. **File content** being committed.
+2. **Commit message body** — the most common leak site, because it's
+   where motivation-context gets narrated.
+3. **PR title and description**.
 
 ## When a skill is surfaced by real-world work, abstract first
 
 Skills are often motivated by a concrete incident. The insight belongs
 in this repo; the incident specifics do not.
 
+**Rule:** keep the failure mode and the fix; drop the trigger's identity.
+
 - ✅ "Surfaced during a production incident where a mid-merge index was
   silently corrupted by a diagnostic `git checkout`."
-- ❌ "Surfaced during the Acme DAY-484 review..."
+- ❌ "Surfaced during the ExampleCo WIDGET-123 review, where the mid-merge
+  index was silently corrupted..."
 
-If a draft commit or skill body contains a client reference, fix it
-**before** committing — do not let history ship with the reference even
-if the skill body is clean. Rewriting unpushed history on a personal
-branch is the right tool here (see `git-feature-branch-sync`).
+If a draft commit, skill body, or PR description contains a client
+reference, fix it **before** committing — do not let history ship with
+the reference even if the skill body is clean. Rewriting unpushed
+history on a personal branch is the right tool here (see
+`git-feature-branch-sync`).
 
 ## AI agents
 
 The same rule applies when an AI agent is drafting. If the agent
-proposes a commit message, PR description, or skill body that includes
-a client reference — or an agent's research or reasoning hands the
-agent a reference from a private memory or conversation transcript —
-strip it before committing. The fact that the reference came from the
-agent, not a human, is not a defense.
+proposes a commit message, skill body, or PR description that includes
+a client reference — or an agent's research / memory hands it a
+reference — strip it before committing. The fact that the reference
+came from the agent, not a human, is not a defense.
 
-## Scope and residue
+## Enforcement
 
-This rule applies to all new contributions going forward. The repo's
-existing history may contain residue from before the rule was formalized;
-remediating that requires rewriting `main`, which is a deliberate
-decision and not part of this CLAUDE.md.
+The `deny-client-refs.sh` PreToolUse hook (wired in
+`claude/.claude/settings.json`) blocks `git commit` when the staged
+diff or commit message contains a tracker-ID token outside the OSS
+allowlist. Tests live in `claude/.claude/hooks/tests/test_hooks.py`.
+
+The hook catches the mechanical category (tracker IDs). Other
+categories above — client names, internal tool names, structural
+fingerprints — still require review discipline. Extend the hook's
+pattern list if a category becomes repeatable enough to automate.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,57 @@
+# Contributor Instructions
+
+This repository is **public** — every commit, skill body, commit message,
+and PR description ships to anyone with the URL. The guardrails below
+govern any contribution (human or agent).
+
+## Redact client-identifying content
+
+Never commit anything that ties a skill, rule, or example back to a
+specific client, engagement, or private codebase. That includes:
+
+- **Client / company names** (including the repo owner's own clients).
+- **Project codenames** unique to a client codebase.
+- **Issue or ticket IDs from client trackers** (e.g., `DAY-484`,
+  `ACME-123`, anything matching `[A-Z]{2,}-\d+` that is not a
+  well-known open-source reference).
+- **Internal URLs or hostnames** (private repo paths, internal
+  services, Slack channel names, client-specific domains).
+- **Person names** other than the repo owner's own commit-author
+  identity.
+
+**Check all three surfaces before committing:**
+
+1. File content being committed.
+2. Commit message body — the most common leak site, because it's where
+   motivation-context gets narrated.
+3. PR title and description.
+
+## When a skill is surfaced by real-world work, abstract first
+
+Skills are often motivated by a concrete incident. The insight belongs
+in this repo; the incident specifics do not.
+
+- ✅ "Surfaced during a production incident where a mid-merge index was
+  silently corrupted by a diagnostic `git checkout`."
+- ❌ "Surfaced during the Acme DAY-484 review..."
+
+If a draft commit or skill body contains a client reference, fix it
+**before** committing — do not let history ship with the reference even
+if the skill body is clean. Rewriting unpushed history on a personal
+branch is the right tool here (see `git-feature-branch-sync`).
+
+## AI agents
+
+The same rule applies when an AI agent is drafting. If the agent
+proposes a commit message, PR description, or skill body that includes
+a client reference — or an agent's research or reasoning hands the
+agent a reference from a private memory or conversation transcript —
+strip it before committing. The fact that the reference came from the
+agent, not a human, is not a defense.
+
+## Scope and residue
+
+This rule applies to all new contributions going forward. The repo's
+existing history may contain residue from before the rule was formalized;
+remediating that requires rewriting `main`, which is a deliberate
+decision and not part of this CLAUDE.md.

--- a/claude/.claude/hooks/deny-client-refs.sh
+++ b/claude/.claude/hooks/deny-client-refs.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Gate: reject `git commit` if the staged diff or the commit message on the
+# command line contains tracker-ID tokens that aren't on the open-source
+# allowlist. Enforces the tracker-ID piece of the repo-root CLAUDE.md
+# redaction rule ("Redact client-identifying content").
+#
+# Scope and limits:
+# - Catches the mechanical category (tracker IDs shaped like [A-Z]{2,}-\d+).
+# - Does NOT catch client names, internal tool names, absolute filesystem
+#   paths with client-names, or structural fingerprints. Those require
+#   review discipline or a blocklist extension.
+# - Scans the full Bash command string so `git commit -m "..."` and
+#   heredoc variants both get checked without parsing the message out
+#   of shell quoting.
+#
+# Allowlist extension: append to OSS_ALLOWLIST below if a legitimate
+# open-source prefix is blocked. Do NOT add client-specific prefixes.
+
+set -uo pipefail
+
+INPUT=$(cat)
+COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command // empty')
+
+# Only gate git commit commands. Exit silently on anything else.
+# Match `git commit` at the start of the command or after a shell
+# separator, same pattern as require-code-review.sh.
+if ! printf '%s\n' "$COMMAND" | grep -qE '(^|&&?|;|\|\|?)\s*git\s+commit(\s|$)'; then
+  exit 0
+fi
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$REPO_ROOT" ]; then
+  exit 0
+fi
+
+STAGED_DIFF=$(git diff --cached 2>/dev/null)
+if [ -z "$STAGED_DIFF" ]; then
+  # Amend-message-only, --allow-empty, or nothing staged. Let git decide.
+  exit 0
+fi
+
+# Scan ONLY added lines in the diff, not removed ones. Without this,
+# a commit that *removes* a tracker ID (legitimate cleanup) would be
+# blocked because the deleted line still contains the token.
+# Exclude `+++ b/path` file headers; keep real `+` content lines.
+ADDED_LINES=$(printf '%s' "$STAGED_DIFF" | grep -E '^\+' | grep -vE '^\+\+\+' || true)
+
+# Scan target: added diff lines plus the full Bash command. The command
+# string includes any `-m "..."` message or heredoc body.
+SCAN_TARGET=$(printf '%s\n%s\n' "$ADDED_LINES" "$COMMAND")
+
+# Allowlist: prefixes that are NEVER client tracker IDs. Extend by prefix
+# (no digits). Organized by category so it's obvious what belongs here.
+#   OSS specs / standards bodies: CVE, CWE, RFC, PEP, ISO, IETF, W3C,
+#                                 NIST, ECMA, ANSI
+#   Public-project trackers:      GH (GitHub shorthand), BUG (bugzilla),
+#                                 JEP / JDK (OpenJDK), LLVM, GCC
+#   Technical constants that      SHA, MD, HTTP, HTTPS, TLS, SSL
+#   happen to match [A-Z]{2,}-\d+:
+OSS_ALLOWLIST='^(CVE|CWE|RFC|PEP|ISO|IETF|W3C|NIST|ECMA|ANSI|GH|BUG|JEP|JDK|LLVM|GCC|SHA|MD|HTTP|HTTPS|TLS|SSL)-'
+
+HITS=$(printf '%s' "$SCAN_TARGET" \
+  | grep -oE '\b[A-Z]{2,}-[0-9]+\b' \
+  | sort -u \
+  | grep -vE "$OSS_ALLOWLIST" \
+  || true)
+
+if [ -z "$HITS" ]; then
+  exit 0
+fi
+
+# Report the first few offenders to keep the message short.
+HIT_LIST=$(printf '%s' "$HITS" | head -5 | tr '\n' ' ' | sed 's/ $//')
+
+REASON="Commit blocked by redaction gate: the staged diff or commit message contains tracker-ID tokens that may reveal a client or private project: ${HIT_LIST}. See repo CLAUDE.md section 'Redact client-identifying content'. If the match is an open-source reference or technical constant not on the allowlist, add the prefix to the OSS_ALLOWLIST variable in ~/.claude/hooks/deny-client-refs.sh. Otherwise rewrite the commit message / staged content without the tracker ID before retrying."
+
+REASON_JSON=$(printf '%s' "$REASON" | jq -Rs '.')
+
+printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' "$REASON_JSON"

--- a/claude/.claude/hooks/tests/test_hooks.py
+++ b/claude/.claude/hooks/tests/test_hooks.py
@@ -21,6 +21,7 @@ HOOKS_DIR = Path(__file__).resolve().parent.parent
 CODE_REVIEW_HOOK = HOOKS_DIR / "require-code-review.sh"
 RESPOND_PR_HOOK = HOOKS_DIR / "require-respond-pr.sh"
 REVIEW_PERMS_HOOK = HOOKS_DIR / "ask-review-permissions.sh"
+DENY_CLIENT_REFS_HOOK = HOOKS_DIR / "deny-client-refs.sh"
 
 
 def run_hook(hook: Path, tool_input: dict, cwd: Path | None = None) -> str:
@@ -395,3 +396,193 @@ class TestAskReviewPermissions:
 
     def test_bash_tool_allowed(self):
         assert run_hook(REVIEW_PERMS_HOOK, bash_input("cat /some/project/.claude/settings.json")) == "allow"
+
+
+# ---------------------------------------------------------------------------
+# deny-client-refs.sh
+# ---------------------------------------------------------------------------
+#
+# Fake placeholders used in these tests — chosen to be obviously synthetic
+# so the test file itself doesn't violate the rule it's testing:
+#   WIDGET-123, FOOCORP-42, NULLCLIENT-999, EXAMPLECO-7, BARCORP-22
+# All six prefixes are invented; none correspond to a real tracker that
+# any known organization uses. The hook's allowlist matches real OSS
+# reference prefixes only (CVE / RFC / PEP / ISO / GH / BUG / IETF).
+
+
+class TestDenyClientRefs:
+    def test_non_commit_command_allowed(self, git_repo):
+        assert run_hook(DENY_CLIENT_REFS_HOOK, bash_input("git status"), cwd=git_repo) == "allow"
+
+    def test_non_git_command_allowed(self, git_repo):
+        assert run_hook(DENY_CLIENT_REFS_HOOK, bash_input("echo WIDGET-123"), cwd=git_repo) == "allow"
+
+    def test_clean_commit_message_allowed(self, git_repo):
+        assert (
+            run_hook(
+                DENY_CLIENT_REFS_HOOK,
+                bash_input("git commit -m 'Refactor the parser'"),
+                cwd=git_repo,
+            )
+            == "allow"
+        )
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "Fix CVE-2024-12345",
+            "Map to CWE-79",
+            "Apply PEP-8 formatting",
+            "Per RFC-7231 section 6.5",
+            "Address GH-123 from upstream",
+            "Fix BUG-4242 in parser",
+            "Reference ISO-8601 dates",
+            "Per IETF-draft handling",
+            "Conform to W3C-REC",
+            "Map to NIST-800-53",
+            "Per ECMA-262",
+            "Per ANSI-89 spec",
+            "Implement JEP-394",
+            "Fix JDK-12345",
+            "Upstream LLVM-123",
+            "GCC-456 workaround",
+            "Require SHA-256",
+            "Deprecate MD-5",
+            "Support HTTP-2",
+            "Disable TLS-1",
+        ],
+        ids=[
+            "cve", "cwe", "pep", "rfc", "gh", "bug", "iso", "ietf",
+            "w3c", "nist", "ecma", "ansi", "jep", "jdk", "llvm", "gcc",
+            "sha", "md", "http", "tls",
+        ],
+    )
+    def test_allowlisted_references_allowed(self, git_repo, message):
+        assert (
+            run_hook(DENY_CLIENT_REFS_HOOK, bash_input(f"git commit -m '{message}'"), cwd=git_repo)
+            == "allow"
+        )
+
+    def test_synthetic_tracker_id_in_message_denied(self, git_repo):
+        assert (
+            run_hook(
+                DENY_CLIENT_REFS_HOOK,
+                bash_input("git commit -m 'Fix WIDGET-123 regression'"),
+                cwd=git_repo,
+            )
+            == "deny"
+        )
+
+    def test_multiple_tracker_ids_denied(self, git_repo):
+        assert (
+            run_hook(
+                DENY_CLIENT_REFS_HOOK,
+                bash_input("git commit -m 'Handle FOOCORP-42 and BARCORP-22'"),
+                cwd=git_repo,
+            )
+            == "deny"
+        )
+
+    def test_tracker_id_in_staged_diff_denied(self, git_repo):
+        """Hook must scan staged content, not just the command string."""
+        (git_repo / "file.txt").write_text("first\nsecond\n// NULLCLIENT-999 fixed\n")
+        subprocess.run(["git", "add", "file.txt"], cwd=git_repo, check=True)
+        assert (
+            run_hook(
+                DENY_CLIENT_REFS_HOOK,
+                bash_input("git commit -m 'Generic refactor'"),
+                cwd=git_repo,
+            )
+            == "deny"
+        )
+
+    def test_mixed_allowed_and_suspect_denied(self, git_repo):
+        """A CVE plus a client-looking token: still deny on the client token."""
+        assert (
+            run_hook(
+                DENY_CLIENT_REFS_HOOK,
+                bash_input("git commit -m 'Fix CVE-2024-1234 via EXAMPLECO-7 changes'"),
+                cwd=git_repo,
+            )
+            == "deny"
+        )
+
+    def test_heredoc_commit_message_scanned(self, git_repo):
+        """Heredoc-style commit messages get scanned via the command string."""
+        cmd = (
+            "git commit -m \"$(cat <<'EOF'\n"
+            "Subject line\n"
+            "\n"
+            "Body referencing FOOCORP-12 incident\n"
+            "EOF\n"
+            ")\""
+        )
+        assert run_hook(DENY_CLIENT_REFS_HOOK, bash_input(cmd), cwd=git_repo) == "deny"
+
+    def test_lowercase_token_allowed(self, git_repo):
+        """Lowercase `widget-123` doesn't match the uppercase-only regex.
+
+        Ticket IDs are conventionally uppercase; a lowercase hyphenated
+        token is more likely to be a package name or slug, not a tracker
+        reference. Explicitly allowed to avoid false positives on common
+        code patterns.
+        """
+        assert (
+            run_hook(
+                DENY_CLIENT_REFS_HOOK,
+                bash_input("git commit -m 'Fix widget-123 styling'"),
+                cwd=git_repo,
+            )
+            == "allow"
+        )
+
+    def test_chained_add_commit_with_suspect_token_denied(self, git_repo):
+        """Chained `git add && git commit` is still gated by this hook."""
+        assert (
+            run_hook(
+                DENY_CLIENT_REFS_HOOK,
+                bash_input("git add . && git commit -m 'Fix WIDGET-1 issue'"),
+                cwd=git_repo,
+            )
+            == "deny"
+        )
+
+    def test_removing_a_tracker_id_is_allowed(self, git_repo):
+        """A redaction commit that *removes* a tracker ID must not be blocked.
+
+        If the hook scanned removed lines, the staged deletion of a token
+        would match and block the cleanup itself — making the hook hostile
+        to its own maintenance flow.
+        """
+        # Seed a committed file that already contains a suspect token.
+        (git_repo / "legacy.txt").write_text("Old notes about WIDGET-999.\n")
+        subprocess.run(["git", "add", "legacy.txt"], cwd=git_repo, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "seed"], cwd=git_repo, check=True)
+        # Now stage a deletion of the token — the diff contains `-WIDGET-999`.
+        (git_repo / "legacy.txt").write_text("Old notes.\n")
+        subprocess.run(["git", "add", "legacy.txt"], cwd=git_repo, check=True)
+        assert (
+            run_hook(
+                DENY_CLIENT_REFS_HOOK,
+                bash_input("git commit -m 'Redact legacy notes'"),
+                cwd=git_repo,
+            )
+            == "allow"
+        )
+
+    def test_empty_staged_diff_allows_commit(self, git_repo):
+        """No staged changes — let git decide (empty-commit, amend, etc.).
+
+        Even though the command mentions a suspect token, there is no new
+        content being introduced; the hook shouldn't block an amend-only
+        or --allow-empty flow.
+        """
+        subprocess.run(["git", "reset", "HEAD"], cwd=git_repo, check=True)
+        assert (
+            run_hook(
+                DENY_CLIENT_REFS_HOOK,
+                bash_input("git commit -m 'Refers to WIDGET-123 but nothing staged'"),
+                cwd=git_repo,
+            )
+            == "allow"
+        )

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -12,6 +12,12 @@
           },
           {
             "type": "command",
+            "if": "Bash(git commit *)",
+            "command": "~/.claude/hooks/deny-client-refs.sh",
+            "statusMessage": "Scanning for client-identifying refs..."
+          },
+          {
+            "type": "command",
             "command": "~/.claude/hooks/require-respond-pr.sh",
             "statusMessage": "Checking respond-pr gate..."
           }


### PR DESCRIPTION
## Summary

- Adds a repo-root `CLAUDE.md` that establishes the going-forward rule: no client-identifying content in any commit to this public repo. Applies to skills, commit messages, PR descriptions — human or agent contributions.
- Enumerates identifier categories (names, ticket IDs with an OSS-reference allowlist, internal tool / URL / Slack / client-domain names, absolute paths, env var names, private-repo SHAs, person names, structural fingerprints) and the three surfaces to check (file content, commit body, PR description).
- Distinguishes redaction (strip-before-commit) from secrets (do-not-commit-ever; rotate and rewrite if one lands).
- Codifies the abstract-first rule for skills surfaced by real-world incidents: **keep the failure mode and the fix; drop the trigger's identity.**

Opened per [PR #17's review comment](https://github.com/jcdendrite/claude-config/pull/17#pullrequestreview-4157010228) — that review noted this rule belongs at repo level, not embedded in a single skill PR.

## Review process

Drafted, then consulted a security/privacy engineer with open-source-maintenance experience. Their findings drove the current version: expanded identifier categories (secrets, internal-tool names, absolute paths, env vars, private-repo SHAs), false-positive allowlist for OSS references (`CVE-` / `RFC-` / `PEP-` / `ISO-` / `GH-`), explicit section on **structural fingerprints** (RLS policy shapes, error-code namespaces, distinctive schema patterns that identify a client even without names), and a sharpened abstract-first rule. Principal-engineer checklist review followed; no additional blockers.

## Scope and residue

This PR establishes the going-forward rule only. `main`'s history already contains residue from before the rule was formalized (e.g., a `ACME-484 (client)` reference in the original `git-state-safety` commit body). Remediating that requires rewriting `main`, which is a release-coordination decision — tracked separately, not permanently deferred.

## Test plan

- [ ] Review the categories list for completeness — anything else you've seen leak that belongs in the enumeration?
- [ ] Agree on the `[A-Z]{2,}-\d+` allowlist shape for OSS references, or tighten it further.
- [ ] Decide whether to track main's residue-cleanup as a follow-on PR (history rewrite) or leave as-is.
- [ ] Decide whether to wire up a pre-commit hook now or wait for a concrete recurrence to justify one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)