### PR TITLE
Skill updates + CLAUDE.md: branch-creation, plan-review B15, respond-pr PATCH, secrets-Read rule

### DIFF
--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -35,3 +35,4 @@
 
 - Never run sudo commands directly.
 - Never commit secrets, credentials, API keys, or large binary assets to repositories.
+- Never use the Read tool on files likely to contain secrets (`.env`, `.claude.json`, `credentials.json`, similar). Reading pulls the secret into the conversation context. When you need to inspect such a file, give the user a shell command (`cat`, `grep`, `jq`) to run via `!` instead.

--- a/claude/.claude/skills/branch-creation/SKILL.md
+++ b/claude/.claude/skills/branch-creation/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: branch-creation
+description: >
+  How to name new feature branches and start them from a clean base.
+  Covers ticket-system naming (Linear, Jira, GitHub Issues) vs
+  ticket-less projects, anti-patterns to reject (tracker `<user>/`
+  defaults), and the pre-creation step of branching from a fresh
+  default-branch tip.
+  TRIGGER when: creating a new feature branch, picking a branch name,
+  deciding whether to use a tracker-provided default branch name.
+  DO NOT TRIGGER when: on an existing branch, syncing a branch with
+  the default (use `git-feature-branch-sync` instead), or
+  force-pushing.
+user-invocable: false
+---
+
+# Branch Creation
+
+## Naming
+
+Branch names follow `<TICKET-ID>/<topic-slug>` when the project has a
+ticket system (Linear, Jira, GitHub Issues, etc.). When there's no
+ticket system, use `<topic-slug>` alone.
+
+- **Topic slug** — lowercase, hyphen-separated, ≤50 chars. Describes
+  the change, not the motivation.
+- **Ticket ID** — as the tracker emits it (e.g., `GH-1234`, `T-42`,
+  `issue-99`).
+- **Don't accept tracker defaults** like the `<user>/<ticket>-<slug>`
+  form some tools emit (Linear's `gitBranchName` field is a common
+  source). The user prefix signals branch ownership, not work type,
+  and isn't standard practice.
+
+Examples:
+
+- With ticket: `GH-1234/checkout-redesign`, `T-42/verify-jwt-hardening`
+- Without ticket: `verify-jwt-hardening`, `checkout-redesign`
+
+### Why no `<type>/` prefix?
+
+Industry guides often recommend `<type>/<ticket>-<topic>` — e.g.,
+`feature/GH-1234-checkout` ([Conventional Branch](https://conventional-branch.github.io/)).
+That pattern adds signal when:
+
+- The team uses branch-prefix-keyed automation (changelog generation,
+  CI gating by branch type, auto-deploy paths).
+- Branches are scanned without opening the associated ticket.
+
+When neither applies — the ticket system already carries the work
+type as a label, and no automation keys off the branch prefix — the
+type prefix duplicates the tracker metadata without adding signal.
+[Lullabot's ADR](https://architecture.lullabot.com/adr/20220920-git-branch-naming/)
+documents the same tradeoff and the same conclusion: *"For our
+purposes we don't need the branch to indicate if it is a feature or
+a fix... Instead we rely on the ticket's type."*
+
+If a specific project needs prefix-keyed automation, add the type
+prefix at that project's CLAUDE.md level. The global default stays
+prefix-free.
+
+## Branch from a fresh default
+
+Create feature branches from the current tip of the default branch,
+not from whatever happens to be checked out:
+
+    git checkout main && git pull --ff-only
+    git checkout -b <new-branch>
+
+Branching off a stale or unrelated branch carries baggage (extra
+commits, dirty state) that doesn't belong in the PR. Repos that route
+branch creation through a worktree helper (`EnterWorktree`, custom
+scripts) usually handle this automatically — verify once, then trust.
+
+If the repo's default branch is `master`, `trunk`, `develop`, or
+anything other than `main`, substitute accordingly. Check with
+`git symbolic-ref refs/remotes/origin/HEAD`.

--- a/claude/.claude/skills/git-feature-branch-sync/SKILL.md
+++ b/claude/.claude/skills/git-feature-branch-sync/SKILL.md
@@ -27,6 +27,10 @@ placeholder. If the repo's default is `master`, `trunk`, `develop`, or
 something else, substitute accordingly — check with
 `git symbolic-ref refs/remotes/origin/HEAD`.
 
+Pre-creation concerns (branch naming, starting from a fresh default
+tip) live in the `branch-creation` skill — this one covers the
+lifecycle after the branch exists.
+
 ## The decision
 
 Keeping a feature branch current with the default branch has two shapes:

--- a/claude/.claude/skills/plan-review/SKILL.md
+++ b/claude/.claude/skills/plan-review/SKILL.md
@@ -116,6 +116,14 @@ B14. **Missing decision rationale** — Are design choices explained? A plan tha
     "use approach X" without explaining why X was chosen over Y leaves the implementer
     unable to make judgment calls when they encounter edge cases.
 
+B15. **Effort section reality** — If the plan has an "Estimated Effort" (or
+    similar) section, does it describe **review surface** — file count, domain
+    complexity, risk concentration, what the reviewer needs to look at — rather
+    than **implementation hours**? When Claude writes the code, hour-based
+    estimates anchored in human coding speed mislead the reviewer about where
+    to focus. Flag any effort section that cites hours, days, or "time to
+    implement"; rewrite in review-surface terms.
+
 ## Domain: Infrastructure
 
 Apply when the plan touches CI/CD, workflows, deployment, or config.

--- a/claude/.claude/skills/respond-pr/SKILL.md
+++ b/claude/.claude/skills/respond-pr/SKILL.md
@@ -42,3 +42,4 @@ gh api repos/owner/repo/pulls/4/comments \
 - Be concise in replies — state what was done, not lengthy explanations
 - If you disagree with a comment, explain why clearly but defer to the reviewer's judgment
 - Do not resolve review threads — let the reviewer verify and resolve them
+- PR comments are editable after posting. If a reply has a typo, factual error, or needs updating, **edit it via PATCH** rather than posting a correction as a new comment: `gh api repos/{owner}/{repo}/pulls/comments/{id} -X PATCH -F body='...'` (or `/issues/comments/{id}` for issue-level comments).


### PR DESCRIPTION
## Summary

Five related updates bundled together, all emerging from applying the newly-landed `ai-instruction-and-memory-files` guidance to personal auto-memory — specific rules too narrow for per-project memory migrated to their natural skill or CLAUDE.md homes.

1. **New `branch-creation` skill** — extracts branch naming and "branch from a fresh default" concerns into their own skill. Recommends `<TICKET-ID>/<topic-slug>` for ticketed projects, `<topic-slug>` alone otherwise. Rejects tracker defaults like `<user>/<ticket>-<slug>` (user prefix signals ownership, not work). Explains why no `<type>/` prefix, citing the [Lullabot ADR](https://architecture.lullabot.com/adr/20220920-git-branch-naming/).

2. **`git-feature-branch-sync` pointer** — one-line reference to the new `branch-creation` skill so the lifecycle split is discoverable. Keeps this skill focused on post-creation sync + force-push safety, matching its stated TRIGGER.

3. **`plan-review` B15 `Effort section reality`** — new check in the Clarity section of the Base checklist. Flags plans whose "Estimated Effort" cites implementation hours (not meaningful when Claude writes the code); rewrites in review-surface terms (files touched, complexity, risk concentration).

4. **`respond-pr` PATCH editability** — Guidelines bullet noting PR comments are editable via `gh api .../comments/{id} -X PATCH -F body='...'`. Prefer editing a prior reply over posting a correction-comment.

5. **Global CLAUDE.md Safety bullet** — prohibits Read-tool use on files likely to contain secrets (`.env`, `.claude.json`, `credentials.json`, similar). Reading pulls the secret into the conversation context; recommends giving the user a shell command to inspect instead.

## Background

A prior attempt at this bundle was lost when a concurrent session force-pushed `main` mid-handoff and its `git reset --hard` wiped the working-tree edits. This version is on a feature branch from day one, isolated from main-branch rewrites.

## Test plan

- [ ] Skim each modified SKILL.md and CLAUDE.md for coherence
- [ ] Confirm `branch-creation` TRIGGER and `git-feature-branch-sync` TRIGGER don't overlap problematically
- [ ] Confirm the `git-feature-branch-sync` pointer reads cleanly
- [ ] Spot-check that B15 fits the plan-review numbering (last Base-Clarity check was B14)
- [ ] Confirm the secrets-Read rule phrasing is broad enough (`.env`, `.claude.json`, `credentials.json`, "similar") without being overly prescriptive

🤖 Generated with [Claude Code](https://claude.com/claude-code)