### PR TITLE
Add worktree-enforcement hook with per-repo opt-in sentinel

### DIFF
--- a/.claude/worktree-required
+++ b/.claude/worktree-required
@@ -1,0 +1,14 @@
+# Claude Code worktree enforcement marker.
+#
+# Presence of this file at the repo root activates
+# ~/.claude/hooks/require-worktree-for-git-writes.sh for this repo:
+# non-read-only git operations (commit, push, rebase, reset, etc.)
+# are denied unless the session runs inside a linked worktree.
+#
+# Motivation: concurrent Claude Code sessions on the same working tree
+# can race — one session's `git reset --hard` or `git stash` can
+# silently wipe another's uncommitted edits. Working in linked
+# worktrees (git worktree add) isolates each session's state.
+#
+# To disable enforcement for this repo, delete this file.
+# See claude-config README.md "Worktree enforcement" for details.

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 __pycache__/
 .pytest_cache/
+
+# Claude Code local state at repo root. The committed .claude/worktree-required
+# sentinel activates worktree enforcement for this repo; everything else in
+# .claude/ is per-machine or per-session and shouldn't be tracked.
+.claude/plans/
+.claude/settings.local.json
+.claude/worktrees/

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This symlinks `claude/.claude/` into `$HOME/.claude/`.
 - **`require-code-review.sh`** — blocks `git commit` (including chained forms like `git add . && git commit`) until `/code-review` has run on the current staged state. Verified via sha256 marker in `~/.claude/review-markers/<repo-hash>`, which auto-invalidates the moment the staging area changes.
 - **`require-respond-pr.sh`** — blocks PR comment reads and posts (`gh api .../pulls|issues/N/{comments,reviews}`, `gh pr comment`, `gh pr review`) and redirects to `/respond-pr`, so all three comment types get fetched and replies carry the `[Claude Code]` attribution prefix. Honors a 60-minute bypass marker at `~/.claude/.respond-pr-active` that the skill sets on entry and removes on exit.
 - **`ask-review-permissions.sh`** — asks before `Edit`/`Write`/`MultiEdit` to `.claude/settings*.json`, nudging toward `/review-permissions` when the edit touches `permissions.allow`.
+- **`require-worktree-for-git-writes.sh`** — opt-in per repo. When active, denies non-read-only git operations unless the session runs in a linked git worktree. Prevents concurrent Claude Code sessions from racing on the same working tree. See [Worktree enforcement](#worktree-enforcement) below for opt-in instructions.
 
 ### Skills (slash commands)
 
@@ -41,9 +42,47 @@ This symlinks `claude/.claude/` into `$HOME/.claude/`.
 - **`settings.json`** — global settings wiring up the hooks and statusline. Session-only overrides (model, effortLevel) are intentionally not tracked — use the `ANTHROPIC_MODEL` and `CLAUDE_CODE_EFFORT_LEVEL` env vars, or `/effort max` mid-session.
 - **`statusline-command.sh`** — status bar showing model, context usage, session cost, working directory, and git branch.
 
+## Worktree enforcement
+
+Concurrent Claude Code sessions that share a working tree can race: one session's `git reset --hard`, `git stash`, or `git checkout` silently wipes another session's uncommitted edits. See [Claude Code issue #34327](https://github.com/anthropics/claude-code/issues/34327) for examples of this failure mode in the wild.
+
+`require-worktree-for-git-writes.sh` mitigates by denying non-read-only git operations (`commit`, `push`, `rebase`, `reset`, `merge`, `checkout`, etc.) unless the session runs inside a linked git worktree. Read-only commands (`status`, `log`, `diff`, `fetch`, `show`, `blame`, etc.) are always allowed. The hook is opt-in per repo via a committed sentinel file.
+
+### Activating enforcement on a repo
+
+```bash
+cd path/to/your/repo
+
+mkdir -p .claude
+cat > .claude/worktree-required <<'EOF'
+# Claude Code worktree enforcement marker.
+# Presence of this file activates ~/.claude/hooks/require-worktree-for-git-writes.sh.
+# See https://github.com/jcdendrite/claude-config for details.
+EOF
+
+echo '.claude/worktrees/' >> .gitignore
+
+git add .claude/worktree-required .gitignore
+git commit -m "Activate Claude Code worktree enforcement"
+```
+
+### Working inside a worktree
+
+With enforcement active, start sessions for non-trivial work in a worktree instead of the main tree:
+
+```bash
+git worktree add .claude/worktrees/my-feature -b my-feature
+cd .claude/worktrees/my-feature
+# work happens here; git commit/push/etc. pass through the hook cleanly
+```
+
+Agents spawned with `isolation: worktree` create their own worktrees under `.claude/worktrees/` automatically.
+
+To opt out, delete `.claude/worktree-required`.
+
 ## Tests
 
-Pytest suite for the hooks (37 cases covering allow, deny, and ask paths):
+Pytest suite for the hooks (covering allow, deny, and ask paths):
 
 ```bash
 pytest claude/.claude/hooks/tests/

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Concurrent Claude Code sessions that share a working tree can race: one session'
 
 ### Activating enforcement on a repo
 
+The sentinel coexists with any existing `.claude/` content — `mkdir -p` is a no-op if the directory is already there, and the sentinel is an inert marker file alongside whatever project-level plans, `settings.local.json`, or untracked worktree dirs the repo already holds.
+
 ```bash
 cd path/to/your/repo
 
@@ -60,13 +62,15 @@ cat > .claude/worktree-required <<'EOF'
 # See https://github.com/jcdendrite/claude-config for details.
 EOF
 
-echo '.claude/worktrees/' >> .gitignore
+grep -qxF '.claude/worktrees/' .gitignore 2>/dev/null || echo '.claude/worktrees/' >> .gitignore
 
 git add .claude/worktree-required .gitignore
 git commit -m "Activate Claude Code worktree enforcement"
 ```
 
 ### Working inside a worktree
+
+A [git worktree](https://git-scm.com/docs/git-worktree) is a linked working directory on a separate branch that shares the repo's `.git` object storage with the main clone. `git worktree add <path> -b <branch>` creates one; multiple worktrees of the same repo can have different branches checked out simultaneously, which is what lets concurrent Claude Code sessions stay isolated.
 
 With enforcement active, start sessions for non-trivial work in a worktree instead of the main tree:
 

--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -31,10 +31,6 @@
 
 - After writing or modifying an implementation plan, run `/plan-review` before presenting the plan to the user. If the review finds issues, address them first, then present the final version.
 
-## Worktree enforcement
-
-- If the worktree-enforcement hook denies a git command, remediate by `cd`-ing into (or creating) a worktree under `.claude/worktrees/` and retrying — full remediation is in the deny message.
-
 ## Safety
 
 - Never run sudo commands directly.

--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -31,6 +31,10 @@
 
 - After writing or modifying an implementation plan, run `/plan-review` before presenting the plan to the user. If the review finds issues, address them first, then present the final version.
 
+## Worktree enforcement
+
+- If the worktree-enforcement hook denies a git command, remediate by `cd`-ing into (or creating) a worktree under `.claude/worktrees/` and retrying — full remediation is in the deny message.
+
 ## Safety
 
 - Never run sudo commands directly.

--- a/claude/.claude/hooks/require-worktree-for-git-writes.sh
+++ b/claude/.claude/hooks/require-worktree-for-git-writes.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+# Gate: require git write operations to happen inside a linked worktree,
+# not the main working tree. Opt-in per-repo via a committed
+# .claude/worktree-required sentinel file at the repo root.
+#
+# Motivation: concurrent Claude Code sessions on the same working tree can
+# race — e.g. one session's `git reset --hard` silently wipes another's
+# uncommitted edits. Working in linked worktrees (`git worktree add`)
+# isolates each session's state.
+#
+# Allow list: ~26 known read-only git subcommands, plus `worktree` (so the
+# bootstrap `git worktree add` isn't denied on the main tree). Anything
+# else is denied when run from the main working tree of an opted-in repo.
+# Allowed unconditionally inside a linked worktree.
+
+# Defensive: prevent GIT_DIR / GIT_WORK_TREE env overrides from making the
+# main tree impersonate a linked worktree via rev-parse output.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE
+
+INPUT=$(cat)
+COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+JQ_EXIT=$?
+CWD=$(printf '%s\n' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)
+[ -z "$CWD" ] && CWD="$PWD"
+
+emit_deny() {
+  local reason="$1"
+  local reason_json
+  reason_json=$(printf '%s' "$reason" | jq -Rs .)
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}' \
+    "$reason_json"
+}
+
+# Fail-closed on malformed input: if jq couldn't parse the stdin JSON, we
+# can't tell what Claude is about to run, so deny rather than silently allow.
+if [ "$JQ_EXIT" -ne 0 ]; then
+  emit_deny "Blocked by worktree-enforcement hook: could not parse tool-input JSON. Refusing to evaluate git discipline under malformed input."
+  exit 0
+fi
+
+# Fast-path: commands that don't mention git are not our concern. Use bash
+# pattern matching instead of grep to avoid locale-dependent behavior on
+# commands containing non-UTF-8 bytes.
+if [[ "$COMMAND" != *git* ]]; then
+  exit 0
+fi
+
+# Find the repo. Outside a git repo, nothing to enforce.
+REPO_ROOT=$(cd "$CWD" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$REPO_ROOT" ]; then
+  exit 0
+fi
+
+# Per-repo opt-in: only enforce if the repo has committed the sentinel.
+if [ ! -f "$REPO_ROOT/.claude/worktree-required" ]; then
+  exit 0
+fi
+
+# "Am I in a linked worktree?" check. For the main working tree,
+# --git-dir and --git-common-dir return the same absolute path. For a
+# linked worktree, --git-dir points at <common>/worktrees/<name> while
+# --git-common-dir still points at <common>. Comparing the two is robust
+# against path-substring false positives (e.g. a repo literally at
+# ~/code/worktrees/myrepo) and env-var spoofing.
+GIT_DIR_ABS=$(cd "$CWD" 2>/dev/null && git rev-parse --absolute-git-dir 2>/dev/null)
+GIT_COMMON_DIR=$(cd "$CWD" 2>/dev/null && git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
+if [ -n "$GIT_DIR_ABS" ] && [ -n "$GIT_COMMON_DIR" ] && [ "$GIT_DIR_ABS" != "$GIT_COMMON_DIR" ]; then
+  exit 0
+fi
+
+# From here on we are in the MAIN working tree of an opted-in repo.
+# Only read-only git subcommands are allowed; everything else is denied.
+
+readonly ALLOWED_SUBCMDS=(
+  blame
+  branch          # "git branch" lists; creating/deleting takes flags
+  cat-file
+  count-objects
+  describe
+  diff
+  fetch           # updates remote-tracking refs only, not working tree
+  for-each-ref
+  fsck
+  help
+  log
+  ls-files
+  ls-remote
+  ls-tree
+  name-rev
+  reflog
+  remote
+  rev-list
+  rev-parse
+  shortlog
+  show
+  status
+  tag             # "git tag" lists; creating takes flags — acceptable risk
+  verify-commit
+  verify-tag
+  version
+  worktree        # bootstrap for this whole mechanism — don't block it
+)
+ALLOWED_RE=$(IFS='|'; echo "${ALLOWED_SUBCMDS[*]}")
+
+# Extract the git subcommand from a fragment like "git -C path commit -m foo".
+# Strips global flags that consume the next word, skips other flags, returns
+# the first bare word — the subcommand. Empty output means we couldn't find
+# one, which is a parse failure and triggers fail-closed deny.
+#
+# Globbing is explicitly disabled for the loop so that an input like
+# "git * log" can't glob against cwd contents to hide the real subcommand.
+extract_git_subcmd() {
+  local fragment="$1"
+  local after_git="${fragment#*git}"
+  local saved_opts=$-
+  set -f
+  local skip_next=false subcmd=""
+  for word in $after_git; do
+    if $skip_next; then
+      skip_next=false
+      continue
+    fi
+    case "$word" in
+      -C|-c|--git-dir|--work-tree|--namespace|--super-prefix|--config-env)
+        skip_next=true ;;
+      -*)
+        ;;
+      *)
+        subcmd="$word"
+        break ;;
+    esac
+  done
+  # Restore the globbing state of our caller.
+  if [[ "$saved_opts" != *f* ]]; then
+    set +f
+  fi
+  printf '%s' "$subcmd"
+}
+
+# Split on shell operators so chained commands get inspected fragment by
+# fragment. Replace operators with newlines, then walk the list.
+FRAGMENTS=$(printf '%s' "$COMMAND" | sed -E 's/;/\n/g; s/&&/\n/g; s/\|\|/\n/g; s/\|/\n/g; s/\$\(/\n/g; s/`/\n/g')
+
+while IFS= read -r fragment; do
+  [ -z "$fragment" ] && continue
+  if [[ "$fragment" != *git* ]]; then
+    continue
+  fi
+
+  subcmd=$(extract_git_subcmd "$fragment")
+  if [ -z "$subcmd" ]; then
+    emit_deny "Blocked by worktree-enforcement hook: could not determine the git subcommand in '$fragment'. This repo has opted into worktree discipline (.claude/worktree-required is committed). Run git write operations from inside a linked worktree — either change the session cwd into an existing worktree under .claude/worktrees/, use the EnterWorktree tool, or spawn an agent with isolation: worktree."
+    exit 0
+  fi
+
+  if ! [[ "$subcmd" =~ ^($ALLOWED_RE)$ ]]; then
+    emit_deny "Blocked by worktree-enforcement hook: 'git $subcmd' is not on the read-only allowlist, and this session is running in the main working tree of a repo that has opted into worktree discipline (.claude/worktree-required is committed). Run git write operations from inside a linked worktree — cd into an existing worktree under .claude/worktrees/, create one with 'git worktree add .claude/worktrees/<branch> -b <branch>' (that specific command is allowed on the main tree), or spawn an agent with isolation: worktree. See claude-config README 'Worktree enforcement' for details."
+    exit 0
+  fi
+done <<< "$FRAGMENTS"
+
+exit 0

--- a/claude/.claude/hooks/tests/test_hooks.py
+++ b/claude/.claude/hooks/tests/test_hooks.py
@@ -22,6 +22,7 @@ CODE_REVIEW_HOOK = HOOKS_DIR / "require-code-review.sh"
 RESPOND_PR_HOOK = HOOKS_DIR / "require-respond-pr.sh"
 REVIEW_PERMS_HOOK = HOOKS_DIR / "ask-review-permissions.sh"
 DENY_CLIENT_REFS_HOOK = HOOKS_DIR / "deny-client-refs.sh"
+WORKTREE_HOOK = HOOKS_DIR / "require-worktree-for-git-writes.sh"
 
 
 def run_hook(hook: Path, tool_input: dict, cwd: Path | None = None) -> str:
@@ -586,3 +587,330 @@ class TestDenyClientRefs:
             )
             == "allow"
         )
+
+
+# ---------------------------------------------------------------------------
+# require-worktree-for-git-writes.sh
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def opted_in_repo(tmp_path):
+    """Git repo with .claude/worktree-required committed (opted into
+    worktree enforcement)."""
+    repo = tmp_path / "opted-in"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=repo, check=True)
+    (repo / ".claude").mkdir()
+    (repo / ".claude" / "worktree-required").write_text("# sentinel\n")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=repo, check=True)
+    return repo
+
+
+@pytest.fixture
+def non_opted_repo(tmp_path):
+    """Git repo without the sentinel — enforcement should be a no-op."""
+    repo = tmp_path / "non-opted"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=repo, check=True)
+    (repo / "f.txt").write_text("x\n")
+    subprocess.run(["git", "add", "f.txt"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=repo, check=True)
+    return repo
+
+
+@pytest.fixture
+def opted_in_with_worktree(opted_in_repo, tmp_path):
+    """Opted-in repo with a linked worktree at a path that does NOT contain
+    '/worktrees/' — verifies the hook's worktree check reads git-dir rather
+    than pattern-matching the working-tree path."""
+    wt_path = tmp_path / "feature-tree"
+    subprocess.run(
+        ["git", "worktree", "add", "-b", "feature", str(wt_path)],
+        cwd=opted_in_repo,
+        check=True,
+    )
+    return opted_in_repo, wt_path
+
+
+class TestRequireWorktreeForGitWrites:
+    def test_no_sentinel_allows_commit(self, non_opted_repo):
+        assert run_hook(WORKTREE_HOOK, bash_input("git commit -m foo"), cwd=non_opted_repo) == "allow"
+
+    def test_no_sentinel_allows_push(self, non_opted_repo):
+        assert run_hook(WORKTREE_HOOK, bash_input("git push origin main"), cwd=non_opted_repo) == "allow"
+
+    def test_opted_in_main_tree_denies_commit(self, opted_in_repo):
+        assert run_hook(WORKTREE_HOOK, bash_input("git commit -m foo"), cwd=opted_in_repo) == "deny"
+
+    def test_opted_in_main_tree_denies_push(self, opted_in_repo):
+        assert run_hook(WORKTREE_HOOK, bash_input("git push origin main"), cwd=opted_in_repo) == "deny"
+
+    def test_opted_in_main_tree_denies_rebase(self, opted_in_repo):
+        assert run_hook(WORKTREE_HOOK, bash_input("git rebase origin/main"), cwd=opted_in_repo) == "deny"
+
+    def test_opted_in_main_tree_denies_reset(self, opted_in_repo):
+        assert run_hook(WORKTREE_HOOK, bash_input("git reset --hard HEAD~1"), cwd=opted_in_repo) == "deny"
+
+    def test_opted_in_main_tree_denies_checkout(self, opted_in_repo):
+        assert run_hook(WORKTREE_HOOK, bash_input("git checkout main"), cwd=opted_in_repo) == "deny"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "git status",
+            "git log --oneline",
+            "git diff HEAD~1",
+            "git show HEAD",
+            "git fetch origin",
+            "git branch",
+            "git rev-parse --show-toplevel",
+            "git remote -v",
+            "git blame file.txt",
+        ],
+    )
+    def test_opted_in_main_tree_allows_readonly(self, opted_in_repo, command):
+        assert run_hook(WORKTREE_HOOK, bash_input(command), cwd=opted_in_repo) == "allow"
+
+    def test_opted_in_chained_write_denies(self, opted_in_repo):
+        """A read-only fragment followed by a write still denies — the
+        write fragment alone is enough."""
+        assert (
+            run_hook(
+                WORKTREE_HOOK,
+                bash_input("git status && git commit -m foo"),
+                cwd=opted_in_repo,
+            )
+            == "deny"
+        )
+
+    def test_opted_in_chained_readonly_allows(self, opted_in_repo):
+        assert (
+            run_hook(
+                WORKTREE_HOOK,
+                bash_input("git status && git log --oneline"),
+                cwd=opted_in_repo,
+            )
+            == "allow"
+        )
+
+    def test_opted_in_worktree_allows_commit(self, opted_in_with_worktree):
+        _, worktree = opted_in_with_worktree
+        assert run_hook(WORKTREE_HOOK, bash_input("git commit -m foo"), cwd=worktree) == "allow"
+
+    def test_opted_in_worktree_allows_push(self, opted_in_with_worktree):
+        _, worktree = opted_in_with_worktree
+        assert run_hook(WORKTREE_HOOK, bash_input("git push origin feature"), cwd=worktree) == "allow"
+
+    def test_non_git_command_allowed(self, opted_in_repo):
+        assert run_hook(WORKTREE_HOOK, bash_input("ls -la"), cwd=opted_in_repo) == "allow"
+
+    def test_outside_git_repo_allowed(self, tmp_path):
+        """Not in a git repo — nothing to enforce."""
+        non_repo = tmp_path / "not-a-repo"
+        non_repo.mkdir()
+        assert run_hook(WORKTREE_HOOK, bash_input("git commit -m foo"), cwd=non_repo) == "allow"
+
+    def test_git_dash_C_flag_stripped(self, opted_in_repo):
+        """`git -C /tmp commit` should parse as `commit` — flag and path stripped."""
+        assert (
+            run_hook(
+                WORKTREE_HOOK,
+                bash_input("git -C /tmp commit -m foo"),
+                cwd=opted_in_repo,
+            )
+            == "deny"
+        )
+
+    def test_git_no_pager_log_allowed(self, opted_in_repo):
+        """`git --no-pager log` parses as `log` — flag stripped."""
+        assert (
+            run_hook(
+                WORKTREE_HOOK,
+                bash_input("git --no-pager log"),
+                cwd=opted_in_repo,
+            )
+            == "allow"
+        )
+
+    def test_parse_failure_denies(self, opted_in_repo):
+        """Fail-closed: if we can't identify the subcommand, deny with a
+        recognizable reason (distinguishable from an allowlist miss)."""
+        result = subprocess.run(
+            [str(WORKTREE_HOOK)],
+            input=json.dumps(bash_input("git -C /tmp")),
+            capture_output=True,
+            text=True,
+            cwd=opted_in_repo,
+            check=False,
+        )
+        assert result.stdout.strip(), "expected a deny verdict"
+        payload = json.loads(result.stdout)
+        assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
+        assert "could not determine the git subcommand" in payload["hookSpecificOutput"]["permissionDecisionReason"]
+
+    def test_worktree_add_allowed_on_main_tree(self, opted_in_repo):
+        """`git worktree add` is the bootstrap for this whole mechanism.
+        Denying it would strand users whose only escape hatch is creating
+        a worktree from the main tree. Explicitly allowlisted."""
+        assert (
+            run_hook(
+                WORKTREE_HOOK,
+                bash_input("git worktree add .claude/worktrees/feature -b feature"),
+                cwd=opted_in_repo,
+            )
+            == "allow"
+        )
+
+    def test_git_config_denied_on_main_tree(self, opted_in_repo):
+        """`git config` can install malicious aliases, pagers, credential
+        helpers that execute arbitrary code on next git invocation. Not
+        safe as 'read-only' even though it doesn't touch the working tree."""
+        assert (
+            run_hook(
+                WORKTREE_HOOK,
+                bash_input("git config --get user.email"),
+                cwd=opted_in_repo,
+            )
+            == "deny"
+        )
+
+    def test_env_prefix_command_denied(self, opted_in_repo):
+        """`env FOO=1 git commit` — after-git strip still yields `commit`."""
+        assert (
+            run_hook(
+                WORKTREE_HOOK,
+                bash_input("env FOO=1 git commit -m foo"),
+                cwd=opted_in_repo,
+            )
+            == "deny"
+        )
+
+    def test_sudo_prefix_command_denied(self, opted_in_repo):
+        """Sudo prefix doesn't change subcommand extraction."""
+        assert (
+            run_hook(
+                WORKTREE_HOOK,
+                bash_input("sudo git commit -m foo"),
+                cwd=opted_in_repo,
+            )
+            == "deny"
+        )
+
+    def test_pipe_readonly_allowed(self, opted_in_repo):
+        """Pipe-chained read-only commands pass; each fragment parsed separately."""
+        assert (
+            run_hook(
+                WORKTREE_HOOK,
+                bash_input("git log --oneline | grep foo"),
+                cwd=opted_in_repo,
+            )
+            == "allow"
+        )
+
+    def test_pipe_then_write_denied(self, opted_in_repo):
+        """A write after a pipe+&& is still caught — pipe and && both split."""
+        assert (
+            run_hook(
+                WORKTREE_HOOK,
+                bash_input("git status | head && git commit -m x"),
+                cwd=opted_in_repo,
+            )
+            == "deny"
+        )
+
+    def test_background_write_denied(self, opted_in_repo):
+        """`git push &` — the & isn't split but `push` is still extracted."""
+        assert (
+            run_hook(
+                WORKTREE_HOOK,
+                bash_input("git push &"),
+                cwd=opted_in_repo,
+            )
+            == "deny"
+        )
+
+    def test_empty_command_allowed(self, opted_in_repo):
+        assert run_hook(WORKTREE_HOOK, bash_input(""), cwd=opted_in_repo) == "allow"
+
+    def test_whitespace_only_command_allowed(self, opted_in_repo):
+        assert run_hook(WORKTREE_HOOK, bash_input("   "), cwd=opted_in_repo) == "allow"
+
+    def test_git_dash_c_inline_config_allowed(self, opted_in_repo):
+        """`git -c key=val log` — the -c inline config flag consumes the
+        next word; subcommand `log` is on the allowlist."""
+        assert (
+            run_hook(
+                WORKTREE_HOOK,
+                bash_input("git -c user.email=t@t.com log"),
+                cwd=opted_in_repo,
+            )
+            == "allow"
+        )
+
+    def test_git_dir_flag_allowed(self, opted_in_repo):
+        """`git --git-dir /tmp/.git log` — --git-dir consumes next word."""
+        assert (
+            run_hook(
+                WORKTREE_HOOK,
+                bash_input("git --git-dir /tmp/.git log"),
+                cwd=opted_in_repo,
+            )
+            == "allow"
+        )
+
+    def test_sentinel_as_directory_treated_as_unopted(self, tmp_path):
+        """`-f` is false for directories, so a directory at
+        .claude/worktree-required leaves the repo effectively unopted."""
+        repo = tmp_path / "weird"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.name", "t"], cwd=repo, check=True)
+        (repo / ".claude").mkdir()
+        (repo / ".claude" / "worktree-required").mkdir()
+        (repo / "f.txt").write_text("x\n")
+        subprocess.run(["git", "add", "."], cwd=repo, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=repo, check=True)
+        assert run_hook(WORKTREE_HOOK, bash_input("git commit -m foo"), cwd=repo) == "allow"
+
+    def test_malformed_json_stdin_denies(self, opted_in_repo):
+        """jq parse failure → fail-closed deny. We skip `run_hook` and feed
+        raw non-JSON directly."""
+        result = subprocess.run(
+            [str(WORKTREE_HOOK)],
+            input="this is not JSON at all{",
+            capture_output=True,
+            text=True,
+            cwd=opted_in_repo,
+            check=False,
+        )
+        assert result.stdout.strip(), "expected a deny verdict on malformed JSON"
+        payload = json.loads(result.stdout)
+        assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    def test_git_dir_env_var_does_not_bypass(self, opted_in_repo):
+        """GIT_DIR=/anything/worktrees/x must NOT make the main tree look
+        like a linked worktree. The hook unsets GIT_DIR defensively."""
+        env = {**os.environ, "GIT_DIR": "/tmp/fake/worktrees/spoofed"}
+        result = subprocess.run(
+            [str(WORKTREE_HOOK)],
+            input=json.dumps(bash_input("git commit -m foo")),
+            capture_output=True,
+            text=True,
+            cwd=opted_in_repo,
+            env=env,
+            check=False,
+        )
+        assert result.stdout.strip(), "expected deny despite GIT_DIR spoof"
+        payload = json.loads(result.stdout)
+        assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    def test_non_bash_tool_allowed(self, opted_in_repo):
+        """Edit tool inputs have no .tool_input.command — hook no-ops."""
+        assert run_hook(WORKTREE_HOOK, edit_input("/tmp/foo.txt"), cwd=opted_in_repo) == "allow"

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -20,6 +20,11 @@
             "type": "command",
             "command": "~/.claude/hooks/require-respond-pr.sh",
             "statusMessage": "Checking respond-pr gate..."
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/require-worktree-for-git-writes.sh",
+            "statusMessage": "Checking worktree enforcement..."
           }
         ]
       },


### PR DESCRIPTION
## Summary

- Adds a new PreToolUse Bash hook, `require-worktree-for-git-writes.sh`, that denies non-read-only git operations in the main working tree of repos that commit a `.claude/worktree-required` sentinel at the repo root. Operations inside a linked git worktree pass through cleanly.
- Opt-in is per repo via the committed sentinel — repos without the file are unaffected. Ships the sentinel in this repo so enforcement activates on `claude-config` itself after the next `git pull`.
- 40 new pytest cases bring the suite to 117 total.

## Motivation

Concurrent Claude Code sessions on the same working tree can race: one session's `git reset --hard`, `git stash`, or `git checkout` silently wipes another session's uncommitted edits. See [anthropics/claude-code#34327](https://github.com/anthropics/claude-code/issues/34327) for examples in the wild. Worktree isolation is the established fix; this hook makes it enforceable rather than hopeful.

## Design decisions

- **Committed sentinel (vs. local git config)**: the sentinel travels with the repo, so all clones enforce consistently — no per-machine, per-clone setup that can be forgotten. `git config --local` was ruled out because the "did I remember?" surface area compounds across developers, repos, and machines; for a safety hook, forgetting puts you back in the race.
- **`git-dir != git-common-dir` check (vs. path-pattern match)**: semantically correct detection of linked worktrees. Resistant to `GIT_DIR` env-var spoofing and to false matches on repos literally located at paths containing `/worktrees/`. The hook also defensively unsets `GIT_DIR`/`GIT_WORK_TREE`.
- **`worktree` on the allowlist**: the remediation tells users to run `git worktree add`; denying that command on the main tree would strand them.
- **`config` NOT on the allowlist**: `git config alias.x '!sh -c "..."'`, `core.pager`, `credential.helper`, `core.sshCommand` all fire on the next git invocation. Treating `git config` as "read-only because it doesn't mutate the tree" was wrong — it mutates a file that becomes executable code.
- **Fail-closed everywhere**: malformed stdin JSON, unparseable git subcommands, and globbing inside the parser all deny rather than silently allow.

## Review

Three specialist reviewers (Senior Bash/Security, Claude Code config, SDET) surfaced issues around `git config` in the allowlist (ACE risk), `GIT_DIR` env-var bypass, globbing inside `extract_git_subcmd`, and JSON parse-failure fail-open. All addressed before commit.

## Test plan

- [x] `pytest claude/.claude/hooks/tests/` — 117 passed
- [ ] After merging, `git pull` in the local `claude-config` checkout. Stow already folded `~/.claude/hooks` as a symlink to the repo's hooks dir, so the new script is visible immediately through the existing symlink — no re-stow needed.
- [ ] Confirm enforcement activates: `cd ~/MyCode/claude-config && git commit --allow-empty -m test` should deny (main tree, sentinel committed)
- [ ] Confirm worktree path works: `git worktree add .claude/worktrees/smoke -b smoke && cd .claude/worktrees/smoke && git commit --allow-empty -m test` should pass