### PR TITLE
README: document deny-client-refs.sh hook and 6 missing skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,23 @@ This symlinks `claude/.claude/` into `$HOME/.claude/`.
 ### Hooks (PreToolUse gates)
 
 - **`require-code-review.sh`** — blocks `git commit` (including chained forms like `git add . && git commit`) until `/code-review` has run on the current staged state. Verified via sha256 marker in `~/.claude/review-markers/<repo-hash>`, which auto-invalidates the moment the staging area changes.
+- **`deny-client-refs.sh`** — blocks `git commit` when the staged diff or commit message contains tracker-ID tokens (`[A-Z]{2,}-\d+`) outside an OSS-prefix allowlist (`CVE-`, `RFC-`, `GH-`, and similar — see the script for the full list). Enforces the tracker-ID category of the repo-root `CLAUDE.md` redaction rule; other categories (client names, internal tool names, structural fingerprints) still require review discipline.
 - **`require-respond-pr.sh`** — blocks PR comment reads and posts (`gh api .../pulls|issues/N/{comments,reviews}`, `gh pr comment`, `gh pr review`) and redirects to `/respond-pr`, so all three comment types get fetched and replies carry the `[Claude Code]` attribution prefix. Honors a 60-minute bypass marker at `~/.claude/.respond-pr-active` that the skill sets on entry and removes on exit.
 - **`ask-review-permissions.sh`** — asks before `Edit`/`Write`/`MultiEdit` to `.claude/settings*.json`, nudging toward `/review-permissions` when the edit touches `permissions.allow`.
 
 ### Skills (slash commands)
 
 - **`/code-review`** — principal engineer code review checklist with ripple-effect triage and domain-specific audits (backend, frontend, security, infrastructure, data).
-- **`/respond-pr`** — fetch and address PR review comments, with `[Claude Code]` attribution on all replies.
-- **`/review-permissions`** — security audit of `permissions.allow` rules with a 21-item checklist.
 - **`/plan-review`** — review implementation plans before presenting, with domain-specific reviewer roles.
+- **`/review-permissions`** — security audit of `permissions.allow` rules with a 21-item checklist.
+- **`/respond-pr`** — fetch and address PR review comments, with `[Claude Code]` attribution on all replies.
+- **`/branch-creation`** — naming conventions (`<TICKET-ID>/<topic-slug>` for ticketed projects, `<topic-slug>` alone otherwise), anti-patterns to reject (tracker `<user>/` defaults), and branching from a fresh default-branch tip.
+- **`/git-feature-branch-sync`** — decision framework for keeping a feature branch current with the default branch: when to rebase-and-force-push vs merge-in, and how to force-push safely (`--force-with-lease` vs `--force-if-includes`).
+- **`/git-state-safety`** — safely inspecting other branches when the working tree is in a fragile state (mid-merge, mid-rebase, mid-cherry-pick), avoiding the silently-corrupted-index failure mode where a diagnostic `git checkout <ref> -- <path>` overwrites a partially-resolved merge, and recovering from bad merges that were already committed.
 - **`/test-conventions`**, **`/test-evaluation`** — test authoring and audit guidance.
+- **`/config-environments`** — designing configuration that differs across environments (dev, staging, production): env var naming, credential isolation, secrets provisioning, and the anti-patterns that reintroduce tight coupling.
+- **`/sql-query-conventions`** — read-path conventions for SQL and PostgREST/Supabase queries: pagination, limits, N+1 avoidance, batch-size ceilings, explicit column selection.
+- **`/ai-instruction-and-memory-files`** — how AI coding agents load instruction files (CLAUDE.md, AGENTS.md, Cursor rules, Lovable knowledge) and Claude Code auto-memory: precedence, duplication rules, length targets, import patterns.
 - **`/read-docx-comments`** — extract comments from `.docx` files with anchored text context.
 
 ### Other


### PR DESCRIPTION
## Summary

The README's hooks and skills lists had drifted behind the actual repo contents. This PR documents what's already there — no code or behavior changes.

### Added

**1 hook:**
- `deny-client-refs.sh` (wired in `settings.json` since #20 but never added to the README list)

**6 skills:**
- `/ai-instruction-and-memory-files`
- `/branch-creation`
- `/config-environments`
- `/git-feature-branch-sync`
- `/git-state-safety`
- `/sql-query-conventions`

### Reordering

The skills list is flat but the order was reshuffled so related entries cluster: review/quality → git workflow → testing → conventions → utility. No new subsections — just a better sequence within the existing bullet list.

### Drift-resistance note

The `deny-client-refs.sh` bullet intentionally says "OSS-prefix allowlist (CVE-, RFC-, GH-, and similar — see the script for the full list)" rather than enumerating all ~20 prefixes. The script's allowlist has already been extended a couple times; an exhaustive README list would go stale.

## Test plan

- [x] Each new description cross-checked against the corresponding SKILL.md frontmatter / hook header — all accurate.
- [ ] Render the README on GitHub and confirm formatting (bullet list, inline backticks, grouping read cleanly).