### PR TITLE
Drop dangling skill-frontmatter pointer from ai-instruction-and-memory-files

### DIFF
--- a/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
+++ b/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
@@ -14,9 +14,7 @@ description: >
   duplicated across files, or debating file length and context budget for
   AI coding agents.
   DO NOT TRIGGER when: editing README.md or other project docs that are
-  not loaded by AI coding agents, editing `.claude/skills/*/SKILL.md`
-  frontmatter (that's a skill-frontmatter concern — use the
-  skill-frontmatter reference instead), or writing code.
+  not loaded by AI coding agents, or writing code.
 user-invocable: false
 ---
 


### PR DESCRIPTION
## Summary

The `ai-instruction-and-memory-files` skill's DO NOT TRIGGER clause excluded `.claude/skills/*/SKILL.md` frontmatter editing and pointed at *"the skill-frontmatter reference"* — a sibling skill that never existed in this repo.

## Why drop rather than repoint

Investigating the marketplace of shipped Anthropic skills (cached from `claude-plugins-official`):

- `skill-creator` covers skill authoring comprehensively (~480 lines, full eval-based iteration loop).
- Zero occurrences of the `DO NOT TRIGGER` pattern across any Anthropic-authored skill — it isn't in their vocabulary.
- `skill-creator`'s mental model is that each skill's description stands alone; Claude sees all descriptions and picks the best one, so cross-skill pointers are unnecessary.

Given that, repointing the clause at `skill-creator` would propagate a convention (sibling cross-referencing in DO NOT TRIGGER) that isn't endorsed by the platform. Dropping the clause is cleaner: the TRIGGER list doesn't positively name `SKILL.md` anyway, and once `skill-creator` is installed locally its description is deliberately pushy about skill-editing contexts, so it'll win the selection contest in any edge case.

## Test plan

- [ ] Verify the diff removes only the `.claude/skills/*/SKILL.md` exclusion line and keeps the README.md / code-writing exclusions
- [ ] Skim the remaining DO NOT TRIGGER clause for coherence
- [ ] Confirm no other skill in the repo references "skill-frontmatter reference" (checked via grep — none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)