### PR TITLE
Skill updates from memory-cleanup sweep: anti-PR-refs, plan-on-branch, generated-files meta-rule

### DIFF
--- a/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
+++ b/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
@@ -96,6 +96,14 @@ and [Chroma's Context Rot research](https://research.trychroma.com/context-rot):
 - Attention decay hits the **middle** of long files — "lost in the middle." Burying critical rules past line ~150 reduces their effective load.
 - Compliance with prose rules tops out around **70%**. Structural tests and hooks hit 100%. When a rule can be encoded as either, prefer the mechanical enforcement.
 
+### Don't embed PR or ticket refs in always-loaded files
+
+Lines like `Precedent: PR #105` or `See TICKET-123 for context` belong
+in commit messages, PR descriptions, or plan files — not in CLAUDE.md
+or AGENTS.md. They rot the moment the next PR lands, and they cost
+per-session context budget without giving future sessions actionable
+signal. Future readers need the *rule* stated clearly.
+
 ## 4. When to duplicate vs. reference
 
 **Reference via `@AGENTS.md` import (Anthropic pattern):** default for

--- a/claude/.claude/skills/branch-creation/SKILL.md
+++ b/claude/.claude/skills/branch-creation/SKILL.md
@@ -74,3 +74,12 @@ scripts) usually handle this automatically — verify once, then trust.
 If the repo's default branch is `master`, `trunk`, `develop`, or
 anything other than `main`, substitute accordingly. Check with
 `git symbolic-ref refs/remotes/origin/HEAD`.
+
+## Plan files go on the implementation branch
+
+If this branch is for work that has an associated plan file
+(`.claude/plans/<name>.md`), commit the plan to this feature branch.
+Don't open a standalone plan-only branch that can merge independently
+of the implementation — plan and code ship as one PR. Reviewing the
+plan as a PR diff on the feature branch is fine; merging it
+separately from the implementation it plans isn't.

--- a/claude/.claude/skills/code-review/SKILL.md
+++ b/claude/.claude/skills/code-review/SKILL.md
@@ -29,6 +29,14 @@ Apply the **Base checklist** always. Apply each **Domain checklist** only when a
 
 Evaluate the code against each item. Only flag items where there is a concrete issue — do not flag items just to show you checked them.
 
+**Read every changed file fully, including generated ones.** Generated
+files (Supabase types, OpenAPI clients, GraphQL codegen, etc.) need
+the same scrutiny — tests passing doesn't mean the file is valid;
+runners like Vitest+esbuild strip types without validating, so npm
+warnings or build noise can leak into the file head undetected. Check
+the first few lines (`head -5`) of generated files even when tests
+are green.
+
 ### Correctness
 
 1. **API misuse** — Are libraries, frameworks, and language APIs used as designed? Flag any reliance on accidental or undocumented behavior (e.g., passing invalid arguments that happen to work, using internal methods, relying on side effects of unrelated calls).


### PR DESCRIPTION
## Summary

Three skill updates surfaced during a sweep of personal auto-memory against the newly-merged `ai-instruction-and-memory-files` guidance. Each rule was previously a standalone memory; each migrates to its natural skill home where it can fire reliably without consuming per-session context.

1. **`ai-instruction-and-memory-files` §3 — "Don't embed PR or ticket refs in always-loaded files"** — captures the anti-rot principle: lines like `Precedent: PR #105` belong in commit messages or PR descriptions, not in CLAUDE.md or AGENTS.md. They go stale immediately and add no signal future readers can act on.

2. **`branch-creation` — "Plan files go on the implementation branch"** — fires at branch-creation time, not commit time. Plan files commit to the feature branch carrying their implementation; don't open standalone plan-only branches that can merge independently of the implementation they plan.

3. **`code-review` — "Read every changed file fully, including generated ones"** — meta-rule added to the Base checklist intro (avoids cascading renumbering of the 1-40 item list). Generated files (Supabase types, OpenAPI clients, GraphQL codegen) need the same scrutiny — Vitest+esbuild strips types without validating, so npm warnings or build noise can leak into the file head undetected.

## Test plan

- [ ] Skim each modified SKILL.md for coherence
- [ ] Confirm the new `ai-instruction-and-memory-files` subsection sits cleanly between §3's compliance-asymmetry bullet and §4's duplication rules
- [ ] Confirm the new `branch-creation` section reads cleanly as the last section in the file
- [ ] Confirm the `code-review` meta-rule paragraph is positioned before "### Correctness" and doesn't disrupt the 1-40 numbering

🤖 Generated with [Claude Code](https://claude.com/claude-code)