### PR TITLE
Bootstrap Claude Code plugins from committed settings.json in install.sh

### DIFF
--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -43,5 +43,16 @@
   "statusLine": {
     "type": "command",
     "command": "bash ~/.claude/statusline-command.sh"
+  },
+  "extraKnownMarketplaces": {
+    "claude-plugins-official": {
+      "source": {
+        "source": "github",
+        "repo": "anthropics/claude-plugins-official"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "skill-creator@claude-plugins-official": true
   }
 }

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ set -e
 echo "=== claude-config Setup ==="
 
 missing=()
-for cmd in stow git gh jq sha256sum; do
+for cmd in stow git gh jq sha256sum claude; do
   command -v "$cmd" >/dev/null 2>&1 || missing+=("$cmd")
 done
 if [ ${#missing[@]} -gt 0 ]; then
@@ -16,6 +16,33 @@ fi
 REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$REPO_DIR"
 stow -v --adopt -t "$HOME" claude
+
+SETTINGS_FILE="$HOME/.claude/settings.json"
+if [ -f "$SETTINGS_FILE" ]; then
+  echo ""
+  echo "=== Registering marketplaces from extraKnownMarketplaces ==="
+  existing_marketplaces="$(claude plugin marketplace list --json 2>/dev/null | jq -r '.[].name')"
+  while IFS=$'\t' read -r name repo; do
+    if echo "$existing_marketplaces" | grep -qFx "$name"; then
+      echo "  ✓ $name (already registered)"
+    else
+      echo "  → adding $name ($repo)"
+      claude plugin marketplace add "$repo" --scope user
+    fi
+  done < <(jq -r '.extraKnownMarketplaces // {} | to_entries[] | "\(.key)\t\(.value.source.repo)"' "$SETTINGS_FILE")
+
+  echo ""
+  echo "=== Installing plugins from enabledPlugins ==="
+  existing_plugins="$(claude plugin list --json 2>/dev/null | jq -r '.[] | select(.scope == "user") | .id')"
+  while read -r plugin; do
+    if echo "$existing_plugins" | grep -qFx "$plugin"; then
+      echo "  ✓ $plugin (already installed)"
+    else
+      echo "  → installing $plugin"
+      claude plugin install "$plugin" -s user
+    fi
+  done < <(jq -r '.enabledPlugins // {} | to_entries[] | select(.value == true) | .key' "$SETTINGS_FILE")
+fi
 
 echo ""
 echo "Done. Optional: run the hook test suite:"


### PR DESCRIPTION
## Summary

Pin `skill-creator@claude-plugins-official` as a repo-level plugin and make `install.sh` responsible for installing it so that running the bootstrap ritual (which users already do on clone and after pulls) picks up plugin entries declared in committed settings.

### Changes

1. **`claude/.claude/settings.json`** — declare the marketplace and the enablement:
   - `extraKnownMarketplaces.claude-plugins-official` pointing at `anthropics/claude-plugins-official` (the GitHub marketplace source). A fresh machine doesn't inherit the per-machine `known_marketplaces.json`, so declaring it here makes the pointer travel with the repo.
   - `enabledPlugins["skill-creator@claude-plugins-official"] = true` so Claude Code treats the plugin as enabled once installed.

2. **`install.sh`** — add a plugin bootstrap block after `stow`:
   - Loop `extraKnownMarketplaces`: call `claude plugin marketplace add` for each entry not already registered (pre-checked via `claude plugin marketplace list --json`).
   - Loop `enabledPlugins`: call `claude plugin install` for each entry not already installed at user scope (pre-checked via `claude plugin list --json` + `select(.scope == "user")`).
   - Added `claude` to the dependency check so we fail fast with a clear message if the CLI is missing.

### Why install.sh and not just the native trust-prompt flow

Claude Code has a native flow that prompts users to install plugins from `enabledPlugins` when they trust a folder. But that flow fires on **trust events**, not on every settings.json re-read. A user who already has this repo trusted would NOT get prompted when a new plugin is added to `enabledPlugins` after `git pull`. The install.sh loop is what makes the pattern work for updates, not just first-clone.

### Idempotency

Both loops pre-check existing state before acting, so re-running `install.sh` on a machine that's already been set up is safe and produces clean output:

```
=== Registering marketplaces from extraKnownMarketplaces ===
  ✓ claude-plugins-official (already registered)

=== Installing plugins from enabledPlugins ===
  ✓ skill-creator@claude-plugins-official (already installed)
```

## Test plan

- [ ] Run `./install.sh` on current machine: verify both loops print the `✓ already` lines (no re-install noise)
- [ ] Verify `skill-creator@claude-plugins-official` actually installs if not already present (the user can test on a throwaway `~/.claude` or via `claude plugin uninstall skill-creator@claude-plugins-official -s user` first, then re-run)
- [ ] Verify `claude plugin list --json | jq '.[] | select(.id == "skill-creator@claude-plugins-official") | .enabled'` returns `true` after install (enabledPlugins entry takes effect)
- [ ] Confirm adding a new plugin entry to `enabledPlugins` and re-running `install.sh` installs it (the update case this PR targets)
- [ ] Sanity-check: on a fresh machine without `claude-plugins-official` registered, the marketplace loop adds it before the plugin loop runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)