### PR TITLE
Pin claude-md-management + claude-code-setup plugins

### DIFF
--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -53,6 +53,8 @@
     }
   },
   "enabledPlugins": {
-    "skill-creator@claude-plugins-official": true
+    "skill-creator@claude-plugins-official": true,
+    "claude-md-management@claude-plugins-official": true,
+    "claude-code-setup@claude-plugins-official": true
   }
 }


### PR DESCRIPTION
## Summary

Add two complementary marketplace plugins to `enabledPlugins`, building on the bootstrap mechanism from #28.

- **`claude-md-management@claude-plugins-official`** — provides the `claude-md-improver` skill, an audit-and-update tool that scans CLAUDE.md files, scores them against quality rubrics, and applies targeted fixes. Complementary to the existing reference skill `ai-instruction-and-memory-files` (which covers Lovable/Cursor/Copilot + MEMORY.md architecture).

- **`claude-code-setup@claude-plugins-official`** — provides `claude-automation-recommender`, which analyzes a codebase and recommends Claude Code automations (hooks, subagents, skills, plugins, MCP servers). No overlap with any existing skill.

## Why these two and not more

The marketplace also ships `plugin-dev`, which contains the useful `hook-development` skill. Held back for now because `plugin-dev` bundles 6 other skills as passengers, and one of them (`skill-development`) has a near-identical TRIGGER to the already-pinned `skill-creator`. That would create ambiguous routing on "create a skill" prompts. Can pin `plugin-dev` in a follow-up when there's active hook/plugin-authoring work justifying the bundle.

## Overlap note (claude-md-improver vs ai-instruction-and-memory-files)

Partial TRIGGER overlap, but they do different jobs:

| Prompt | Wins |
|---|---|
| "audit/improve my CLAUDE.md" | `claude-md-improver` (action) |
| "should this go in CLAUDE.md or auto-memory?" | `ai-instruction-and-memory-files` (reference, + MEMORY.md coverage) |
| "how does AGENTS.md precedence work?" | `ai-instruction-and-memory-files` (not CLAUDE.md-specific) |
| "check my .lovable/*.md files" | `ai-instruction-and-memory-files` (Lovable/Cursor coverage) |

Action skill vs. reference skill with partial phrasing overlap — Claude routes to the more specific match.

## Test plan

- [ ] Re-run `install.sh`: confirm the two new plugins are picked up by the bootstrap loop and installed at user scope
- [ ] Confirm `claude plugin list --json` shows both new plugins as `enabled: true`
- [ ] Start a fresh conversation and verify `claude-md-improver` + `claude-automation-recommender` appear in the available-skills list
- [ ] Sanity-check that `skill-creator` still triggers on "create a skill" prompts (no routing regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)