### PR TITLE
Note worktree enforcement in root CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,13 @@ This repository is **public** — every commit, skill body, commit message,
 and PR description ships to anyone with the URL. The guardrails below
 govern any contribution (human or agent).
 
+## Working in this repo
+
+Worktree enforcement is active. `.claude/worktree-required` is committed, so
+non-read-only git operations must run inside a linked worktree
+(`git worktree add .claude/worktrees/<branch> -b <branch>`) or an agent with
+`isolation: worktree`. See README "Worktree enforcement" for why.
+
 ## Redact client-identifying content
 
 Never commit anything that ties a skill, rule, or example back to a


### PR DESCRIPTION
## Summary

- Adds a four-line "Working in this repo" section to root `CLAUDE.md` noting that this repo opts into worktree enforcement, so non-read-only git operations must run from a linked worktree or an `isolation: worktree` agent.
- Motivation: fresh Claude Code sessions currently discover the constraint by hitting `require-worktree-for-git-writes.sh` mid-task. `CLAUDE.md` is loaded at session start; README has the full rationale.

## Test plan

- [x] Read the new section
- [x] Verified factual claims (sentinel is tracked; hook allows `git worktree add` on main tree; README section "Worktree enforcement" exists at line 52)