### PR TITLE
Fix worktree-enforcement hook word-boundary false positive

### DIFF
--- a/claude/.claude/hooks/require-worktree-for-git-writes.sh
+++ b/claude/.claude/hooks/require-worktree-for-git-writes.sh
@@ -38,10 +38,12 @@ if [ "$JQ_EXIT" -ne 0 ]; then
   exit 0
 fi
 
-# Fast-path: commands that don't mention git are not our concern. Use bash
-# pattern matching instead of grep to avoid locale-dependent behavior on
-# commands containing non-UTF-8 bytes.
-if [[ "$COMMAND" != *git* ]]; then
+# Fast-path: commands that don't mention `git` as a word are not our
+# concern. A plain `*git*` substring check false-positives on `.github`,
+# `.gitignore`, `github.com`, `longitude`, and similar, blocking harmless
+# reads like `ls .github/workflows/`. Require a non-alnum boundary (or
+# string edge) on both sides so `git` fires only as a command word.
+if ! [[ "$COMMAND" =~ (^|[^[:alnum:]])git([^[:alnum:]]|$) ]]; then
   exit 0
 fi
 
@@ -102,6 +104,33 @@ readonly ALLOWED_SUBCMDS=(
 )
 ALLOWED_RE=$(IFS='|'; echo "${ALLOWED_SUBCMDS[*]}")
 
+# Decide whether a fragment actually invokes `git`, not just mentions it
+# as a substring of a path or URL. Scans whitespace-separated words and
+# returns success iff any word equals `git` or ends in `/git` (absolute
+# path form, e.g. `/usr/bin/git`). Env-var prefixes (`FOO=1 git ...`),
+# `env`/`sudo` prefixes, and `git` as the nth word are all handled by
+# walking every word rather than just the first.
+#
+# Rejects: `ls .github/workflows/`, `cat .gitignore`, `grep github.com`,
+# `./git-foo` (not `git` and not `*/git`). Accepts: `git log`, `sudo git
+# commit`, `FOO=1 git push`, `/usr/bin/git status`.
+fragment_invokes_git() {
+  local fragment="$1"
+  local saved_opts=$-
+  set -f
+  local found=false word
+  for word in $fragment; do
+    if [[ "$word" == "git" || "$word" == */git ]]; then
+      found=true
+      break
+    fi
+  done
+  if [[ "$saved_opts" != *f* ]]; then
+    set +f
+  fi
+  $found
+}
+
 # Extract the git subcommand from a fragment like "git -C path commit -m foo".
 # Strips global flags that consume the next word, skips other flags, returns
 # the first bare word — the subcommand. Empty output means we couldn't find
@@ -143,7 +172,7 @@ FRAGMENTS=$(printf '%s' "$COMMAND" | sed -E 's/;/\n/g; s/&&/\n/g; s/\|\|/\n/g; s
 
 while IFS= read -r fragment; do
   [ -z "$fragment" ] && continue
-  if [[ "$fragment" != *git* ]]; then
+  if ! fragment_invokes_git "$fragment"; then
     continue
   fi
 

--- a/claude/.claude/hooks/tests/test_hooks.py
+++ b/claude/.claude/hooks/tests/test_hooks.py
@@ -914,3 +914,74 @@ class TestRequireWorktreeForGitWrites:
     def test_non_bash_tool_allowed(self, opted_in_repo):
         """Edit tool inputs have no .tool_input.command — hook no-ops."""
         assert run_hook(WORKTREE_HOOK, edit_input("/tmp/foo.txt"), cwd=opted_in_repo) == "allow"
+
+    # -- Word-boundary false-positive regression ----------------------------
+    # Regression: the hook originally used `*git*` substring checks that
+    # matched `.github`, `.gitignore`, `github.com`, and similar, blocking
+    # harmless `ls .github/workflows/` reads. The fix requires `git` to
+    # appear as a command word (bounded by non-alnum or string edges),
+    # and each fragment must have a word equal to `git` or ending in
+    # `/git` to be treated as a git invocation.
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "ls .github/workflows/",
+            "cat .gitignore",
+            "grep -r github.com /src",
+            "find . -name '*.git'",
+            "./git-foo",
+            "gitk master",
+        ],
+        ids=[
+            "ls-dotgithub",
+            "cat-dotgitignore",
+            "grep-githubcom",
+            "find-dotgit",
+            "git-foo-extension",
+            "gitk-alnum-trailing",
+        ],
+    )
+    def test_git_substring_in_non_git_command_allowed(self, opted_in_repo, command):
+        """Commands that mention `git` only as a path/URL/prefix substring
+        must not be treated as git invocations. `gitk` pins the regex's
+        both-sides non-alnum requirement — a change that only kept the
+        leading boundary would regress this case."""
+        assert run_hook(WORKTREE_HOOK, bash_input(command), cwd=opted_in_repo) == "allow"
+
+    def test_chained_dotgithub_read_and_git_log_allowed(self, opted_in_repo):
+        """Read-only fragment touching `.github` followed by a read-only
+        git command: both fragments must resolve correctly."""
+        assert (
+            run_hook(
+                WORKTREE_HOOK,
+                bash_input("ls .github/workflows/ && git log --oneline"),
+                cwd=opted_in_repo,
+            )
+            == "allow"
+        )
+
+    def test_chained_dotgitignore_read_and_git_commit_denied(self, opted_in_repo):
+        """Fragment mentioning `.gitignore` must not mask a real `git
+        commit` in a later fragment."""
+        assert (
+            run_hook(
+                WORKTREE_HOOK,
+                bash_input("cat .gitignore && git commit -m x"),
+                cwd=opted_in_repo,
+            )
+            == "deny"
+        )
+
+    def test_git_log_with_dotgithub_path_arg_allowed(self, opted_in_repo):
+        """Real read-only git command whose arguments reference a `.github`
+        path must still parse as its subcommand — `git log -- .github/...`
+        is `log`, not denied."""
+        assert (
+            run_hook(
+                WORKTREE_HOOK,
+                bash_input("git log -- .github/workflows/hooks.yml"),
+                cwd=opted_in_repo,
+            )
+            == "allow"
+        )


### PR DESCRIPTION
## Summary

`require-worktree-for-git-writes.sh` used `*git*` substring checks that matched `.github`, `.gitignore`, `github.com`, and similar, then fed fragments like `ls .github/workflows/` into `extract_git_subcmd`, which returned `hub/workflows/` as the alleged subcommand and denied the read. Harmless reads of this repo's own `.github/` and `.gitignore` were being blocked.

- Top-level fast-path replaced with a word-boundary regex: `(^|[^[:alnum:]])git([^[:alnum:]]|$)`. Rejects `.github`, `.gitignore`, `longitude`, `gitk`; accepts `git`, `/usr/bin/git`, `FOO=1 git`.
- New `fragment_invokes_git` helper scans each fragment's words and only returns success when some word is exactly `git` or ends in `/git`. Replaces the per-fragment `*git*` check. `extract_git_subcmd` is unchanged and runs only after the helper validates a real git invocation.

Pre-existing edge case left alone: `A=foo.git git log` still extracts `git` as the subcommand and denies instead of resolving to `log`. Not covered by any existing test and outside the scope of this fix.

## Test plan

- [x] 9 new regression tests under `TestRequireWorktreeForGitWrites`:
  - Parametrized: `ls .github/workflows/`, `cat .gitignore`, `grep -r github.com /src`, `find . -name '*.git'`, `./git-foo`, `gitk master` → allow
  - `ls .github/workflows/ && git log --oneline` → allow (chained read-only git after `.github` fragment)
  - `cat .gitignore && git commit -m x` → deny (real write still caught after `.gitignore` fragment)
  - `git log -- .github/workflows/hooks.yml` → allow (positive: real git command whose arg contains `.github`)
- [x] Full suite: 125 passed (117 pre-existing + 8 new — the parametrized case counts once in the name but fires 6 subtests, making the total 125)
- [x] Reviewed by bash/shell-safety specialist and SDET specialist under `/code-review`; SDET's `gitk`-style boundary test suggestion incorporated