### PR TITLE
CLAUDE.md: note stow linking so agents stop suggesting install.sh re-runs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,9 @@ non-read-only git operations must run inside a linked worktree
 (`git worktree add .claude/worktrees/<branch> -b <branch>`) or an agent with
 `isolation: worktree`. See README "Worktree enforcement" for why.
 
+`claude/` is stowed into `$HOME`. Changes under `claude/.claude/**` go live on
+`git pull` — no re-install needed.
+
 ## Redact client-identifying content
 
 Never commit anything that ties a skill, rule, or example back to a


### PR DESCRIPTION
## Summary

Two-line addition to the "Working in this repo" section of root `CLAUDE.md`:

> `claude/` is stowed into `$HOME`. Changes under `claude/.claude/**` go live on `git pull` — no re-install needed.

## Why

This is the third Claude session in a row to independently conclude that landing a new skill requires re-running `install.sh`. It doesn't — stow symlinks `claude/.claude/` into `$HOME/.claude/`, so a `git pull` after merge picks up new skills/hooks/settings automatically. `install.sh` only needs to run at bootstrap time (new machine) or when `enabledPlugins` changes.

The fact is in `README.md:19` but README isn't auto-loaded into the agent context. Root `CLAUDE.md` is, so the note belongs there to actually change agent behavior.

## Test plan

- [ ] Pull after merge; verify the new line is visible in `CLAUDE.md`.
- [ ] Next time a PR adds a skill or hook, check that the test plan doesn't call for re-running `install.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)