### PR TITLE
Normalize settings.json field order to match CLI auto-format

### DIFF
--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -6,14 +6,14 @@
         "hooks": [
           {
             "type": "command",
-            "if": "Bash(git commit *)",
             "command": "~/.claude/hooks/require-code-review.sh",
+            "if": "Bash(git commit *)",
             "statusMessage": "Checking code review..."
           },
           {
             "type": "command",
-            "if": "Bash(git commit *)",
             "command": "~/.claude/hooks/deny-client-refs.sh",
+            "if": "Bash(git commit *)",
             "statusMessage": "Scanning for client-identifying refs..."
           },
           {
@@ -44,6 +44,11 @@
     "type": "command",
     "command": "bash ~/.claude/statusline-command.sh"
   },
+  "enabledPlugins": {
+    "skill-creator@claude-plugins-official": true,
+    "claude-md-management@claude-plugins-official": true,
+    "claude-code-setup@claude-plugins-official": true
+  },
   "extraKnownMarketplaces": {
     "claude-plugins-official": {
       "source": {
@@ -51,10 +56,5 @@
         "repo": "anthropics/claude-plugins-official"
       }
     }
-  },
-  "enabledPlugins": {
-    "skill-creator@claude-plugins-official": true,
-    "claude-md-management@claude-plugins-official": true,
-    "claude-code-setup@claude-plugins-official": true
   }
 }


### PR DESCRIPTION
## Summary

Pure reordering of `claude/.claude/settings.json`, no semantic change:

- Inside hook entries: `"command"` before `"if"` (was `"if"` first).
- At top level: `"enabledPlugins"` before `"extraKnownMarketplaces"` (was after).

## Why

The Claude CLI normalizes to this shape whenever it touches the file. That means every session starts with the same dirty-tree diff that either gets ignored (and reopens next session) or accidentally bundled into an unrelated PR. Committing the normalized form stops the churn.

Confirmed `jq .` parses the result — JSON is still valid, and field order has no semantic effect on settings evaluation.

## Test plan

- [ ] Merge, pull, and confirm `git status` stays clean on main after `claude` does normal housekeeping touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)