### PR TITLE
Add user-local private-projects blocklist to deny-private-project-refs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,10 @@ __pycache__/
 .claude/plans/
 .claude/settings.local.json
 .claude/worktrees/
+
+# Belt-and-suspenders: the user-local private-projects blocklist read by
+# deny-private-project-refs.sh lives at ~/.claude/private-projects.md
+# directly, NOT inside the stowed claude/ subdir. If a user accidentally
+# creates the file in this tree, this prevents it from ever landing in
+# git history. See claude/.claude/hooks/deny-private-project-refs.sh.
+claude/.claude/private-projects.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,11 +92,18 @@ came from the agent, not a human, is not a defense.
 The `deny-private-project-refs.sh` PreToolUse hook (wired in
 `claude/.claude/settings.json`) blocks `git commit`, `gh pr create`,
 and `gh pr edit` when the staged diff, commit message, or PR
-title/body/body-source-file contains a tracker-ID token outside the
-OSS allowlist. Tests live in `claude/.claude/hooks/tests/test_hooks.py`.
+title/body/body-source-file contains either:
 
-The hook catches the mechanical category (tracker IDs). Other
-categories above — private-project names, internal tool names,
-structural fingerprints — still require review discipline. Extend
-the hook's pattern list if a category becomes repeatable enough to
-automate.
+1. A tracker-ID token (`[A-Z]{2,}-\d+`) outside the OSS allowlist, or
+2. A literal substring matching an entry in the user's opt-in
+   `~/.claude/private-projects.md` blocklist (case-insensitive).
+
+The blocklist file is user-local and never committed. See README
+"Private-project redaction" for opt-in instructions. Tests live in
+`claude/.claude/hooks/tests/test_hooks.py`.
+
+The hook catches two mechanical categories (tracker IDs always; named
+projects when the user opts in). Other categories above — internal
+tool names, structural fingerprints — still require review
+discipline. Extend the hook's pattern list if a category becomes
+repeatable enough to automate.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,8 +95,8 @@ and `gh pr edit` when the staged diff, commit message, or PR
 title/body/body-source-file contains either:
 
 1. A tracker-ID token (`[A-Z]{2,}-\d+`) outside the OSS allowlist, or
-2. A literal substring matching an entry in the user's opt-in
-   `~/.claude/private-projects.md` blocklist (case-insensitive).
+2. A case-insensitive whole-word match against an entry in the
+   user's opt-in `~/.claude/private-projects.md` blocklist.
 
 The blocklist file is user-local and never committed. See README
 "Private-project redaction" for opt-in instructions. Tests live in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,15 @@ non-read-only git operations must run inside a linked worktree
 `claude/` is stowed into `$HOME`. Changes under `claude/.claude/**` go live on
 `git pull` — no re-install needed.
 
+**Footgun: never recommend `>>` writes through stow-symlinked files.**
+Files under `~/.claude/` (like `~/.claude/CLAUDE.md`) are symlinks to
+tracked files in this repo. Telling a user to
+`echo "..." >> ~/.claude/CLAUDE.md` writes through the symlink and
+silently stages changes to the public repo. To add Claude-context for
+a feature, edit the committed file directly via PR. For per-user
+private context, use a non-stowed location like
+`~/.claude/private-projects.md` (opt-in, not part of the stow tree).
+
 ## Redact private-project-identifying content
 
 Never commit anything that ties a skill, rule, or example back to a

--- a/README.md
+++ b/README.md
@@ -103,13 +103,21 @@ Two scans run, in order:
 ### Opt-in: enable the blocklist
 
 ```bash
-touch ~/.claude/private-projects.md
+# Create the file with a header explaining its purpose (the hook
+# ignores `#` lines, so headers don't affect matching):
+cat > ~/.claude/private-projects.md <<'EOF'
+# Project names listed below are blocked from appearing in any commit
+# message, PR description, or staged content in this repo. Read by
+# ~/.claude/hooks/deny-private-project-refs.sh as a literal blocklist.
+
+EOF
+
+# Append your project names, one per line:
 echo "Acme Corp" >> ~/.claude/private-projects.md
 echo "Project Bluebird" >> ~/.claude/private-projects.md
-
-# Same source of truth for Claude's context — so it self-scrubs while drafting:
-echo "@private-projects.md" >> ~/.claude/CLAUDE.md
 ```
+
+The hook is the load-bearing defense — when it blocks, you (or Claude) sees the deny message and revises before retrying. There's no need to also import the file into `~/.claude/CLAUDE.md`: that would write through the stow symlink to the tracked repo file, which is a footgun without a real defensive payoff.
 
 ### File format
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This symlinks `claude/.claude/` into `$HOME/.claude/`.
 ### Hooks (PreToolUse gates)
 
 - **`require-code-review.sh`** — blocks `git commit` (including chained forms like `git add . && git commit`) until `/code-review` has run on the current staged state. Verified via sha256 marker in `~/.claude/review-markers/<repo-hash>`, which auto-invalidates the moment the staging area changes.
-- **`deny-private-project-refs.sh`** — blocks `git commit`, `gh pr create`, and `gh pr edit` when the staged diff, commit message, or PR title/body/body-source-file contains tracker-ID tokens (`[A-Z]{2,}-\d+`) outside an OSS-prefix allowlist (`CVE-`, `RFC-`, `GH-`, and similar — see the script for the full list). Enforces the tracker-ID category of the repo-root `CLAUDE.md` redaction rule; other categories (private-project names, internal tool names, structural fingerprints) still require review discipline.
+- **`deny-private-project-refs.sh`** — blocks `git commit`, `gh pr create`, and `gh pr edit` when the staged diff, commit message, or PR title/body/body-source-file contains either (a) tracker-ID tokens (`[A-Z]{2,}-\d+`) outside an OSS-prefix allowlist (`CVE-`, `RFC-`, `GH-`, and similar — see the script for the full list), or (b) a literal substring match against entries in the user's opt-in `~/.claude/private-projects.md` blocklist. Enforces the mechanical categories of the repo-root `CLAUDE.md` redaction rule; structural fingerprints still require review discipline. See [Private-project redaction](#private-project-redaction) below.
 - **`require-respond-pr.sh`** — blocks PR comment reads and posts (`gh api .../pulls|issues/N/{comments,reviews}`, `gh pr comment`, `gh pr review`) and redirects to `/respond-pr`, so all three comment types get fetched and replies carry the `[Claude Code]` attribution prefix. Honors a 60-minute bypass marker at `~/.claude/.respond-pr-active` that the skill sets on entry and removes on exit.
 - **`ask-review-permissions.sh`** — asks before `Edit`/`Write`/`MultiEdit` to `.claude/settings*.json`, nudging toward `/review-permissions` when the edit touches `permissions.allow`.
 - **`require-worktree-for-git-writes.sh`** — opt-in per repo. When active, denies non-read-only git operations unless the session runs in a linked git worktree. Prevents concurrent Claude Code sessions from racing on the same working tree. See [Worktree enforcement](#worktree-enforcement) below for opt-in instructions.
@@ -90,6 +90,68 @@ cd .claude/worktrees/my-feature
 Agents spawned with `isolation: worktree` create their own worktrees under `.claude/worktrees/` automatically.
 
 To opt out, delete `.claude/worktree-required`.
+
+## Private-project redaction
+
+This repo is public, so any project codename, organization name, or tracker-ID that lands in a commit or PR description ships to the world. The repo-root [`CLAUDE.md`](./CLAUDE.md) "Redact private-project-identifying content" rule defines what to keep out; `deny-private-project-refs.sh` is the mechanical enforcement.
+
+Two scans run, in order:
+
+1. **Tracker-ID scan (always on, no setup).** Matches `[A-Z]{2,}-\d+` tokens not on the OSS allowlist.
+2. **Private-projects blocklist (opt-in).** Reads `~/.claude/private-projects.md` at hook runtime and blocks commits/PRs whose content contains any non-comment, non-blank line from the file as a case-insensitive literal substring.
+
+### Opt-in: enable the blocklist
+
+```bash
+touch ~/.claude/private-projects.md
+echo "Acme Corp" >> ~/.claude/private-projects.md
+echo "Project Bluebird" >> ~/.claude/private-projects.md
+
+# Same source of truth for Claude's context — so it self-scrubs while drafting:
+echo "@private-projects.md" >> ~/.claude/CLAUDE.md
+```
+
+### File format
+
+- One project name per line.
+- Lines starting with `#` are comments; ignored.
+- Blank lines ignored.
+- Leading and trailing whitespace stripped.
+- Names can contain spaces.
+- Match is case-insensitive literal substring. No regex. No globs.
+
+### What to put in the file (and what NOT to)
+
+The two scans cover different shapes — understanding the split keeps you from adding entries that backfire:
+
+- **Tracker-ID scan (always on):** automatically catches `[A-Z]{2,}-\d+` patterns. So any `ACME-<n>` tracker reference (where `<n>` is digits) is *already* blocked — you don't need a blocklist entry for them.
+- **Blocklist scan (this file):** catches case-insensitive literal substrings of the entries you list.
+
+**Worked example.** Suppose your private project is `AcmeCorporation` with tracker prefix `ACME`:
+
+✅ **Add `AcmeCorporation`** — catches the bare project name in commits like "Refactor AcmeCorporation auth flow", which the tracker-ID regex doesn't cover. Case-insensitive match handles `acmecorporation`, `ACMECORPORATION`, etc., so you don't need variants.
+
+❌ **Don't add `ACME`** — the tracker-ID regex already catches `ACME-<digits>`. Adding bare `ACME` to the blocklist would false-positive on the substring `acme` inside English words (`acme of clarity`, `Acme Anvil` references in documentation, etc.). For shorter prefixes like `DAY` the false-positive surface is much worse (`today`, `holiday`, `daylight`).
+
+**Rule of thumb:**
+
+- **Tracker prefixes** (`[A-Z]{2,}` + dash + digits): trust the tracker-ID regex; don't blocklist the bare prefix.
+- **Distinctive project names** (full names, codenames): blocklist them.
+- **Generic-word codenames** (`Pulse`, `Atlas`, `Echo`): blocklist with caution — same false-positive risk as bare prefixes. If the name is a common English word, reviewer discipline may be a better tier than mechanical match.
+
+**Multi-word forms** reduce false-positive risk. If your project is referred to as "AC platform" internally and `AC` alone would false-positive everywhere, blocklist `AC platform` instead — the multi-word phrase is much more selective.
+
+### Why user-local, not committed
+
+A committed list of private-project names in this public repo would itself be the leak — it would hardcode in cleartext the exact strings the rule prevents from shipping. The file lives at `~/.claude/private-projects.md` directly, **not** inside `claude-config/claude/.claude/` (which `stow` symlinks into `$HOME/`). Creating it in the wrong place risks accidental commit; the repo-root `.gitignore` has a belt-and-suspenders entry for `claude/.claude/private-projects.md` as a safety net.
+
+### Privacy of the deny message
+
+When the blocklist scan blocks a commit or PR, the deny message **does not name which entry matched**. Echoing a name the user explicitly flagged as sensitive would re-expose it in terminal output, screenshots, CI logs, and Claude's own conversation context — exactly the surfaces the gate exists to protect. The tracker-ID scan does name matched tokens because they're mechanical patterns, not user-flagged secrets.
+
+### For fork contributors
+
+Forks of `claude-config` inherit the same hook (the scoping check passes for any `claude-config` substring in the origin URL). A fork user can drop their own `~/.claude/private-projects.md` and contribute back without their project names ever ending up in a PR they open against the upstream.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -98,17 +98,19 @@ This repo is public, so any project codename, organization name, or tracker-ID t
 Two scans run, in order:
 
 1. **Tracker-ID scan (always on, no setup).** Matches `[A-Z]{2,}-\d+` tokens not on the OSS allowlist.
-2. **Private-projects blocklist (opt-in).** Reads `~/.claude/private-projects.md` at hook runtime and blocks commits/PRs whose content contains any non-comment, non-blank line from the file as a case-insensitive literal substring.
+2. **Private-projects blocklist (opt-in).** Reads `~/.claude/private-projects.md` at hook runtime and blocks commits/PRs whose content contains any non-comment, non-blank line from the file as a case-insensitive whole-word match.
 
 ### Opt-in: enable the blocklist
 
 ```bash
-# Create the file with a header explaining its purpose (the hook
-# ignores `#` lines, so headers don't affect matching):
+# Create the file with a header pointing at this section for usage
+# rules (the hook ignores `#` lines, so the header doesn't affect
+# matching):
 cat > ~/.claude/private-projects.md <<'EOF'
-# Project names listed below are blocked from appearing in any commit
-# message, PR description, or staged content in this repo. Read by
-# ~/.claude/hooks/deny-private-project-refs.sh as a literal blocklist.
+# Project names blocked from commits / PR titles / PR bodies in
+# claude-config (and forks). Match semantics + what to put in this
+# file: see README.md "Private-project redaction" in the
+# claude-config repo.
 
 EOF
 
@@ -117,8 +119,6 @@ echo "Acme Corp" >> ~/.claude/private-projects.md
 echo "Project Bluebird" >> ~/.claude/private-projects.md
 ```
 
-The hook is the load-bearing defense — when it blocks, you (or Claude) sees the deny message and revises before retrying. There's no need to also import the file into `~/.claude/CLAUDE.md`: that would write through the stow symlink to the tracked repo file, which is a footgun without a real defensive payoff.
-
 ### File format
 
 - One project name per line.
@@ -126,28 +126,25 @@ The hook is the load-bearing defense — when it blocks, you (or Claude) sees th
 - Blank lines ignored.
 - Leading and trailing whitespace stripped.
 - Names can contain spaces.
-- Match is case-insensitive literal substring. No regex. No globs.
+- Match is case-insensitive whole-word literal. No regex. No globs.
 
 ### What to put in the file (and what NOT to)
 
-The two scans cover different shapes — understanding the split keeps you from adding entries that backfire:
-
-- **Tracker-ID scan (always on):** automatically catches `[A-Z]{2,}-\d+` patterns. So any `ACME-<n>` tracker reference (where `<n>` is digits) is *already* blocked — you don't need a blocklist entry for them.
-- **Blocklist scan (this file):** catches case-insensitive literal substrings of the entries you list.
+The match is **case-insensitive whole-word**, which is narrower than substring match — `AcmeCorp` matches `AcmeCorp`, `acmecorp`, `ACMECORP` (any casing as a standalone word), but NOT `AcmeCorpService` (concatenated — `S` is a word character so the boundary fails), and NOT `acme` inside `acmebrand` (substring within a word).
 
 **Worked example.** Suppose your private project is `AcmeCorporation` with tracker prefix `ACME`:
 
-✅ **Add `AcmeCorporation`** — catches the bare project name in commits like "Refactor AcmeCorporation auth flow", which the tracker-ID regex doesn't cover. Case-insensitive match handles `acmecorporation`, `ACMECORPORATION`, etc., so you don't need variants.
+✅ **Add `AcmeCorporation`** — catches the project name as a standalone word in commits, PR bodies, or added diff lines. Case variants (`acmecorporation`, `ACMECORPORATION`) match too — you don't need separate entries.
 
-❌ **Don't add `ACME`** — the tracker-ID regex already catches `ACME-<digits>`. Adding bare `ACME` to the blocklist would false-positive on the substring `acme` inside English words (`acme of clarity`, `Acme Anvil` references in documentation, etc.). For shorter prefixes like `DAY` the false-positive surface is much worse (`today`, `holiday`, `daylight`).
+❌ **Don't add `ACME` alone** — the tracker-ID regex already catches `ACME-<digits>` patterns automatically; bare `ACME` adds nothing the regex doesn't already cover, while introducing a small false-positive surface for legitimate standalone uses of the word.
+
+❌ **Avoid very short or common-word codenames as bare entries.** Whole-word matching shrinks the false-positive surface compared to substring match, but a 3-letter codename like `ART` would still match commits mentioning the word `art` or `ART` standalone (`ART department review`, `the art of war`). If your codename is a common standalone word, use a multi-word form (`ART pipeline` instead of `ART` alone) — the longer phrase is more selective — or rely on reviewer discipline instead of mechanical match.
 
 **Rule of thumb:**
 
 - **Tracker prefixes** (`[A-Z]{2,}` + dash + digits): trust the tracker-ID regex; don't blocklist the bare prefix.
-- **Distinctive project names** (full names, codenames): blocklist them.
-- **Generic-word codenames** (`Pulse`, `Atlas`, `Echo`): blocklist with caution — same false-positive risk as bare prefixes. If the name is a common English word, reviewer discipline may be a better tier than mechanical match.
-
-**Multi-word forms** reduce false-positive risk. If your project is referred to as "AC platform" internally and `AC` alone would false-positive everywhere, blocklist `AC platform` instead — the multi-word phrase is much more selective.
+- **Distinctive project names** (full names, codenames ≥ 5 chars and not common English words): blocklist them. Whole-word + case-insensitive handles casing variants automatically.
+- **Concatenated identifiers** (`AcmeCorpService`, `acmecorp_client`, `acme-corp-api`): NOT caught by whole-word match against `AcmeCorp`. If a project name commonly appears concatenated AND the concatenated form is sensitive to leak, add the concatenated form as its own entry.
 
 ### Why user-local, not committed
 

--- a/claude/.claude/hooks/deny-private-project-refs.sh
+++ b/claude/.claude/hooks/deny-private-project-refs.sh
@@ -57,9 +57,18 @@
 # A *user-local* list at ~/.claude/private-projects.md is a different
 # artifact: outside any repo, per-machine, never in git. The hook reads
 # it at runtime, fails open if the file is absent or unreadable, and
-# matches case-insensitive literal substrings against the same
+# matches case-insensitive whole-word literals against the same
 # SCAN_TARGET the tracker-ID scan inspects. Tracker-ID matches take
 # priority — a commit with both gets the tracker-ID deny message.
+#
+# Whole-word matching (grep -w): the entry must be bordered by non-
+# word characters on each side. So `Acme` matches the standalone word
+# `Acme` (in any casing under -i) but NOT `AcmeCorp` (continuation),
+# `acmebrand` (concatenation), or `acme` inside `today` (substring).
+# The tradeoff vs. plain substring match: lower false-positive rate on
+# common-substring entries, at the cost of missing concatenated
+# identifiers (which the user can blocklist as separate entries if
+# they appear in commit-time content).
 #
 # Invariant: the blocklist scan's deny message does NOT name the
 # matched entry. Echoing a name the user explicitly flagged as
@@ -255,8 +264,10 @@ if [ -r "$PRIVATE_PROJECTS_FILE" ]; then
     case "$line" in '#'*) continue ;; esac
 
     # `-F` is literal-match (no regex foot-guns), `-i` case-insensitive,
-    # `--` guards entries that happen to start with `-`.
-    if printf '%s' "$SCAN_TARGET" | grep -qi -F -- "$line"; then
+    # `-w` whole-word boundaries, `--` guards entries that happen to
+    # start with `-`. See header "Whole-word matching" note for the
+    # tradeoff rationale.
+    if printf '%s' "$SCAN_TARGET" | grep -qiw -F -- "$line"; then
       # Generic message — see header "Invariant" note. The matched
       # entry is intentionally NOT named.
       emit_deny "Blocked by redaction gate: the staged diff, commit message, PR title, PR body, or referenced body-source file contains an entry from your ~/.claude/private-projects.md blocklist. Review the content and remove the project name before retrying. (The hook deliberately does not name which entry matched — printing it would re-expose the value in terminal output, CI logs, and Claude's conversation context, which is exactly what this gate exists to prevent.) See repo CLAUDE.md section 'Redact private-project-identifying content'."

--- a/claude/.claude/hooks/deny-private-project-refs.sh
+++ b/claude/.claude/hooks/deny-private-project-refs.sh
@@ -15,9 +15,13 @@
 #
 # Scope and limits:
 # - Catches the mechanical category (tracker IDs shaped like [A-Z]{2,}-\d+).
-# - Does NOT catch private project names, internal tool names, absolute
-#   filesystem paths with private-project names, or structural
-#   fingerprints. Those require review discipline.
+# - Catches a second mechanical category when the user opts in via
+#   ~/.claude/private-projects.md: a literal, case-insensitive
+#   substring scan against entries in that user-local file. See the
+#   "Deliberate scope" section below for the full design.
+# - Does NOT catch internal tool names, absolute filesystem paths with
+#   private-project names, or structural fingerprints. Those require
+#   review discipline.
 # - Scans the full Bash command string so `git commit -m "..."`,
 #   `gh pr create --body "..."`, `gh pr edit N --title "..."`, and
 #   heredoc variants all get checked without parsing the message out
@@ -43,11 +47,26 @@
 #   `gh pr create --body-file` but is NOT scanned here. Pre-existing
 #   gap, not addressed by this plan.
 #
-# Deliberate non-scope (this PR): a committed list of project names in
-# this public repo would itself be the leak — hardcoding in cleartext
-# the exact strings the rule is trying to prevent from shipping.
-# Mechanical defense beyond the tracker-ID category is out of scope for
-# this PR; a follow-up may add a non-committed mechanism.
+# Deliberate scope: user-local private-projects blocklist.
+# ---------------------------------------------------------
+# A *committed* list of project names in this public repo would itself
+# be the leak — hardcoding in cleartext the exact strings the rule
+# prevents from shipping. That objection still stands; do not propose a
+# committed blocklist.
+#
+# A *user-local* list at ~/.claude/private-projects.md is a different
+# artifact: outside any repo, per-machine, never in git. The hook reads
+# it at runtime, fails open if the file is absent or unreadable, and
+# matches case-insensitive literal substrings against the same
+# SCAN_TARGET the tracker-ID scan inspects. Tracker-ID matches take
+# priority — a commit with both gets the tracker-ID deny message.
+#
+# Invariant: the blocklist scan's deny message does NOT name the
+# matched entry. Echoing a name the user explicitly flagged as
+# sensitive would re-expose it in terminal output, screenshots, CI
+# logs, and Claude's conversation context — exactly the surfaces this
+# gate exists to protect. Generic-message-only is load-bearing and
+# tested.
 #
 # Allowlist extension: append to OSS_ALLOWLIST below if a legitimate
 # open-source prefix is blocked. Do NOT add private-project-specific
@@ -214,11 +233,34 @@ HITS=$(printf '%s' "$SCAN_TARGET" \
   | grep -vE "$OSS_ALLOWLIST" \
   || true)
 
-if [ -z "$HITS" ]; then
+if [ -n "$HITS" ]; then
+  # Report the first few offenders to keep the message short.
+  HIT_LIST=$(printf '%s' "$HITS" | head -5 | tr '\n' ' ' | sed 's/ $//')
+  emit_deny "Commit blocked by redaction gate: the staged diff, commit message, PR title, PR body, or referenced body-source file contains tracker-ID tokens that may reveal a private project: ${HIT_LIST}. See repo CLAUDE.md section 'Redact private-project-identifying content'. If the match is an open-source reference or technical constant not on the allowlist, add the prefix to the OSS_ALLOWLIST variable in ~/.claude/hooks/deny-private-project-refs.sh. Otherwise rewrite the commit message / staged content / PR body without the tracker ID before retrying."
   exit 0
 fi
 
-# Report the first few offenders to keep the message short.
-HIT_LIST=$(printf '%s' "$HITS" | head -5 | tr '\n' ' ' | sed 's/ $//')
+# Tracker-ID scan clean. Try the user-local private-projects blocklist.
+# Fail-open: a contributor without the file works normally. The
+# readability gate ([ -r ]) covers both absent and unreadable cases.
+PRIVATE_PROJECTS_FILE="${HOME}/.claude/private-projects.md"
+if [ -r "$PRIVATE_PROJECTS_FILE" ]; then
+  while IFS= read -r raw_line || [ -n "$raw_line" ]; do
+    # Strip CR (CRLF), then leading/trailing whitespace.
+    line=${raw_line%$'\r'}
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    # Skip blanks and `#` comments.
+    [ -z "$line" ] && continue
+    case "$line" in '#'*) continue ;; esac
 
-emit_deny "Commit blocked by redaction gate: the staged diff, commit message, PR title, PR body, or referenced body-source file contains tracker-ID tokens that may reveal a private project: ${HIT_LIST}. See repo CLAUDE.md section 'Redact private-project-identifying content'. If the match is an open-source reference or technical constant not on the allowlist, add the prefix to the OSS_ALLOWLIST variable in ~/.claude/hooks/deny-private-project-refs.sh. Otherwise rewrite the commit message / staged content / PR body without the tracker ID before retrying."
+    # `-F` is literal-match (no regex foot-guns), `-i` case-insensitive,
+    # `--` guards entries that happen to start with `-`.
+    if printf '%s' "$SCAN_TARGET" | grep -qi -F -- "$line"; then
+      # Generic message — see header "Invariant" note. The matched
+      # entry is intentionally NOT named.
+      emit_deny "Blocked by redaction gate: the staged diff, commit message, PR title, PR body, or referenced body-source file contains an entry from your ~/.claude/private-projects.md blocklist. Review the content and remove the project name before retrying. (The hook deliberately does not name which entry matched — printing it would re-expose the value in terminal output, CI logs, and Claude's conversation context, which is exactly what this gate exists to prevent.) See repo CLAUDE.md section 'Redact private-project-identifying content'."
+      exit 0
+    fi
+  done < "$PRIVATE_PROJECTS_FILE"
+fi

--- a/claude/.claude/hooks/tests/test_hooks.py
+++ b/claude/.claude/hooks/tests/test_hooks.py
@@ -1269,6 +1269,55 @@ class TestDenyPrivateProjectRefs:
             == "allow"
         )
 
+    def test_blocklist_substring_within_word_does_not_match(self, claude_config_repo, private_projects_file):
+        """Whole-word match: `Pulse` blocklist entry must NOT match
+        `impulse` in a commit message — `impulse` is one word, no
+        boundary at the `Pulse` substring. This is the load-bearing
+        false-positive avoidance that motivated whole-word matching."""
+        private_projects_file("Pulse\n")
+        assert (
+            run_hook(
+                DENY_PRIVATE_PROJECT_REFS_HOOK,
+                bash_input("git commit -m 'Add impulse handler for events'"),
+                cwd=claude_config_repo,
+            )
+            == "allow"
+        )
+
+    def test_blocklist_concatenated_identifier_does_not_match(self, claude_config_repo, private_projects_file):
+        """Whole-word match: `AcmeCorp` does NOT match `AcmeCorpService`.
+        The trailing `S` is a word character so no boundary exists
+        after `AcmeCorp`. Documented behavior — users who need to
+        catch concatenated forms add the concatenated form as its own
+        blocklist entry."""
+        private_projects_file("AcmeCorp\n")
+        assert (
+            run_hook(
+                DENY_PRIVATE_PROJECT_REFS_HOOK,
+                bash_input("git commit -m 'Refactor AcmeCorpService auth flow'"),
+                cwd=claude_config_repo,
+            )
+            == "allow"
+        )
+
+    def test_blocklist_match_at_punctuation_boundary(self, claude_config_repo, private_projects_file):
+        """Whole-word match: punctuation is a non-word boundary. So
+        `AcmeCorp` matches `AcmeCorp.` (period), `AcmeCorp,` (comma),
+        and `AcmeCorp's` (apostrophe before non-word `s`-content...
+        wait, `'` is non-word so `\\bAcmeCorp\\b` matches before the
+        apostrophe). Verifies the common case where the project name
+        appears at the end of a sentence or in possessive form."""
+        private_projects_file("AcmeCorp\n")
+        for punct_form in ["Working with AcmeCorp.", "AcmeCorp's release notes", "Refactor for AcmeCorp, finally"]:
+            assert (
+                run_hook(
+                    DENY_PRIVATE_PROJECT_REFS_HOOK,
+                    bash_input(f"git commit -m '{punct_form}'"),
+                    cwd=claude_config_repo,
+                )
+                == "deny"
+            ), f"expected deny for {punct_form!r}"
+
     def test_blocklist_deny_message_does_not_name_entry(self, claude_config_repo, private_projects_file):
         """LOAD-BEARING: the deny message must NOT echo the matched entry.
 

--- a/claude/.claude/hooks/tests/test_hooks.py
+++ b/claude/.claude/hooks/tests/test_hooks.py
@@ -440,6 +440,40 @@ def unrelated_remote_repo(git_repo):
 
 
 class TestDenyPrivateProjectRefs:
+    @pytest.fixture(autouse=True)
+    def _isolate_home_for_blocklist(self, monkeypatch, tmp_path):
+        """Isolate $HOME for the entire class so the developer's real
+        ~/.claude/private-projects.md never bleeds into tests.
+
+        Without this, a developer with "the parser" or any other
+        generic substring in their real blocklist could fail tests
+        like test_clean_commit_message_allowed nondeterministically.
+        Subprocess inherits this monkeypatched env (run_hook doesn't
+        override it), so the hook reads the isolated $HOME at
+        runtime.
+        """
+        home = tmp_path / "home"
+        (home / ".claude").mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(home))
+        return home
+
+    @pytest.fixture
+    def private_projects_file(self, _isolate_home_for_blocklist):
+        """Writer for ~/.claude/private-projects.md inside the
+        isolated $HOME established by the autouse fixture above.
+
+        Returns a function that takes the file's content (a string)
+        and writes it. Tests that don't call this writer get a
+        nonexistent blocklist file (the fail-open path)."""
+        home = _isolate_home_for_blocklist
+        blocklist = home / ".claude" / "private-projects.md"
+
+        def _write(content: str) -> Path:
+            blocklist.write_text(content)
+            return blocklist
+
+        return _write
+
     def test_non_commit_command_allowed(self, claude_config_repo):
         assert run_hook(DENY_PRIVATE_PROJECT_REFS_HOOK, bash_input("git status"), cwd=claude_config_repo) == "allow"
 
@@ -1054,6 +1088,219 @@ class TestDenyPrivateProjectRefs:
             )
             == "allow"
         )
+
+    # -- User-local private-projects blocklist -----------------------------
+    # Second mechanical defense alongside the tracker-ID scan. Reads
+    # ~/.claude/private-projects.md as a literal, case-insensitive
+    # substring blocklist. Fails open if the file is absent or unreadable.
+    # Critical invariant: the deny message NEVER names the matched entry.
+
+    def test_blocklist_match_in_commit_message_denied(self, claude_config_repo, private_projects_file):
+        private_projects_file("Acme Corp\n")
+        assert (
+            run_hook(
+                DENY_PRIVATE_PROJECT_REFS_HOOK,
+                bash_input("git commit -m 'Working on Acme Corp integration'"),
+                cwd=claude_config_repo,
+            )
+            == "deny"
+        )
+
+    def test_blocklist_match_case_insensitive_denied(self, claude_config_repo, private_projects_file):
+        """Blocklist entry `Initech`; commit has lowercase `initech`."""
+        private_projects_file("Initech\n")
+        assert (
+            run_hook(
+                DENY_PRIVATE_PROJECT_REFS_HOOK,
+                bash_input("git commit -m 'Migrate initech config to new schema'"),
+                cwd=claude_config_repo,
+            )
+            == "deny"
+        )
+
+    def test_blocklist_match_multi_word_entry_denied(self, claude_config_repo, private_projects_file):
+        """Multi-word entries match — line-by-line read, not word-split."""
+        private_projects_file("Project Bluebird\n")
+        assert (
+            run_hook(
+                DENY_PRIVATE_PROJECT_REFS_HOOK,
+                bash_input("git commit -m 'Update project bluebird notes'"),
+                cwd=claude_config_repo,
+            )
+            == "deny"
+        )
+
+    def test_blocklist_match_in_gh_pr_inline_body_denied(self, claude_config_repo, private_projects_file):
+        private_projects_file("Acme Corp\n")
+        assert (
+            run_hook(
+                DENY_PRIVATE_PROJECT_REFS_HOOK,
+                bash_input("gh pr create --body 'Refactor for Acme Corp release'"),
+                cwd=claude_config_repo,
+            )
+            == "deny"
+        )
+
+    def test_blocklist_match_in_gh_pr_body_file_denied(self, claude_config_repo, private_projects_file, tmp_path):
+        """Blocklist applies to body-file content, not just the inline command."""
+        private_projects_file("Acme Corp\n")
+        body_file = tmp_path / "pr-body.md"
+        body_file.write_text("## Summary\n\nAcme Corp integration polish.\n")
+        assert (
+            run_hook(
+                DENY_PRIVATE_PROJECT_REFS_HOOK,
+                bash_input(f"gh pr create --body-file {body_file}"),
+                cwd=claude_config_repo,
+            )
+            == "deny"
+        )
+
+    def test_blocklist_match_in_staged_diff_denied(self, claude_config_repo, private_projects_file):
+        """Added lines in the staged diff are scanned against the blocklist."""
+        private_projects_file("Acme Corp\n")
+        (claude_config_repo / "file.txt").write_text("first\nsecond\n# Acme Corp section\n")
+        subprocess.run(["git", "add", "file.txt"], cwd=claude_config_repo, check=True)
+        assert (
+            run_hook(
+                DENY_PRIVATE_PROJECT_REFS_HOOK,
+                bash_input("git commit -m 'Generic refactor'"),
+                cwd=claude_config_repo,
+            )
+            == "deny"
+        )
+
+    def test_blocklist_comments_and_blanks_ignored(self, claude_config_repo, private_projects_file):
+        """File with `#` comments and blank lines + a real entry must
+        skip the noise and still match on the real entry."""
+        private_projects_file("# Engagements\n\n# More\nAcme Corp\n\n")
+        assert (
+            run_hook(
+                DENY_PRIVATE_PROJECT_REFS_HOOK,
+                bash_input("git commit -m 'Working on Acme Corp release'"),
+                cwd=claude_config_repo,
+            )
+            == "deny"
+        )
+
+    def test_blocklist_entry_whitespace_trimmed(self, claude_config_repo, private_projects_file):
+        """Leading/trailing whitespace on a blocklist line is stripped
+        before matching, so a stray indent doesn't silently disable the entry."""
+        private_projects_file("   Acme Corp   \n")
+        assert (
+            run_hook(
+                DENY_PRIVATE_PROJECT_REFS_HOOK,
+                bash_input("git commit -m 'Working on Acme Corp release'"),
+                cwd=claude_config_repo,
+            )
+            == "deny"
+        )
+
+    def test_blocklist_absent_allows(self, claude_config_repo):
+        """No ~/.claude/private-projects.md → fail-open. Existing behavior
+        for users who haven't opted in must be unchanged."""
+        # The autouse fixture leaves $HOME without a blocklist file.
+        assert (
+            run_hook(
+                DENY_PRIVATE_PROJECT_REFS_HOOK,
+                bash_input("git commit -m 'Working on Acme Corp release'"),
+                cwd=claude_config_repo,
+            )
+            == "allow"
+        )
+
+    def test_blocklist_only_comments_and_blanks_allows(self, claude_config_repo, private_projects_file):
+        """File exists but has no usable entries → fail-open."""
+        private_projects_file("# Just a header\n\n# Nothing real\n\n")
+        assert (
+            run_hook(
+                DENY_PRIVATE_PROJECT_REFS_HOOK,
+                bash_input("git commit -m 'Working on Acme Corp release'"),
+                cwd=claude_config_repo,
+            )
+            == "allow"
+        )
+
+    def test_blocklist_no_match_allows(self, claude_config_repo, private_projects_file):
+        private_projects_file("Acme Corp\nProject Bluebird\n")
+        assert (
+            run_hook(
+                DENY_PRIVATE_PROJECT_REFS_HOOK,
+                bash_input("git commit -m 'Refactor the parser module'"),
+                cwd=claude_config_repo,
+            )
+            == "allow"
+        )
+
+    def test_blocklist_unrelated_remote_short_circuits(self, unrelated_remote_repo, private_projects_file):
+        """The blocklist scan must respect the same origin.url short-
+        circuit as the tracker-ID scan. A repo that isn't claude-config
+        gets no scanning at all, even if the content matches a blocklist
+        entry — the user's blocklist is for THEIR private projects, but
+        the gate only fires in this public repo."""
+        private_projects_file("Acme Corp\n")
+        assert (
+            run_hook(
+                DENY_PRIVATE_PROJECT_REFS_HOOK,
+                bash_input("git commit -m 'Working on Acme Corp release'"),
+                cwd=unrelated_remote_repo,
+            )
+            == "allow"
+        )
+
+    def test_blocklist_removed_line_in_diff_allows(self, claude_config_repo, private_projects_file):
+        """Removing a blocklisted name in the staged diff is the legitimate
+        cleanup flow — the hook must not block it. Mirror of
+        test_removing_a_tracker_id_is_allowed."""
+        private_projects_file("Acme Corp\n")
+        # Seed: file with the name committed.
+        (claude_config_repo / "legacy.txt").write_text("Old notes about Acme Corp.\n")
+        subprocess.run(["git", "add", "legacy.txt"], cwd=claude_config_repo, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "seed"], cwd=claude_config_repo, check=True)
+        # Stage the removal — diff has `-Old notes about Acme Corp.`
+        # which is NOT in ADDED_LINES, and the commit message is generic.
+        (claude_config_repo / "legacy.txt").write_text("Old notes.\n")
+        subprocess.run(["git", "add", "legacy.txt"], cwd=claude_config_repo, check=True)
+        assert (
+            run_hook(
+                DENY_PRIVATE_PROJECT_REFS_HOOK,
+                bash_input("git commit -m 'Redact legacy notes'"),
+                cwd=claude_config_repo,
+            )
+            == "allow"
+        )
+
+    def test_blocklist_deny_message_does_not_name_entry(self, claude_config_repo, private_projects_file):
+        """LOAD-BEARING: the deny message must NOT echo the matched entry.
+
+        Echoing a name the user explicitly flagged as sensitive would
+        re-expose it in terminal output, screenshots, CI logs, and
+        Claude's own conversation context — exactly the surfaces this
+        gate exists to protect. This invariant is documented in the
+        hook header and must hold across refactors.
+        """
+        private_projects_file("Acme Corp\n")
+        result = subprocess.run(
+            [str(DENY_PRIVATE_PROJECT_REFS_HOOK)],
+            input=json.dumps(bash_input("git commit -m 'Working on Acme Corp release'")),
+            capture_output=True,
+            text=True,
+            cwd=claude_config_repo,
+            check=False,
+        )
+        assert result.stdout.strip(), "expected a deny verdict"
+        payload = json.loads(result.stdout)
+        assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
+        reason = payload["hookSpecificOutput"]["permissionDecisionReason"]
+
+        # Bright-line: no case variant of the matched entry appears.
+        assert "Acme Corp" not in reason
+        assert "acme corp" not in reason.lower()
+
+        # Lock in the explanation so a refactor that drops it fails fast.
+        assert "deliberately does not name which entry matched" in reason
+
+        # Sanity: the user is pointed at their own blocklist file.
+        assert "private-projects.md" in reason
 
 
 # ---------------------------------------------------------------------------

--- a/install.sh
+++ b/install.sh
@@ -44,6 +44,23 @@ if [ -f "$SETTINGS_FILE" ]; then
   done < <(jq -r '.enabledPlugins // {} | to_entries[] | select(.value == true) | .key' "$SETTINGS_FILE")
 fi
 
+check_private_projects_file() {
+  local file="$HOME/.claude/private-projects.md"
+  if [ ! -e "$file" ]; then
+    echo ""
+    echo "TIP: Create ~/.claude/private-projects.md and add \"@private-projects.md\""
+    echo "     to ~/.claude/CLAUDE.md to enable redaction of project names you don't"
+    echo "     want leaking in commits/PRs. See README section 'Private-project redaction'."
+  elif [ -z "$(grep -Ev '^[[:space:]]*(#|$)' "$file" 2>/dev/null)" ]; then
+    echo ""
+    echo "WARNING: ~/.claude/private-projects.md exists but contains no usable entries"
+    echo "         (only comments or blank lines). Either populate it or delete it —"
+    echo "         an empty file is the confusing state."
+  fi
+}
+
+check_private_projects_file
+
 echo ""
 echo "Done. Optional: run the hook test suite:"
 echo "  pytest claude/.claude/hooks/tests/"


### PR DESCRIPTION
## Summary

Adds the second mechanical defense to `deny-private-project-refs.sh`: a user-local opt-in blocklist of project names. PR #37 closed the tracker-ID surface across all three write paths (`git commit`, `gh pr create`, `gh pr edit`); this PR catches the named-project category that the tracker-ID regex doesn't.

## Design

The hook reads `~/.claude/private-projects.md` at runtime — a user-local file outside any repo, per-machine, never in `git add`. Each non-comment, non-blank line becomes a case-insensitive literal substring blocklist entry against the same `SCAN_TARGET` the tracker-ID scan inspects (commit message, staged diff added lines, gh pr body/title, body-source file contents).

Tracker-ID matches take priority. Fail-open if the file is absent or unreadable — opt-in protection, not a mandatory checkpoint.

## Why a user-local file (not committed)

PR #37's description rejected a committed blocklist on the grounds that "a list of project names in this public repo would itself be the leak." That objection is correct — and is about *location*, not behavior. The user-local file lives at `~/.claude/private-projects.md`, outside any repo, so the same behavior (literal-substring scan) doesn't reintroduce the leak.

## No-echo invariant (load-bearing)

The blocklist deny message deliberately does NOT name the matched entry. Echoing a name the user explicitly flagged as sensitive would re-expose it in terminal output, screenshots, CI logs, and Claude's conversation context — exactly the surfaces the gate exists to protect. The tracker-ID scan reports matched tokens (defensible — they're mechanical regex matches against the user's own draft), but blocklist entries are user-flagged secrets and stay private even at deny time. A dedicated test locks this in.

## Other changes

- `.gitignore`: belt-and-suspenders for the file landing inside the stowed tree by mistake.
- `README.md`: new "Private-project redaction" section with opt-in instructions, file format, and a worked example explaining what to blocklist (distinctive project names) vs. what NOT to (tracker prefixes — already covered by the regex, prone to false positives on common substrings).
- `install.sh`: tri-state check (absent => tip, empty => warning, populated => silent) using POSIX `[[:space:]]` for macOS portability.
- `CLAUDE.md`: Enforcement section updated to describe both mechanical defenses.

## Test plan

- [x] `pytest claude/.claude/hooks/tests/` — 180 passing (up from 166)
- [x] No-echo invariant: deny message contains neither the matched entry nor any case variant; static "deliberately does not name which entry matched" phrase is asserted so a future refactor that drops the explanation fails fast
- [x] Fail-open: hook allows when blocklist file is absent
- [x] Scoping: blocklist match in unrelated repo short-circuits to allow (same `origin.url` check the tracker-ID scan respects)
- [x] Removing a blocklisted name in the staged diff is allowed (deletion lines aren't scanned, mirroring the tracker-ID `removing_a_tracker_id_is_allowed` test)
- [x] Self-test: the hook caught a tracker-shaped placeholder in this branch's own README worked example before commit. Fixed in the same diff. Satisfying meta-validation that the gate works end-to-end.
- [x] `hook-tests` CI passes on this branch

## New test cases (14)

Block paths: commit message match, gh pr inline body match, gh pr `--body-file` content match, staged-diff added-line match, multi-word entry, lowercase variant, comments-and-blanks-mixed file, whitespace-trimmed entry.

Allow paths: file absent, only-comments-and-blanks file, no-match populated file, unrelated remote scoping, removed-in-diff.

Invariant lock-in: deny message contains no case variant of matched entry AND contains the static explanation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)