### PR TITLE
ai-instruction-and-memory-files: action-gate trigger on memory writes

### DIFF
--- a/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
+++ b/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
@@ -8,11 +8,14 @@ description: >
   the `@AGENTS.md` import pattern Anthropic officially endorses, and the
   split between user-written instructions and Claude-written memory.
   TRIGGER when: editing CLAUDE.md or AGENTS.md, editing `.lovable/*.md`,
-  creating a new instruction file, auditing or pruning Claude Code
-  auto-memory in `~/.claude/projects/*/memory/`, deciding whether a rule
-  belongs in CLAUDE.md vs auto-memory, evaluating whether rules should be
-  duplicated across files, or debating file length and context budget for
-  AI coding agents.
+  creating a new instruction file, creating, editing, auditing, or
+  pruning Claude Code auto-memory in `~/.claude/projects/*/memory/`
+  (including new `MEMORY.md` entries — fire BEFORE the write, not
+  after, since the surface choice between CLAUDE.md/AGENTS.md and
+  memory is the failure mode this skill prevents), deciding whether a
+  rule belongs in CLAUDE.md vs auto-memory, evaluating whether rules
+  should be duplicated across files, or debating file length and
+  context budget for AI coding agents.
   DO NOT TRIGGER when: editing README.md or other project docs that are
   not loaded by AI coding agents, or writing code.
 user-invocable: false

--- a/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
+++ b/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
@@ -9,13 +9,10 @@ description: >
   split between user-written instructions and Claude-written memory.
   TRIGGER when: editing CLAUDE.md or AGENTS.md, editing `.lovable/*.md`,
   creating a new instruction file, creating, editing, auditing, or
-  pruning Claude Code auto-memory in `~/.claude/projects/*/memory/`
-  (including new `MEMORY.md` entries — fire BEFORE the write, not
-  after, since the surface choice between CLAUDE.md/AGENTS.md and
-  memory is the failure mode this skill prevents), deciding whether a
-  rule belongs in CLAUDE.md vs auto-memory, evaluating whether rules
-  should be duplicated across files, or debating file length and
-  context budget for AI coding agents.
+  pruning Claude Code auto-memory in `~/.claude/projects/*/memory/`,
+  deciding whether a rule belongs in CLAUDE.md vs auto-memory,
+  evaluating whether rules should be duplicated across files, or
+  debating file length and context budget for AI coding agents.
   DO NOT TRIGGER when: editing README.md or other project docs that are
   not loaded by AI coding agents, or writing code.
 user-invocable: false


### PR DESCRIPTION
## Summary

Action-gate the `ai-instruction-and-memory-files` skill's TRIGGER on memory writes. Surfaced in PR #38 review.

## What was wrong

The trigger had `"auditing or pruning Claude Code auto-memory"` but not `"creating, editing"`. So when an agent was about to *write a new memory file from scratch* (the most common case), the skill didn't fire.

The trigger also had `"deciding whether a rule belongs in CLAUDE.md vs auto-memory"` — but that's *state-gated*. It relies on the agent consciously framing the action as a surface-choice decision. In practice the auto-memory framework primes the agent to default to memory, and "deciding" doesn't happen.

In PR #38 I wrote a new memory file capturing a stow-symlink architectural fact (`~/.claude/CLAUDE.md` is a symlink to a tracked repo file, so `>>` writes through it leak into the public repo). The rule applies to every agent in every clone — it belongs in the committed `CLAUDE.md`, not user-ephemeral memory. The skill body's §6 anti-duplication table already says so ("Rule any contributor (or other agent) should follow → CLAUDE.md, or AGENTS.md via @AGENTS.md"). I just didn't load the skill at the right moment.

## The fix

Expand the trigger's verb list from `"auditing or pruning"` to `"creating, editing, auditing, or pruning"`. Now any memory file write (creating a new topic file, editing an existing one, adding a `MEMORY.md` index entry) fires the skill, which already has the surface-selection rules in §5 and §6.

Net diff vs. main: 4 words added (`creating, editing,`), no other changes. Skill body unchanged.

## Self-application

The first commit on this branch added a meta-parenthetical to the trigger ("fire BEFORE the write, not after, since the surface choice between CLAUDE.md/AGENTS.md and memory is the failure mode this skill prevents"). Reviewer asked whether I'd run the skill on its own diff — I hadn't. Running it now flagged §3:

> "Compliance with prose rules tops out around 70%. Structural tests and hooks hit 100%. When a rule can be encoded as either, prefer the mechanical enforcement."

The verb expansion is the structural enforcement; the parenthetical was prose explaining what the verbs already encoded. Trimmed in the second commit.

## Test plan

- [x] Diff verified action-gating: each verb (`creating`, `editing`, `auditing`, `pruning`) maps to a concrete agent action on memory files
- [x] Skill body unchanged (no risk of regressing existing guidance)
- [x] Skill applied to its own diff — surfaced the parenthetical bloat, removed in commit 2
- [x] No tracker-shaped tokens or private-project references in the diff
- [ ] `hook-tests` CI passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)