### PR TITLE
CLAUDE.md: rule for editing skills — apply skill to own diff

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,14 @@ ship with the reference even if the skill body is clean. Rewriting
 unpushed history on a personal branch is the right tool here (see
 `git-feature-branch-sync`).
 
+## AI agents
+
+The same rule applies when an AI agent is drafting. If the agent
+proposes a commit message, skill body, or PR description that includes
+a private-project reference — or an agent's research / memory hands it
+a reference — strip it before committing. The fact that the reference
+came from the agent, not a human, is not a defense.
+
 ## When editing a skill, run the skill on its own diff
 
 A skill's body states the rules it enforces; an edit can violate
@@ -99,14 +107,6 @@ The common failure mode: an edit adds prose to a skill that argues
 against prose-heavy rules (or a long body to a skill that targets
 brevity, etc.) — exactly the kind of thing the skill would flag if
 applied to its own diff.
-
-## AI agents
-
-The same rule applies when an AI agent is drafting. If the agent
-proposes a commit message, skill body, or PR description that includes
-a private-project reference — or an agent's research / memory hands it
-a reference — strip it before committing. The fact that the reference
-came from the agent, not a human, is not a defense.
 
 ## Enforcement
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,18 @@ ship with the reference even if the skill body is clean. Rewriting
 unpushed history on a personal branch is the right tool here (see
 `git-feature-branch-sync`).
 
+## When editing a skill, run the skill on its own diff
+
+A skill's body states the rules it enforces; an edit can violate
+those rules unless you re-read the body with the diff in mind.
+Before committing a skill change, load the skill into context and
+check the diff against its sections.
+
+The common failure mode: an edit adds prose to a skill that argues
+against prose-heavy rules (or a long body to a skill that targets
+brevity, etc.) — exactly the kind of thing the skill would flag if
+applied to its own diff.
+
 ## AI agents
 
 The same rule applies when an AI agent is drafting. If the agent


### PR DESCRIPTION
## Summary

Adds a contributor rule to CLAUDE.md: before committing a skill change, load the skill into context and check the diff against its sections.

## Why this belongs in repo-root CLAUDE.md

- **Scope:** the rule applies whenever an agent edits a skill, which only happens in this repo. Not global, not user-specific. Repo-root CLAUDE.md, not user memory or `claude/.claude/CLAUDE.md`.
- **Precedent:** the same file already has "## When a skill is surfaced by real-world work, abstract first" — a meta-rule about skill authorship. The new section sits next to it (different rule, same neighborhood).

## Self-application

The first draft of the new section ended with "Surfaced in PR #39 where..." with two paragraphs of incident specifics. Then I applied `ai-instruction-and-memory-files` to my own diff and §3 caught the violation: PR refs and ticket IDs in always-loaded files rot the moment the next PR lands and cost per-session context budget without giving future sessions actionable signal. They belong in commit messages, PR descriptions, or plan files — not in CLAUDE.md or AGENTS.md.

Trimmed to keep the rule and a generic failure-mode pattern, dropped the incident specifics. Net diff: 12 lines added.

This PR is itself a demonstration of the rule it adds — applying the skill to the diff caught a violation before commit.

## Test plan

- [x] Diff verified against §3 of `ai-instruction-and-memory-files` (length, no PR refs, rule stated clearly)
- [x] Diff verified against §6 (no duplication — the rule exists nowhere else in CLAUDE.md or any skill)
- [x] PR body itself scrubbed of tracker-shaped tokens (the original draft quoted §3 verbatim including a `TICKET-N`-style example that the hook would reject; paraphrased instead)
- [ ] `hook-tests` CI passes on this branch (docs-only change; tests should be unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
