### PR TITLE
CLAUDE.md: relocate skill-editing rule + fix redaction hierarchy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,18 @@ a feature, edit the committed file directly via PR. For per-user
 private context, use a non-stowed location like
 `~/.claude/private-projects.md` (opt-in, not part of the stow tree).
 
+## When editing a skill, run the skill on its own diff
+
+A skill's body states the rules it enforces; an edit can violate
+those rules unless you re-read the body with the diff in mind.
+Before committing a skill change, load the skill into context and
+check the diff against its sections.
+
+The common failure mode: an edit adds prose to a skill that argues
+against prose-heavy rules (or a long body to a skill that targets
+brevity, etc.) — exactly the kind of thing the skill would flag if
+applied to its own diff.
+
 ## Redact private-project-identifying content
 
 Never commit anything that ties a skill, rule, or example back to a
@@ -63,14 +75,14 @@ OAuth tokens, service-role keys, `.env` contents, database URLs with
 credentials, private-key material. The repo has no legitimate use for
 any of these. If one ever lands, rotate it *then* rewrite history.
 
-## Check all three surfaces before committing
+### Check all three surfaces before committing
 
 1. **File content** being committed.
 2. **Commit message body** — the most common leak site, because it's
    where motivation-context gets narrated.
 3. **PR title and description**.
 
-## When a skill is surfaced by real-world work, abstract first
+### When a skill is surfaced by real-world work, abstract first
 
 Skills are often motivated by a concrete incident. The insight belongs
 in this repo; the incident specifics do not.
@@ -88,27 +100,15 @@ ship with the reference even if the skill body is clean. Rewriting
 unpushed history on a personal branch is the right tool here (see
 `git-feature-branch-sync`).
 
-## AI agents
+### AI agents
 
-The same rule applies when an AI agent is drafting. If the agent
+The same redaction rule applies when an AI agent is drafting. If the agent
 proposes a commit message, skill body, or PR description that includes
 a private-project reference — or an agent's research / memory hands it
 a reference — strip it before committing. The fact that the reference
 came from the agent, not a human, is not a defense.
 
-## When editing a skill, run the skill on its own diff
-
-A skill's body states the rules it enforces; an edit can violate
-those rules unless you re-read the body with the diff in mind.
-Before committing a skill change, load the skill into context and
-check the diff against its sections.
-
-The common failure mode: an edit adds prose to a skill that argues
-against prose-heavy rules (or a long body to a skill that targets
-brevity, etc.) — exactly the kind of thing the skill would flag if
-applied to its own diff.
-
-## Enforcement
+### Enforcement
 
 The `deny-private-project-refs.sh` PreToolUse hook (wired in
 `claude/.claude/settings.json`) blocks `git commit`, `gh pr create`,


### PR DESCRIPTION
## Summary

Three related cleanups in CLAUDE.md, all surfaced during PR #40 review.

## 1. Relocate the skill-editing section

PR #40 added `## When editing a skill, run the skill on its own diff` after `## AI agents`, before `## Enforcement`. That placement was wrong: the skill-editing rule is **not** about redaction, but it landed inside the redaction cluster. Moved it up to between `## Working in this repo` and `## Redact private-project-identifying content` so the redaction cluster stays self-contained and ends cleanly with its `### Enforcement` subsection.

## 2. Demote redaction sub-rules to `###`

`## Redact private-project-identifying content` is the umbrella section. Two existing sub-rules already used `###` (`Also redact structural fingerprints`, `Secrets, tokens, credentials`), but four others were promoted to `##` even though each is a sub-rule of the same umbrella concern:

- `### Check all three surfaces before committing` (the three redaction surfaces)
- `### When a skill is surfaced by real-world work, abstract first` (about redacting in skill bodies)
- `### AI agents` (the redaction rule applying to AI drafts)
- `### Enforcement` (the redaction-enforcement hook)

## 3. Topic-anchor the AI-agents back-reference

`The same rule applies when an AI agent is drafting` → `The same redaction rule applies...`. The original phrasing assumed the previous section was always about redaction; positional rearrangements (like the relocation in this same PR) can break that anchor. Topic-anchoring removes the fragility.

## Test plan

- [x] Hierarchy: `Redact private-project-identifying content` at `##`, all six redaction sub-rules at `###`
- [x] `When editing a skill, run the skill on its own diff` at `##` (correctly outside the redaction cluster)
- [x] AI-agents reference is topic-anchored, not position-anchored
- [x] No PR refs in CLAUDE.md content (only in this PR description and commit message)
- [x] `ai-instruction-and-memory-files` skill applied to the diff — file under 200 lines, no duplication, surface choice (CLAUDE.md) correct
- [ ] `hook-tests` CI passes on this branch (docs-only change; tests should be unaffected)

## Why force-pushed

Original PR #41 was branched from a stale local `origin/main` (before PR #39 and PR #40 merged). Rebasing exposed a structural conflict: the originally proposed demotion of `## Enforcement` would have made it a subsection of `## When editing a skill...` (the most recent `##`), not of the redaction umbrella. Resolving cleanly required moving the skill-editing section above redaction. Reset and rewrote the branch on top of current `main` rather than carrying that conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)