### PR TITLE
ai-instruction-and-memory-files: drop .lovable/*.md auto-load implication

### DIFF
--- a/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
+++ b/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
@@ -7,9 +7,8 @@ description: >
   index + topic files): precedence, duplication rules, length targets,
   the `@AGENTS.md` import pattern Anthropic officially endorses, and the
   split between user-written instructions and Claude-written memory.
-  TRIGGER when: editing CLAUDE.md or AGENTS.md, editing `.lovable/*.md`
-  (NOT auto-loaded by Lovable — see §2), creating a new instruction file,
-  creating, editing, auditing, or
+  TRIGGER when: editing CLAUDE.md or AGENTS.md, editing `.lovable/*.md`,
+  creating a new instruction file, creating, editing, auditing, or
   pruning Claude Code auto-memory in `~/.claude/projects/*/memory/`,
   deciding whether a rule belongs in CLAUDE.md vs auto-memory,
   evaluating whether rules should be duplicated across files, or
@@ -84,13 +83,8 @@ All four are loaded every session. Lovable docs warn that in very long
 conversations instructions can drift; the "always read" guarantee for
 AGENTS.md is the defense-in-depth.
 
-**`.lovable/*.md` is NOT in this loaded set.** Despite the directory
-name, files under `.lovable/` are version-controlled human reference
-only — Lovable does not auto-load them. Knowledge becomes visible per
-session only by adding it through the Lovable UI's project-knowledge
-editor (source 1 above). Don't design guardrails that rely on
-`.lovable/*.md` being loaded — for guardrail placement see §4 (when to
-duplicate across surfaces) and §5 (decision flow).
+**`.lovable/*.md` is NOT loaded by Lovable** — these are repo-tracked
+notes for humans; visible knowledge comes only via the UI editor (source 1 above).
 
 ## 3. Length targets
 
@@ -105,11 +99,9 @@ and [Chroma's Context Rot research](https://research.trychroma.com/context-rot):
 
 ### Don't embed PR or ticket refs in always-loaded files
 
-Lines like `Precedent: PR #105` or `See TICKET-123 for context` belong
-in commit messages, PR descriptions, or plan files — not in CLAUDE.md
-or AGENTS.md. They rot the moment the next PR lands, and they cost
-per-session context budget without giving future sessions actionable
-signal. Future readers need the *rule* stated clearly.
+`Precedent: PR #105` and `See TICKET-NNN` rot the moment the next PR
+lands and cost per-session context budget. Put them in commit messages,
+PR descriptions, or plan files — state the rule, not the precedent.
 
 ## 4. When to duplicate vs. reference
 

--- a/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
+++ b/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
@@ -7,8 +7,9 @@ description: >
   index + topic files): precedence, duplication rules, length targets,
   the `@AGENTS.md` import pattern Anthropic officially endorses, and the
   split between user-written instructions and Claude-written memory.
-  TRIGGER when: editing CLAUDE.md or AGENTS.md, editing `.lovable/*.md`,
-  creating a new instruction file, creating, editing, auditing, or
+  TRIGGER when: editing CLAUDE.md or AGENTS.md, editing `.lovable/*.md`
+  (NOT auto-loaded by Lovable — see §2), creating a new instruction file,
+  creating, editing, auditing, or
   pruning Claude Code auto-memory in `~/.claude/projects/*/memory/`,
   deciding whether a rule belongs in CLAUDE.md vs auto-memory,
   evaluating whether rules should be duplicated across files, or
@@ -82,6 +83,14 @@ Effective order:
 All four are loaded every session. Lovable docs warn that in very long
 conversations instructions can drift; the "always read" guarantee for
 AGENTS.md is the defense-in-depth.
+
+**`.lovable/*.md` is NOT in this loaded set.** Despite the directory
+name, files under `.lovable/` are version-controlled human reference
+only — Lovable does not auto-load them. Knowledge becomes visible per
+session only by adding it through the Lovable UI's project-knowledge
+editor (source 1 above). Don't design guardrails that rely on
+`.lovable/*.md` being loaded — for guardrail placement see §4 (when to
+duplicate across surfaces) and §5 (decision flow).
 
 ## 3. Length targets
 

--- a/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
+++ b/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
@@ -83,8 +83,8 @@ All four are loaded every session. Lovable docs warn that in very long
 conversations instructions can drift; the "always read" guarantee for
 AGENTS.md is the defense-in-depth.
 
-**`.lovable/*.md` is NOT loaded by Lovable** — these are repo-tracked
-notes for humans; visible knowledge comes only via the UI editor (source 1 above).
+**`.lovable/*.md` is NOT loaded by Lovable** — these files are repo-tracked
+copies of what's set in the UI editor (source 1 above); only the UI version loads.
 
 ## 3. Length targets
 


### PR DESCRIPTION
## Summary

The skill's TRIGGER list mentioned `.lovable/*.md` without qualification, implying that Lovable auto-loads those files as project knowledge. It does not — `.lovable/*.md` is repo-tracked human reference; knowledge becomes visible to Lovable per session only by adding it through the Lovable UI's project-knowledge editor.

In `claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md`:

- **§2** adds a 2-line bold callout stating `.lovable/*.md` is NOT loaded by Lovable, with a back-reference to the source-1 entry in the §2 list (the UI editor).
- **§3 "Don't embed PR or ticket refs"** is tightened from 7 lines to 5 — same point, less padding, stronger imperative ("state the rule, not the precedent"). Bundled scope; the section is the closest existing demonstration of the very rule it embodies. Placeholder also swapped to `TICKET-NNN` so the example doesn't itself match the redaction hook's tracker-ID pattern when staged.

The corrected `.lovable/*.md` fact also lives in §2's existing four-source list (which already correctly excluded `.lovable/*.md`); this PR makes the exclusion explicit instead of leaving it as an inference for the reader.

## Test plan

- [ ] Read the diff against the skill's own length-target / prose-vs-structural rules (skill-on-own-diff check). 197 → 198 lines, under the 200 soft target.
- [ ] Verify the new §2 callout doesn't introduce a misconception (e.g., "project-knowledge UI field is durable") — earlier draft had this risk; current version drops the risky sentence entirely.
- [ ] Verify TRIGGER still fires for `.lovable/*.md` editing (the trigger phrase is unchanged).
- [ ] Verify §3 trim preserves all load-bearing claims (rule, rotting failure mode, where they belong, takeaway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)