### PR TITLE
respond-pr: per-session bypass marker keyed by session_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,12 @@ This symlinks `claude/.claude/` into `$HOME/.claude/`.
 
 ## What this installs
 
-### Hooks (PreToolUse gates)
+### Hooks
 
 - **`require-code-review.sh`** — blocks `git commit` (including chained forms like `git add . && git commit`) until `/code-review` has run on the current staged state. Verified via sha256 marker in `~/.claude/review-markers/<repo-hash>`, which auto-invalidates the moment the staging area changes.
 - **`deny-private-project-refs.sh`** — blocks `git commit`, `gh pr create`, and `gh pr edit` when the staged diff, commit message, or PR title/body/body-source-file contains either (a) tracker-ID tokens (`[A-Z]{2,}-\d+`) outside an OSS-prefix allowlist (`CVE-`, `RFC-`, `GH-`, and similar — see the script for the full list), or (b) a literal substring match against entries in the user's opt-in `~/.claude/private-projects.md` blocklist. Enforces the mechanical categories of the repo-root `CLAUDE.md` redaction rule; structural fingerprints still require review discipline. See [Private-project redaction](#private-project-redaction) below.
-- **`require-respond-pr.sh`** — blocks PR comment reads and posts (`gh api .../pulls|issues/N/{comments,reviews}`, `gh pr comment`, `gh pr review`) and redirects to `/respond-pr`, so all three comment types get fetched and replies carry the `[Claude Code]` attribution prefix. Honors a 60-minute bypass marker at `~/.claude/.respond-pr-active` that the skill sets on entry and removes on exit.
+- **`require-respond-pr.sh`** — blocks PR comment reads and posts (`gh api .../pulls|issues/N/{comments,reviews}`, `gh pr comment`, `gh pr review`) and redirects to `/respond-pr`, so all three comment types get fetched and replies carry the `[Claude Code]` attribution prefix. Honors a per-session bypass marker at `~/.claude/.respond-pr-active.d/<session_id>` that the skill sets on entry and removes on exit; the hook refreshes the marker's mtime on each bypass so long skill runs don't hit the 60-minute staleness cutoff. Per-session keying (rather than a singleton path) keeps parallel Claude sessions from thrashing on cleanup or leaking bypass to unrelated sessions.
+- **`capture-session-id.sh`** (SessionStart) — at session start, writes the session's `session_id` to `~/.claude/sessions/<claude-pid>` so skills running as Bash tool calls (which don't see the hook payload) can look up their own session id via the bash tool's `$PPID`. Used by `/respond-pr` to compute its bypass-marker filename.
 - **`ask-review-permissions.sh`** — asks before `Edit`/`Write`/`MultiEdit` to `.claude/settings*.json`, nudging toward `/review-permissions` when the edit touches `permissions.allow`.
 - **`require-worktree-for-git-writes.sh`** — opt-in per repo. When active, denies non-read-only git operations unless the session runs in a linked git worktree. Prevents concurrent Claude Code sessions from racing on the same working tree. See [Worktree enforcement](#worktree-enforcement) below for opt-in instructions.
 

--- a/claude/.claude/hooks/capture-session-id.sh
+++ b/claude/.claude/hooks/capture-session-id.sh
@@ -19,21 +19,40 @@
 #   that shim, not claude. claude is the shim's parent. POSIX
 #   `ps -o ppid= -p $PPID` walks up one level. Works on Linux, macOS, WSL.
 #
-# Failure mode: every step exits 0 silently. If session_id or claude_pid
-# can't be determined, the lookup file isn't written; the skill will then
-# fail loudly when it tries to read it. A SessionStart hook must never
-# block session startup, even on internal error.
+# Failure mode: every step exits 0 (a SessionStart hook that fails-closed
+# would block session startup, which is worse than a delayed Step 0
+# failure in the skill). Each failure path emits a one-line diagnostic to
+# stderr — visible in the user's terminal, not added to Claude's context
+# (which is stdout). When the lookup file isn't written, the /respond-pr
+# skill's Step 0 fails loudly with a clear message; the stderr trail here
+# is the upstream signal explaining why.
 
 INPUT=$(cat 2>/dev/null)
-[ -z "$INPUT" ] && exit 0
+if [ -z "$INPUT" ]; then
+  echo "[capture-session-id] empty stdin; lookup file not written; respond-pr skill will fail at Step 0" >&2
+  exit 0
+fi
 
 SESSION_ID=$(printf '%s\n' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null)
-[ -z "$SESSION_ID" ] && exit 0
+if [ -z "$SESSION_ID" ]; then
+  echo "[capture-session-id] no session_id in payload; respond-pr skill will fail at Step 0" >&2
+  exit 0
+fi
 
 CLAUDE_PID=$(ps -o ppid= -p "$PPID" 2>/dev/null | tr -d ' ')
-[ -z "$CLAUDE_PID" ] && exit 0
+if [ -z "$CLAUDE_PID" ]; then
+  echo "[capture-session-id] could not resolve claude PID via 'ps -o ppid= -p $PPID'; respond-pr skill will fail at Step 0" >&2
+  exit 0
+fi
 
-mkdir -p "$HOME/.claude/sessions" 2>/dev/null || exit 0
-printf '%s\n' "$SESSION_ID" > "$HOME/.claude/sessions/$CLAUDE_PID" 2>/dev/null
+if ! mkdir -p "$HOME/.claude/sessions" 2>/dev/null; then
+  echo "[capture-session-id] could not create $HOME/.claude/sessions; respond-pr skill will fail at Step 0" >&2
+  exit 0
+fi
+
+if ! printf '%s\n' "$SESSION_ID" > "$HOME/.claude/sessions/$CLAUDE_PID" 2>/dev/null; then
+  echo "[capture-session-id] could not write lookup file $HOME/.claude/sessions/$CLAUDE_PID; respond-pr skill will fail at Step 0" >&2
+  exit 0
+fi
 
 exit 0

--- a/claude/.claude/hooks/capture-session-id.sh
+++ b/claude/.claude/hooks/capture-session-id.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# SessionStart hook: bootstrap a session_id ↔ claude-PID mapping at session
+# start so downstream skills running as Bash tool calls can learn their
+# own session_id.
+#
+# Why: the require-respond-pr.sh gate's bypass marker is keyed by session_id
+# (the documented Claude Code hook payload field). The marker writer is the
+# /respond-pr skill, which runs as Bash tool calls. Bash tool calls don't
+# see session_id in env or on stdin — only hooks do. This hook captures
+# session_id once at session start and exposes it at a path the skill can
+# look up.
+#
+# Lookup contract on the skill side:
+#   The Bash tool's $PPID is the claude main process PID. The skill reads
+#   ~/.claude/sessions/$PPID to learn its session_id.
+#
+# Deriving claude_pid from inside this hook:
+#   This hook is invoked through a transient `sh` shim, so its $PPID is
+#   that shim, not claude. claude is the shim's parent. POSIX
+#   `ps -o ppid= -p $PPID` walks up one level. Works on Linux, macOS, WSL.
+#
+# Failure mode: every step exits 0 silently. If session_id or claude_pid
+# can't be determined, the lookup file isn't written; the skill will then
+# fail loudly when it tries to read it. A SessionStart hook must never
+# block session startup, even on internal error.
+
+INPUT=$(cat 2>/dev/null)
+[ -z "$INPUT" ] && exit 0
+
+SESSION_ID=$(printf '%s\n' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null)
+[ -z "$SESSION_ID" ] && exit 0
+
+CLAUDE_PID=$(ps -o ppid= -p "$PPID" 2>/dev/null | tr -d ' ')
+[ -z "$CLAUDE_PID" ] && exit 0
+
+mkdir -p "$HOME/.claude/sessions" 2>/dev/null || exit 0
+printf '%s\n' "$SESSION_ID" > "$HOME/.claude/sessions/$CLAUDE_PID" 2>/dev/null
+
+exit 0

--- a/claude/.claude/hooks/require-respond-pr.sh
+++ b/claude/.claude/hooks/require-respond-pr.sh
@@ -7,12 +7,19 @@
 # skill fetches all three AND enforces the [Claude Code] attribution prefix
 # on replies.
 #
-# Bypass: the /respond-pr skill touches ~/.claude/.respond-pr-active at its
-# start and removes it at the end. While the marker exists AND is fresh
-# (<60 min old), this hook lets gh commands through so the skill itself
-# doesn't recurse into its own gate. The 60-minute staleness cutoff
-# prevents an orphaned marker from permanently disabling the gate if the
-# skill errored out mid-execution.
+# Bypass: the /respond-pr skill writes a marker at
+# ~/.claude/.respond-pr-active.d/<session_id> at its start and removes it at
+# the end. While THIS session's marker exists AND is fresh (<60 min old),
+# this hook lets gh commands through so the skill itself doesn't recurse
+# into its own gate. Per-session keying (vs. a singleton path) prevents two
+# parallel respond-pr sessions from thrashing on cleanup, and prevents one
+# session's marker from leaking bypass to unrelated parallel sessions —
+# both of which the singleton design did not handle.
+#
+# The hook refreshes the marker's mtime on each bypass so a long-running
+# skill invocation (large PR, many comments) doesn't hit the 60-min
+# staleness cutoff mid-run. The cutoff still applies to genuinely orphaned
+# markers from a session that errored before reaching the cleanup step.
 
 INPUT=$(cat)
 TOOL=$(printf '%s\n' "$INPUT" | jq -r '.tool_name // empty')
@@ -24,11 +31,16 @@ fi
 
 COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command // empty')
 
-# Bypass: fresh marker from the /respond-pr skill means we're already inside
-# the skill and should let its own gh commands through.
-MARKER="$HOME/.claude/.respond-pr-active"
-if [ -f "$MARKER" ] && [ -n "$(find "$MARKER" -mmin -60 2>/dev/null)" ]; then
-  exit 0
+# Bypass: fresh marker for THIS session's session_id means we're inside the
+# skill and should let its own gh commands through. Empty session_id (older
+# Claude Code versions, payload-schema drift) falls through to the gate.
+SESSION_ID=$(printf '%s\n' "$INPUT" | jq -r '.session_id // empty')
+if [ -n "$SESSION_ID" ]; then
+  MARKER="$HOME/.claude/.respond-pr-active.d/$SESSION_ID"
+  if [ -f "$MARKER" ] && [ -n "$(find "$MARKER" -mmin -60 2>/dev/null)" ]; then
+    touch "$MARKER" 2>/dev/null
+    exit 0
+  fi
 fi
 
 # Match PR comment read/write patterns. Three forms:

--- a/claude/.claude/hooks/tests/test_hooks.py
+++ b/claude/.claude/hooks/tests/test_hooks.py
@@ -490,38 +490,57 @@ class TestCaptureSessionId:
         # but it must be a positive integer.
         assert files[0].name.isdigit() and int(files[0].name) > 0
 
-    def test_empty_session_id_writes_nothing(self, isolated_home):
-        run_hook(CAPTURE_SESSION_ID_HOOK, {"session_id": ""})
-        assert self._sessions_files(isolated_home) == []
-
-    def test_missing_session_id_field_writes_nothing(self, isolated_home):
-        run_hook(CAPTURE_SESSION_ID_HOOK, {"some_other_field": "value"})
-        assert self._sessions_files(isolated_home) == []
-
-    def test_empty_stdin_does_not_block_or_write(self, isolated_home):
-        """Empty payload must not block session start."""
-        result = subprocess.run(
+    def _run_capturing_stderr(self, payload: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
             [str(CAPTURE_SESSION_ID_HOOK)],
-            input="",
+            input=payload,
             capture_output=True,
             text=True,
             check=False,
         )
+
+    def test_empty_session_id_writes_nothing_with_stderr_diagnostic(self, isolated_home):
+        result = self._run_capturing_stderr(json.dumps({"session_id": ""}))
         assert result.returncode == 0
         assert self._sessions_files(isolated_home) == []
+        assert "[capture-session-id]" in result.stderr
+        assert "no session_id" in result.stderr
 
-    def test_malformed_json_does_not_block(self, isolated_home):
+    def test_missing_session_id_field_writes_nothing_with_stderr_diagnostic(self, isolated_home):
+        result = self._run_capturing_stderr(json.dumps({"some_other_field": "value"}))
+        assert result.returncode == 0
+        assert self._sessions_files(isolated_home) == []
+        assert "[capture-session-id]" in result.stderr
+        assert "no session_id" in result.stderr
+
+    def test_empty_stdin_does_not_block_and_emits_stderr(self, isolated_home):
+        """Empty payload must not block session start, but must leave a
+        diagnostic trail on stderr (not stdout — stdout would pollute
+        Claude's context)."""
+        result = self._run_capturing_stderr("")
+        assert result.returncode == 0
+        assert self._sessions_files(isolated_home) == []
+        assert "[capture-session-id]" in result.stderr
+        assert "empty stdin" in result.stderr
+        assert result.stdout == ""
+
+    def test_malformed_json_does_not_block_and_emits_stderr(self, isolated_home):
         """SessionStart hook must never fail-closed on payload corruption —
-        a broken hook would prevent the session from starting."""
-        result = subprocess.run(
-            [str(CAPTURE_SESSION_ID_HOOK)],
-            input="not valid json {{",
-            capture_output=True,
-            text=True,
-            check=False,
-        )
+        a broken hook would prevent the session from starting. Malformed
+        JSON is treated as missing session_id."""
+        result = self._run_capturing_stderr("not valid json {{")
         assert result.returncode == 0
         assert self._sessions_files(isolated_home) == []
+        assert "[capture-session-id]" in result.stderr
+        assert result.stdout == ""
+
+    def test_happy_path_emits_no_stderr(self, isolated_home):
+        """Successful runs must be silent — stderr noise on every session
+        start would condition the user to ignore it."""
+        result = self._run_capturing_stderr(json.dumps({"session_id": "abc-123"}))
+        assert result.returncode == 0
+        assert len(self._sessions_files(isolated_home)) == 1
+        assert result.stderr == ""
 
 
 # ---------------------------------------------------------------------------

--- a/claude/.claude/hooks/tests/test_hooks.py
+++ b/claude/.claude/hooks/tests/test_hooks.py
@@ -23,6 +23,7 @@ RESPOND_PR_HOOK = HOOKS_DIR / "require-respond-pr.sh"
 REVIEW_PERMS_HOOK = HOOKS_DIR / "ask-review-permissions.sh"
 DENY_PRIVATE_PROJECT_REFS_HOOK = HOOKS_DIR / "deny-private-project-refs.sh"
 WORKTREE_HOOK = HOOKS_DIR / "require-worktree-for-git-writes.sh"
+CAPTURE_SESSION_ID_HOOK = HOOKS_DIR / "capture-session-id.sh"
 
 
 def run_hook(hook: Path, tool_input: dict, cwd: Path | None = None) -> str:
@@ -45,8 +46,11 @@ def run_hook(hook: Path, tool_input: dict, cwd: Path | None = None) -> str:
     return payload["hookSpecificOutput"]["permissionDecision"]
 
 
-def bash_input(command: str) -> dict:
-    return {"tool_name": "Bash", "tool_input": {"command": command}}
+def bash_input(command: str, session_id: str | None = None) -> dict:
+    payload: dict = {"tool_name": "Bash", "tool_input": {"command": command}}
+    if session_id is not None:
+        payload["session_id"] = session_id
+    return payload
 
 
 def edit_input(file_path: str) -> dict:
@@ -279,6 +283,15 @@ class TestRequireRespondPr:
     def test_non_matching_commands_allowed(self, isolated_home, current_repo_foo_bar, command):
         assert run_hook(RESPOND_PR_HOOK, bash_input(command), cwd=current_repo_foo_bar) == "allow"
 
+    # -- Bypass-marker behavior --------------------------------------------
+    # Marker layout: ~/.claude/.respond-pr-active.d/<session_id>. The skill
+    # writes one file per session at entry; the hook checks the file matching
+    # THIS request's session_id (from JSON payload). Per-session keying
+    # prevents two failure modes the prior singleton path had:
+    #   (1) Cleanup thrash — session A's `rm -f` deleting B's marker.
+    #   (2) Bypass leak — session A's marker silently authorizing B's
+    #       gh calls even though B never ran /respond-pr.
+
     @pytest.mark.parametrize(
         "command",
         [
@@ -287,11 +300,20 @@ class TestRequireRespondPr:
         ],
     )
     def test_fresh_bypass_marker_allows(self, isolated_home, current_repo_foo_bar, command):
-        (isolated_home / ".claude" / ".respond-pr-active").touch()
-        assert run_hook(RESPOND_PR_HOOK, bash_input(command), cwd=current_repo_foo_bar) == "allow"
+        sid = "test-session-fresh"
+        marker_dir = isolated_home / ".claude" / ".respond-pr-active.d"
+        marker_dir.mkdir(parents=True)
+        (marker_dir / sid).touch()
+        assert (
+            run_hook(RESPOND_PR_HOOK, bash_input(command, session_id=sid), cwd=current_repo_foo_bar)
+            == "allow"
+        )
 
     def test_stale_bypass_marker_denies(self, isolated_home, current_repo_foo_bar):
-        marker = isolated_home / ".claude" / ".respond-pr-active"
+        sid = "test-session-stale"
+        marker_dir = isolated_home / ".claude" / ".respond-pr-active.d"
+        marker_dir.mkdir(parents=True)
+        marker = marker_dir / sid
         marker.touch()
         # Backdate 90 minutes — past the hook's 60-minute staleness cutoff.
         ninety_min_ago = time.time() - 90 * 60
@@ -299,10 +321,81 @@ class TestRequireRespondPr:
         assert (
             run_hook(
                 RESPOND_PR_HOOK,
+                bash_input("gh api repos/foo/bar/pulls/5/comments", session_id=sid),
+                cwd=current_repo_foo_bar,
+            )
+            == "deny"
+        )
+
+    def test_other_sessions_marker_does_not_leak_bypass(self, isolated_home, current_repo_foo_bar):
+        """Regression: a marker for session A must NOT bypass session B's
+        gated calls. This is the silent failure mode of the prior singleton
+        design — while any session held the marker, every other session's
+        matching gh calls bypassed the gate."""
+        marker_dir = isolated_home / ".claude" / ".respond-pr-active.d"
+        marker_dir.mkdir(parents=True)
+        (marker_dir / "session-A").touch()
+        assert (
+            run_hook(
+                RESPOND_PR_HOOK,
+                bash_input("gh api repos/foo/bar/pulls/5/comments", session_id="session-B"),
+                cwd=current_repo_foo_bar,
+            )
+            == "deny"
+        )
+
+    def test_no_session_id_in_input_denies(self, isolated_home, current_repo_foo_bar):
+        """Without session_id in the hook payload, bypass is impossible —
+        deny even if a marker file exists in the dir."""
+        marker_dir = isolated_home / ".claude" / ".respond-pr-active.d"
+        marker_dir.mkdir(parents=True)
+        (marker_dir / "any-session").touch()
+        # bash_input() with session_id=None omits the field entirely.
+        assert (
+            run_hook(
+                RESPOND_PR_HOOK,
                 bash_input("gh api repos/foo/bar/pulls/5/comments"),
                 cwd=current_repo_foo_bar,
             )
             == "deny"
+        )
+
+    def test_marker_dir_missing_denies(self, isolated_home, current_repo_foo_bar):
+        """Sessions dir entirely absent (e.g., capture-session-id.sh never
+        ran) → deny. The skill is responsible for failing loudly in that
+        case; the hook just denies safely."""
+        assert (
+            run_hook(
+                RESPOND_PR_HOOK,
+                bash_input("gh api repos/foo/bar/pulls/5/comments", session_id="some-session"),
+                cwd=current_repo_foo_bar,
+            )
+            == "deny"
+        )
+
+    def test_bypass_refreshes_marker_mtime(self, isolated_home, current_repo_foo_bar):
+        """Long-running skill mitigation: the hook touches the marker on
+        each bypass so a respond-pr session approaching the 60-minute
+        staleness cutoff doesn't get blocked mid-execution."""
+        sid = "long-run-session"
+        marker_dir = isolated_home / ".claude" / ".respond-pr-active.d"
+        marker_dir.mkdir(parents=True)
+        marker = marker_dir / sid
+        marker.touch()
+        fifty_min_ago = time.time() - 50 * 60
+        os.utime(marker, (fifty_min_ago, fifty_min_ago))
+        pre_mtime = marker.stat().st_mtime
+        assert (
+            run_hook(
+                RESPOND_PR_HOOK,
+                bash_input("gh api repos/foo/bar/pulls/5/comments", session_id=sid),
+                cwd=current_repo_foo_bar,
+            )
+            == "allow"
+        )
+        post_mtime = marker.stat().st_mtime
+        assert post_mtime > pre_mtime, (
+            "marker mtime must be refreshed on bypass to keep long skill runs alive"
         )
 
     def test_non_bash_tool_allowed(self, isolated_home):
@@ -364,6 +457,71 @@ class TestRequireRespondPr:
             )
             == "deny"
         )
+
+
+# ---------------------------------------------------------------------------
+# capture-session-id.sh
+# ---------------------------------------------------------------------------
+
+
+class TestCaptureSessionId:
+    """SessionStart hook that bootstraps the session_id ↔ claude-PID
+    lookup file. Skill bodies running as Bash tool calls don't see the
+    hook payload; they read ~/.claude/sessions/$PPID to learn their own
+    session_id (where $PPID is the claude main process PID).
+
+    The hook must never block session startup, so every error path exits 0.
+    """
+
+    def _sessions_files(self, home: Path) -> list[Path]:
+        sessions_dir = home / ".claude" / "sessions"
+        if not sessions_dir.exists():
+            return []
+        return list(sessions_dir.iterdir())
+
+    def test_valid_input_writes_lookup_file(self, isolated_home):
+        sid = "abc-123-session"
+        run_hook(CAPTURE_SESSION_ID_HOOK, {"session_id": sid})
+        files = self._sessions_files(isolated_home)
+        assert len(files) == 1, f"expected one lookup file, got {files}"
+        assert files[0].read_text().strip() == sid
+        # Filename is the claude_pid the hook resolved via `ps -o ppid=`.
+        # We don't pin the exact value (depends on test runner topology),
+        # but it must be a positive integer.
+        assert files[0].name.isdigit() and int(files[0].name) > 0
+
+    def test_empty_session_id_writes_nothing(self, isolated_home):
+        run_hook(CAPTURE_SESSION_ID_HOOK, {"session_id": ""})
+        assert self._sessions_files(isolated_home) == []
+
+    def test_missing_session_id_field_writes_nothing(self, isolated_home):
+        run_hook(CAPTURE_SESSION_ID_HOOK, {"some_other_field": "value"})
+        assert self._sessions_files(isolated_home) == []
+
+    def test_empty_stdin_does_not_block_or_write(self, isolated_home):
+        """Empty payload must not block session start."""
+        result = subprocess.run(
+            [str(CAPTURE_SESSION_ID_HOOK)],
+            input="",
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0
+        assert self._sessions_files(isolated_home) == []
+
+    def test_malformed_json_does_not_block(self, isolated_home):
+        """SessionStart hook must never fail-closed on payload corruption —
+        a broken hook would prevent the session from starting."""
+        result = subprocess.run(
+            [str(CAPTURE_SESSION_ID_HOOK)],
+            input="not valid json {{",
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0
+        assert self._sessions_files(isolated_home) == []
 
 
 # ---------------------------------------------------------------------------

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -1,5 +1,15 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/capture-session-id.sh"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",

--- a/claude/.claude/skills/respond-pr/SKILL.md
+++ b/claude/.claude/skills/respond-pr/SKILL.md
@@ -10,7 +10,11 @@ Fetch all review comments on the current branch's open pull request and address 
 
 ## Steps
 
-0. **Enable hook bypass.** Run `mkdir -p ~/.claude && touch ~/.claude/.respond-pr-active`. The `require-respond-pr.sh` PreToolUse hook checks for this marker and lets this skill's own `gh` commands through while the marker is fresh (<60 minutes old). Without this step, every `gh api` call below will be blocked by the very gate that redirected you here.
+0. **Enable hook bypass.** Run:
+   ```
+   SESSION_ID=$(cat "$HOME/.claude/sessions/$PPID") && [ -n "$SESSION_ID" ] && mkdir -p "$HOME/.claude/.respond-pr-active.d" && touch "$HOME/.claude/.respond-pr-active.d/$SESSION_ID"
+   ```
+   The `require-respond-pr.sh` PreToolUse hook bypasses while THIS session's marker is fresh (<60 min) and refreshes its mtime on each bypass so long runs don't hit the staleness cutoff. Per-session keying prevents parallel respond-pr sessions from thrashing on cleanup or leaking bypass to unrelated sessions. If the chain fails (empty `SESSION_ID`, etc.), the `capture-session-id.sh` SessionStart hook didn't run — abort and report; do not proceed without the marker, since every gated `gh` call below will be blocked.
 1. Identify the PR number for the current branch: `gh pr view --json number -q '.number'`
 2. Fetch **all three** types of comments. Two failure modes Claude commonly hits: (a) fetching only the first type and missing the other two; (b) fetching without `--paginate` and silently truncating at 30 results per type. Both produce reviews that look complete but miss real feedback.
    - **Inline file comments:** `gh api repos/{owner}/{repo}/pulls/{number}/comments --paginate`
@@ -23,7 +27,11 @@ Fetch all review comments on the current branch's open pull request and address 
    - If it's a question or discussion point, draft a clear response
 4. Post replies using the GitHub API with `in_reply_to` (use `-F` for integer IDs)
 5. Commit and push any code changes in a single commit
-6. **Remove the hook bypass marker:** `rm -f ~/.claude/.respond-pr-active`. If the skill errors out before reaching this step, don't manually clean up — the hook's 60-minute staleness cutoff handles orphaned markers automatically.
+6. **Remove this session's hook bypass marker:**
+   ```
+   SESSION_ID=$(cat "$HOME/.claude/sessions/$PPID" 2>/dev/null) && [ -n "$SESSION_ID" ] && rm -f "$HOME/.claude/.respond-pr-active.d/$SESSION_ID"
+   ```
+   Removes only this session's file. If the skill errors out before reaching this step, don't manually clean up — the hook's 60-minute staleness cutoff handles the orphan automatically.
 
 ## Attribution
 


### PR DESCRIPTION
## Summary

The `respond-pr` skill's bypass marker was a singleton at `~/.claude/.respond-pr-active`. Two parallel-session failure modes:

1. **Cleanup thrash** — session A's `rm -f` deletes the marker session B is still using; B's subsequent `gh` calls get blocked mid-skill.
2. **Bypass leak (silent)** — while *any* session held the marker, every other session's matching `gh` calls bypassed the gate. Unrelated sessions silently skipped the skill, fetching only inline comments (missing top-level reviews and issue-level comments) and posting replies without the `[Claude Code]` attribution prefix.

This PR replaces the singleton with per-session keying tied to the hook payload's documented `session_id` field.

## Design

- **Marker path:** `~/.claude/.respond-pr-active.d/<session_id>` (one file per session).
- **Hook:** `require-respond-pr.sh` reads `session_id` from its JSON input, bypasses only if *this session's* marker exists and is fresh (<60 min). Refreshes the marker's mtime on each bypass so long skill runs don't hit the staleness cutoff mid-execution.
- **Skill:** Step 0 looks up the session's `session_id` and writes the per-session marker. Step 6 removes only its own marker.
- **Bootstrap:** new SessionStart hook `capture-session-id.sh` writes `~/.claude/sessions/<claude-pid>` at session start so the skill (running as Bash tool calls without access to the hook payload) can look up its own `session_id` via the bash tool's `$PPID` (which is the claude main process directly).

## Why session_id, not PPID

Initially considered a `$PPID`-based scheme. An empirical probe of the hook process tree disproved the assumption it relied on: the hook is invoked through a transient `sh` shim, so its `$PPID` is that shim, not `claude`. The bash tool's `$PPID` *is* `claude`. They are not the same process. `session_id` from the JSON payload is the documented harness contract and is schema-stable; the probe confirmed it's reliably populated.

## Test plan

192 tests, all passing. New coverage in `claude/.claude/hooks/tests/test_hooks.py`:

- [x] `test_other_sessions_marker_does_not_leak_bypass` — regression test for the silent-bypass-leak failure mode (session A's marker must not authorize session B's gated calls).
- [x] `test_no_session_id_in_input_denies` — empty `session_id` in payload → deny, even if marker files exist.
- [x] `test_marker_dir_missing_denies` — sessions dir absent → deny.
- [x] `test_bypass_refreshes_marker_mtime` — long-run mitigation: hook touches the marker on bypass.
- [x] `TestCaptureSessionId` — happy path, empty `session_id`, missing field, malformed JSON, empty stdin (all must exit 0; SessionStart must never block startup).

Manual smoke (post-merge, after `git pull` to pick up the SessionStart hook):
- [ ] Run `/respond-pr` against a real PR; verify it completes cleanly.
- [ ] Open two Claude sessions in parallel; confirm cleanup thrash is gone.
- [ ] Verify a third session's `gh api .../pulls/N/comments` is *blocked* while the other two have active markers (regression check for the leak).

## Migration

Existing users can `rm -f ~/.claude/.respond-pr-active` after this lands — the singleton path is no longer read. Harmless if left in place; just an orphan file.

## Out of scope (follow-ups)

The `code-review` marker at `~/.claude/review-markers/<repo-hash>` has its own narrower parallel-session concern (two sessions in the same worktree staging different diffs collide). Different shape from this fix; tracked for a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)