### PR TITLE
Reserve PROJ- and TICKET- as placeholder tracker prefixes in redaction gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,9 +52,7 @@ specific private project, engagement, or private codebase. Categories:
   Default: if in doubt, strip it. When an example or commit message
   needs a tracker-ID-shaped placeholder, use `PROJ-<digits>` or
   `TICKET-<digits>` — both prefixes are reserved as placeholders
-  and pass the allowlist with any digit suffix. Don't obfuscate
-  the digits (e.g. to `NNN`); the placeholder is supposed to show
-  the shape of a real tracker ID, which obfuscation hides.
+  and pass the allowlist with any digit suffix.
 - **Internal URLs, hostnames, Slack channels, project domains**.
 - **Absolute filesystem paths** that embed project names
   (`~/Code/acme-platform/...`, `/home/foo/WorkForProject/...`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,12 @@ specific private project, engagement, or private codebase. Categories:
   `[A-Z]{2,}-\d+` that is *not* on this allowlist of standard
   open-source references: `CVE-`, `RFC-`, `PEP-`, `ISO-`, `GH-`,
   `BUG-` / bugzilla-style, and clearly-public project prefixes.
-  Default: if in doubt, strip it.
+  Default: if in doubt, strip it. When an example or commit message
+  needs a tracker-ID-shaped placeholder, use `PROJ-<digits>` or
+  `TICKET-<digits>` — both prefixes are reserved as placeholders
+  and pass the allowlist with any digit suffix. Don't obfuscate
+  the digits (e.g. to `NNN`); the placeholder is supposed to show
+  the shape of a real tracker ID, which obfuscation hides.
 - **Internal URLs, hostnames, Slack channels, project domains**.
 - **Absolute filesystem paths** that embed project names
   (`~/Code/acme-platform/...`, `/home/foo/WorkForProject/...`).

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ This repo is public, so any project codename, organization name, or tracker-ID t
 
 Two scans run, in order:
 
-1. **Tracker-ID scan (always on, no setup).** Matches `[A-Z]{2,}-\d+` tokens not on the OSS allowlist.
+1. **Tracker-ID scan (always on, no setup).** Matches `[A-Z]{2,}-\d+` tokens not on the OSS allowlist. The allowlist also reserves two placeholder prefixes — `PROJ-` and `TICKET-` — so skill examples and commit messages can use a realistic-looking tracker shape (`PROJ-<digits>`, `TICKET-<digits>`) without obfuscating the digits to defeat the scan.
 2. **Private-projects blocklist (opt-in).** Reads `~/.claude/private-projects.md` at hook runtime and blocks commits/PRs whose content contains any non-comment, non-blank line from the file as a case-insensitive whole-word match.
 
 ### Opt-in: enable the blocklist

--- a/claude/.claude/hooks/deny-private-project-refs.sh
+++ b/claude/.claude/hooks/deny-private-project-refs.sh
@@ -144,7 +144,11 @@ fi
 #                                 JEP / JDK (OpenJDK), LLVM, GCC
 #   Technical constants that      SHA, MD, HTTP, HTTPS, TLS, SSL
 #   happen to match [A-Z]{2,}-\d+:
-OSS_ALLOWLIST='^(CVE|CWE|RFC|PEP|ISO|IETF|W3C|NIST|ECMA|ANSI|GH|BUG|JEP|JDK|LLVM|GCC|SHA|MD|HTTP|HTTPS|TLS|SSL)-'
+#   Designated placeholders:      PROJ, TICKET — reserved for examples
+#                                 and docs; see repo CLAUDE.md
+#                                 "Redact private-project-identifying
+#                                 content" for the rationale.
+OSS_ALLOWLIST='^(CVE|CWE|RFC|PEP|ISO|IETF|W3C|NIST|ECMA|ANSI|GH|BUG|JEP|JDK|LLVM|GCC|SHA|MD|HTTP|HTTPS|TLS|SSL|PROJ|TICKET)-'
 
 # Extract paths passed to any gh-pr body-source flag. Covers:
 #   --body-file <path>    --body-file=<path>

--- a/claude/.claude/hooks/tests/test_hooks.py
+++ b/claude/.claude/hooks/tests/test_hooks.py
@@ -513,11 +513,14 @@ class TestDenyPrivateProjectRefs:
             "Deprecate MD-5",
             "Support HTTP-2",
             "Disable TLS-1",
+            "See PROJ-123 for the placeholder convention",
+            "See TICKET-456 for the placeholder convention",
         ],
         ids=[
             "cve", "cwe", "pep", "rfc", "gh", "bug", "iso", "ietf",
             "w3c", "nist", "ecma", "ansi", "jep", "jdk", "llvm", "gcc",
             "sha", "md", "http", "tls",
+            "proj_placeholder", "ticket_placeholder",
         ],
     )
     def test_allowlisted_references_allowed(self, claude_config_repo, message):
@@ -531,6 +534,29 @@ class TestDenyPrivateProjectRefs:
             run_hook(
                 DENY_PRIVATE_PROJECT_REFS_HOOK,
                 bash_input("git commit -m 'Fix WIDGET-123 regression'"),
+                cwd=claude_config_repo,
+            )
+            == "deny"
+        )
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "Fix MYPROJ-7 regression",
+            "Address SUPERTICKET-1 review",
+            "Bump BIGPROJ-99 dep",
+            "Land OURTICKET-42 follow-up",
+        ],
+        ids=["myproj", "superticket", "bigproj", "ourticket"],
+    )
+    def test_placeholder_prefix_substring_still_denied(self, claude_config_repo, message):
+        """Anchor (`^`) on OSS_ALLOWLIST must keep prefixes that *contain*
+        but don't *equal* PROJ / TICKET in the deny path. Without this
+        test, a refactor that drops the anchor would pass CI silently."""
+        assert (
+            run_hook(
+                DENY_PRIVATE_PROJECT_REFS_HOOK,
+                bash_input(f"git commit -m '{message}'"),
                 cwd=claude_config_repo,
             )
             == "deny"


### PR DESCRIPTION
## Summary

- Adds two prefixes to `deny-private-project-refs.sh`'s `OSS_ALLOWLIST` so tracker-ID-shaped placeholders in skill examples, docs, and commit messages don't have to be obfuscated (e.g. to all-letter forms) to defeat the redaction scan. Obfuscation defeats the placeholder's purpose — the example is supposed to show the *shape* of a real tracker ID.
- Adds positive tests (placeholder tokens are now allowed) and a negative regression test that locks in the `^` anchor's protection against prefix substrings — tokens that share a tail with an allowlisted prefix but don't start with it must still deny. Without this test, a future regex refactor that drops the anchor would pass CI silently.
- Updates the repo-root `CLAUDE.md` "Redact private-project-identifying content" section and the `README.md` "Private-project redaction" section to document the new placeholder convention.

## Tradeoff

A real private project that uses one of these reserved prefixes as its actual tracker prefix would no longer be caught by the mechanical scan. The user-local `~/.claude/private-projects.md` blocklist remains the fallback for that case — adding the project name to that file catches surrounding context. Both reserved prefixes are conventionally placeholder shapes and unlikely to be a real tracker key.

## Test plan

- [x] `python3 -m pytest test_hooks.py` — 189 passed (was 185 on main; +2 positive placeholder cases, +4 negative substring cases).
- [x] Specialist reviews (security + hook correctness) ran; one BLOCKER raised (missing negative test) and one comment-budget NIT — both addressed before this PR.
- [ ] After merge: PR #43's obfuscated placeholder can be swapped back to a real-shaped tracker ID, since the scan will accept it once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)