### PR TITLE
Revert TICKET-NNN placeholder obfuscation now that hook accepts digit form

### DIFF
--- a/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
+++ b/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
@@ -99,7 +99,7 @@ and [Chroma's Context Rot research](https://research.trychroma.com/context-rot):
 
 ### Don't embed PR or ticket refs in always-loaded files
 
-`Precedent: PR #105` and `See TICKET-NNN` rot the moment the next PR
+`Precedent: PR #105` and `See TICKET-123` rot the moment the next PR
 lands and cost per-session context budget. Put them in commit messages,
 PR descriptions, or plan files — state the rule, not the precedent.
 


### PR DESCRIPTION
## Summary

PR #45 (just merged) reserved `TICKET-` as an allowlisted placeholder prefix in `deny-private-project-refs.sh`, so the obfuscation introduced as a workaround on PR #43 is no longer needed. This swap reverts the placeholder example in `ai-instruction-and-memory-files/SKILL.md` to a digit-bearing shape — matching what real tracker IDs look like, which is the point of having a placeholder in the first place.

## Test plan

- [x] Hook tests still pass on main (verified by PR #45 CI).
- [x] Redaction gate accepts the digit form locally (this very PR went through the hook without manual override).

🤖 Generated with [Claude Code](https://claude.com/claude-code)