### PR TITLE
README: document supported platforms (Linux/macOS/WSL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,12 @@
 
 Portable [Claude Code](https://claude.ai/claude-code) global configuration: custom skills, PreToolUse hooks that gate `git commit` and PR-comment flows, and a custom statusline. Runs on any Unix-like system (Linux, macOS, WSL). Managed with [GNU Stow](https://www.gnu.org/software/stow/).
 
-## Prerequisites
+## Requirements
 
-`stow`, `git`, `gh`, `jq`, `sha256sum`. `install.sh` verifies they exist and exits early if any are missing.
+- **Operating system:** Linux, macOS, or WSL2. Native Windows (PowerShell / cmd.exe) is not supported — every hook is a bash script and `install.sh` uses GNU `stow` with symlinks. If you're on Windows, install inside [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) instead.
+- **Shell:** `bash`. Hooks and `install.sh` use `#!/bin/bash`.
+- **Tools:** `stow`, `git`, `gh`, `jq`, `sha256sum`, and the `claude` CLI. `install.sh` verifies they exist and exits early if any are missing.
+- **Optional:** `pytest` for running the hook test suite (`pytest claude/.claude/hooks/tests/`).
 
 **macOS:** `sha256sum` ships in GNU `coreutils`. Install with `brew install coreutils`, then add the gnubin directory to PATH so the unprefixed name resolves: `export PATH="$(brew --prefix coreutils)/libexec/gnubin:$PATH"`.
 


### PR DESCRIPTION
## Summary

Adds a **Requirements** section to the README so a user evaluating the repo on GitHub can see, before cloning, that native Windows (PowerShell / cmd.exe) is not supported and they should install in WSL instead. Today the description line mentions "Runs on any Unix-like system (Linux, macOS, WSL)" but the only structured surface was a bare tools list under **Prerequisites** — easy to miss the OS implication. The Prerequisites heading is renamed to **Requirements** and gains an OS bullet plus a shell bullet; the existing tools and macOS-sha256sum content carry over.

No code changes. Audit was read-only.

## Audit findings

Verified each claim against the worktree state:

- **Hooks:** all six `claude/.claude/hooks/*.sh` use `#!/bin/bash`. No `.py` / `.sh` non-bash / `.zsh` siblings.
- **install.sh:** `#!/bin/bash`; runs `stow -v --adopt -t "$HOME" claude` at line 18 (GNU stow's `--adopt` flag is not in BSD-stow alternatives). Symlinks are the install mechanism.
- **Dependency check** (install.sh:7) covers exactly: `stow git gh jq sha256sum claude` — matches the README tools list verbatim.
- **Test suite:** pytest under `claude/.claude/hooks/tests/test_hooks.py`. install.sh:66 already prints `pytest claude/.claude/hooks/tests/` as the suggested invocation; the README mirrors that.
- **No hard Linux-syscall / `/proc` / `/dev` dependencies.** `deny-private-project-refs.sh` references `/dev/stdin` and `/proc/*/fd/*` only as defensive rejection patterns for pseudo-file paths — they are guards, not requirements.
- **macOS:** existing sha256sum-via-`brew install coreutils` note carried over unchanged.

Every dependency the bundle uses is available on Linux, macOS, and WSL2. WSL2 is inferred from the audit, not smoke-tested end-to-end — flagged in the commit message.

## Out of scope

No code changes to make scripts work on native Windows. No CI shell-script linting. No `install.sh` reorganization. No WSL setup walkthrough — link to upstream Microsoft docs only.

## Test plan

- [ ] Render README on github.com after push and confirm the new **Requirements** section reads cleanly and fits the surrounding tone.
- [ ] Confirm the repo description line ("Runs on any Unix-like system (Linux, macOS, WSL)") and the new **Requirements** section don't contradict each other.