### PR TITLE
CLAUDE.md: AI agents don't merge their own PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,14 @@ a feature, edit the committed file directly via PR. For per-user
 private context, use a non-stowed location like
 `~/.claude/private-projects.md` (opt-in, not part of the stow tree).
 
+## AI agents: don't merge your own PRs
+
+In this repo, an AI agent that opens a PR does not also merge it.
+CI passing is necessary but not sufficient — wait for the user's
+explicit "merge it" before running `gh pr merge`. Open-ended verbs
+like "handle" or "do the swap" cover writing the change and opening
+the PR, not landing it.
+
 ## When editing a skill, run the skill on its own diff
 
 A skill's body states the rules it enforces; an edit can violate


### PR DESCRIPTION
## Summary

Adds a short CLAUDE.md section that names `gh pr merge` explicitly as something an AI agent in this repo should not run without explicit user approval, even if CI is green. The global "confirm risky actions" rule covers this in principle, but it's clearly easy to misread an open-ended verb like "handle X" as durable authorization for the merge step too — surfaced after a 1-line follow-up PR was auto-merged in this repo.

## Test plan

- [x] CLAUDE.md hook tests still pass (no logic change in hooks).
- [ ] Reviewer eyes on wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)