### PR TITLE
code-review: generalize self-scoping principle to ripple-triage

### DIFF
--- a/claude/.claude/skills/code-review/SKILL.md
+++ b/claude/.claude/skills/code-review/SKILL.md
@@ -205,6 +205,18 @@ diff fresh from its own perspective; passing a summarized review as a
 substitute for the source drops the signal that specialist review is
 designed to catch.
 
+The Change type column keys on what the change *does for an operator
+or consumer*, not on which file types changed. A markdown-only diff
+can still cross a runtime-config or CI/CD boundary if it establishes,
+documents, restructures, or formalizes the taxonomy operators use to
+provision secrets, identify deploy targets, or reason about config
+layering. When a row's trigger language is plausibly in scope but the
+file types don't make it obvious, default to firing the named
+reviewers — they self-scope against the diff and return early when the
+change is out of their lane. The cost is one subagent turn returning
+"no concerns"; the upside is catching impacts the dispatcher can't
+see from file paths alone.
+
 Evaluate the change against these cross-boundary patterns. Update this
 table as new patterns emerge.
 


### PR DESCRIPTION
## Summary

- Lifts the "agents self-scope; dispatcher only has paths" principle out of the Step 0 schema paragraph and applies it to the ripple-effect triage section as a general default.
- Adds a single paragraph noting that the Change type column keys on what the diff *does for an operator or consumer*, not on which file types changed.
- Closes the gap where a docs-only diff that establishes, documents, restructures, or formalizes runtime-config / CI-CD taxonomy reads as out of scope to a strict file-type read of the runtime-config row's trigger language ("env vars, secrets, feature flags") even though the operator-facing impact is squarely in that lane.

## Why

The runtime-config row's trigger language reads as "actual env-var change," and a markdown-only diff documenting where production secrets live (or how config layers, or how deploy targets are identified) doesn't clearly match — but the impact on the operator is the same. The schema-paragraph self-scoping rule that #34 introduced was the right pattern, just scoped too narrowly to schema diffs.

## Out of scope

- Per-row trigger rewrites (the generalized principle handles them).
- Agent file changes.
- `plan-review` skill edits.

## Test plan

- [ ] Read the updated ripple-triage section as if running `/code-review` on a docs-only PR documenting secrets-management taxonomy. The new paragraph should make it obvious to fire `staff-platform-engineer + ciso-reviewer` even though no env var actually changed.
- [ ] Confirm the existing "Spawn on the CODE, not on this review's output" paragraph (immediately above) still reads correctly — the new paragraph extends it, doesn't replace it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)