### PR TITLE
skills + agents: reduce overlap; tighten shared concerns

### DIFF
--- a/claude/.claude/agents/ciso-reviewer.md
+++ b/claude/.claude/agents/ciso-reviewer.md
@@ -36,9 +36,7 @@ If the change is bounded to cosmetic-only edits (typo fixes, formatting, copy po
 
 **Secret lifecycle** — new tokens/keys: provisioning, rotation, revocation. Logged anywhere (full request bodies, error payloads, audit tables)?
 
-**Defense in depth** — more than one layer of enforcement. "The policy handles it" without an in-code check is single-layer.
-
-**Error messages** — leak internal IDs, stack traces, query text, existence-of-record signals an attacker could enumerate.
+**Defense in depth** — flag single-layer designs even when the one layer is correct. "RLS handles it" without an in-code check, or an in-code check without a policy backstop, is a finding regardless of whether the layer present is sound.
 
 **Audit log integrity** — for security-relevant events (privileged actions, access grants, secret changes): log entry written, immutable, tamper-evident.
 

--- a/claude/.claude/agents/staff-backend-engineer.md
+++ b/claude/.claude/agents/staff-backend-engineer.md
@@ -48,8 +48,6 @@ If the diff is purely frontend, purely infra config with no behavior change, or 
 
 **Server-side event emission** — cron jobs, webhooks, batch flows emitting product analytics events (subscription renewal, system-initiated flows) or APM events. Verify emission is present, fires on success AND retry paths, and matches the product event contract. Product event SEMANTICS are owned by `staff-product-engineer`; you own emission correctness at server callsites.
 
-**Hot-path performance** — queries in loops, N+1 patterns, unbounded list operations, synchronous work in request handlers, missing pagination/limits on user-supplied inputs.
-
 **Application data-store schema design** — for every changed or new schema:
 - **Relational**: column type choice (`text` vs `varchar(n)` is engine-specific — Postgres treats them as equivalent and prefers `text`; MySQL / SQL Server differ; pick per the project's engine), `timestamp` vs `timestamptz` (default `timestamptz` unless a specific reason), `numeric` precision/scale on money, `uuid` vs `bigint` PK tradeoffs, `jsonb` vs dedicated columns, enum vs lookup table; constraint design (uniqueness, FK actions, check constraints); index coverage for application hot queries.
 - **NoSQL** (DynamoDB, Mongo, Cassandra, Cosmos, Firestore, etc.): partition-key choice and write-heat distribution, GSI / LSI design and write-cost economics, single-table vs multi-table tradeoffs, document-shape evolution and version-field discipline, secondary-index access patterns.

--- a/claude/.claude/agents/staff-backend-engineer.md
+++ b/claude/.claude/agents/staff-backend-engineer.md
@@ -48,6 +48,8 @@ If the diff is purely frontend, purely infra config with no behavior change, or 
 
 **Server-side event emission** — cron jobs, webhooks, batch flows emitting product analytics events (subscription renewal, system-initiated flows) or APM events. Verify emission is present, fires on success AND retry paths, and matches the product event contract. Product event SEMANTICS are owned by `staff-product-engineer`; you own emission correctness at server callsites.
 
+**Per-request work shape** — inside request handlers and per-item loop bodies, flag DB / network calls invoked per element, synchronous blocking calls on async paths, and unbounded inputs without a server-side cap.
+
 **Application data-store schema design** — for every changed or new schema:
 - **Relational**: column type choice (`text` vs `varchar(n)` is engine-specific — Postgres treats them as equivalent and prefers `text`; MySQL / SQL Server differ; pick per the project's engine), `timestamp` vs `timestamptz` (default `timestamptz` unless a specific reason), `numeric` precision/scale on money, `uuid` vs `bigint` PK tradeoffs, `jsonb` vs dedicated columns, enum vs lookup table; constraint design (uniqueness, FK actions, check constraints); index coverage for application hot queries.
 - **NoSQL** (DynamoDB, Mongo, Cassandra, Cosmos, Firestore, etc.): partition-key choice and write-heat distribution, GSI / LSI design and write-cost economics, single-table vs multi-table tradeoffs, document-shape evolution and version-field discipline, secondary-index access patterns.

--- a/claude/.claude/agents/staff-data-engineer.md
+++ b/claude/.claude/agents/staff-data-engineer.md
@@ -42,8 +42,6 @@ Migration safety is **three-way co-owned** with `staff-backend-engineer` (writes
 
 **PII column candidates** — flag new columns shaped like PII (email, phone, address, government-ID-shaped, free-text-likely-to-contain-PII) for the team to evaluate tagging or field-level encryption. Do not assert what the catalog or governance policy must do — flag the candidate.
 
-**RLS / row-security policy coverage** — new tables without row security are accessible to any authenticated client via auto-exposed APIs (PostgREST, Hasura, generated resolvers). Flag missing policies. Co-owned with `ciso-reviewer` (you own enforceability; they own threat framing).
-
 **Type co-review carve-out** — backend owns column type choice, but you flag three categories with downstream pipeline implications:
 - `timestamptz` vs `timestamp` (CDC and replication correctness footgun)
 - `numeric` precision/scale on money columns (downstream warehouse cast pain)

--- a/claude/.claude/agents/staff-frontend-engineer.md
+++ b/claude/.claude/agents/staff-frontend-engineer.md
@@ -20,11 +20,13 @@ If the diff is purely backend, infrastructure, server-only types with no contrac
 
 **Optimistic mutation lifecycle (universal invariant)** — optimistic writes must: (a) cancel in-flight refetches first, (b) snapshot current state, (c) apply optimistic update, (d) on error, restore from snapshot — not a try/catch branch, (e) on settled, invalidate relevant queries, (f) the mutation function must throw on error so rollback fires. Ad-hoc optimistic writes outside a mutation lifecycle are a bug class. TanStack Query's `onMutate`/`onError`/`onSettled` is one canonical implementation; SWR, Apollo, custom reducers must express the same invariants.
 
-**Query contract mapping** — when the backend shape changes, do the client selector, type, and cache key all match? Co-owned with backend.
+**Query contract mapping** — when backend response shape changes, do client selectors, types, AND cache keys all match? Co-owned with backend.
 
-**Auth state transitions** — logged-in ↔ logged-out, token refresh, session expiry: does the UI handle transitions explicitly or show stale user data for a render before the redirect?
+**Auth state transitions** — logged-in ↔ logged-out, token refresh, session expiry — handle the transition explicitly or risk a stale-user-data render before the redirect.
 
-**Loading, error, empty (code-level)** — for every new or changed data-fetching path, are all three states handled, or only the happy path?
+**Per-state coverage on data-fetching paths** — loading, error, empty, success: all four states handled, not just the happy path.
+
+**Render stability and bundle hygiene** — inline literals in JSX props re-rendering children, missing list `key`s, un-memoized hot work; full-library imports where tree-shaking would suffice; unlazy-loaded images without intrinsic dimensions.
 
 **Routing and navigation** — route guards, scroll restoration, deep-linkable state, 404/unauthorized routes, programmatic vs declarative nav, back-button after mutation.
 
@@ -34,15 +36,11 @@ If the diff is purely backend, infrastructure, server-only types with no contrac
 
 **SSR / hydration** (where applicable) — hydration mismatches, client-only guards, server-safe imports, flash-of-unauthorized-content.
 
-**Accessibility (code-level)** — interactive elements with accessible names, keyboard operation for non-button click handlers, focus management in modals/drawers (focus trap, return-focus-on-close), skip links, live regions for async status, ARIA on the right role, `prefers-reduced-motion`, focus-visible, color contrast.
+**Accessibility beyond the obvious** — focus management in modals/drawers (focus trap, return-focus-on-close), skip links, live regions for async status, `prefers-reduced-motion`, focus-visible. The skill checklist covers named-element basics; this angle is the patterns assistive-technology users hit that authors miss.
 
 **Internationalization and typography** — hardcoded strings where i18n exists, date / number / currency formatting, `dir` for RTL, truncation on long strings, locale-specific input formats (postal codes, phone numbers).
 
 **Web Vitals** — LCP (largest contentful paint), CLS (layout shift — intrinsic image dimensions, reserve space), INP (interaction to next paint — main-thread work during user input).
-
-**Bundle and asset hygiene** — full-library imports where tree-shaking would suffice, large deps for one helper, unlazy-loaded images, missing `loading="lazy"` and intrinsic dimensions.
-
-**Render stability** — new inline object/array/function literals in JSX props forcing child re-renders, missing `key` on list items, expensive work not memoized in frequently-rendering components.
 
 **Client-side PII and token leakage** — tokens in `localStorage`, PII in analytics/Sentry breadcrumbs, sensitive data in URL query strings.
 

--- a/claude/.claude/agents/staff-frontend-engineer.md
+++ b/claude/.claude/agents/staff-frontend-engineer.md
@@ -20,6 +20,8 @@ If the diff is purely backend, infrastructure, server-only types with no contrac
 
 **Optimistic mutation lifecycle (universal invariant)** — optimistic writes must: (a) cancel in-flight refetches first, (b) snapshot current state, (c) apply optimistic update, (d) on error, restore from snapshot — not a try/catch branch, (e) on settled, invalidate relevant queries, (f) the mutation function must throw on error so rollback fires. Ad-hoc optimistic writes outside a mutation lifecycle are a bug class. TanStack Query's `onMutate`/`onError`/`onSettled` is one canonical implementation; SWR, Apollo, custom reducers must express the same invariants.
 
+**Async cancellation and effect lifecycle** — `useEffect` cleanup must abort or no-op pending work to avoid stale-closure writes / setState-on-unmounted; user-initiated requests need an `AbortController` so a faster keystroke doesn't lose to a slower stale response (request race); long-running effects need a cancellation token that the cleanup actually triggers.
+
 **Query contract mapping** — when backend response shape changes, do client selectors, types, AND cache keys all match? Co-owned with backend.
 
 **Auth state transitions** — logged-in ↔ logged-out, token refresh, session expiry — handle the transition explicitly or risk a stale-user-data render before the redirect.

--- a/claude/.claude/agents/staff-platform-engineer.md
+++ b/claude/.claude/agents/staff-platform-engineer.md
@@ -16,21 +16,19 @@ If the diff is pure application logic with no operational surface delta, or a co
 
 ## Review angles — pipelines, IaC, shell
 
-**Environment parity** — change works the same on dev machines, CI runners, and production. OS, shell version, installed tools, case sensitivity, PATH.
+**Environment parity** — pipeline behavior differs across local / CI / staging / prod (OS, shell version, tools, PATH).
 
-**Trigger scope** — for CI workflows, do triggers (branch, path, actor, event) match job purpose? "Lint on PR" firing on bot commits wastes minutes; "deploy on push to main" firing on draft PRs is dangerous.
+**Trigger scope and concurrency** — workflow triggers (branch, path, actor, event) match job purpose; concurrency groups with `cancel-in-progress: true` don't kill unrelated important jobs via too-broad keys.
 
-**Concurrency groups** — workflow-level concurrency with `cancel-in-progress: true` can kill important running jobs. Check the group key scope.
+**Secret scoping** — secrets in `run:` echo, broad `env:` blocks, artifact uploads, command-line args (visible in `ps`); scope to the step that needs it.
 
-**Secret handling** — secrets in `run:` commands that echo, broad `env:` blocks, artifact uploads, command-line arguments (visible in `ps`). Scope to the step that needs it.
+**Workflow idempotency** — safe to re-run after partial failure (no unconditional creates, atomic state, cleanup on retry).
 
 **Artifact and action pinning** — third-party Actions pinned to commit SHA, not `@main`/`@v3` (mutable). `pull_request_target` misuse with PR-head checkout. Mutable container tags (`:latest` in production).
 
 **Runner trust** — self-hosted runners on public repos, `pull_request_target` + untrusted code, forks accessing secrets.
 
 **Terraform state** — remote backend configured, state locking, access control, `terraform apply` without plan review.
-
-**Idempotency of scripts/workflows** — safe to re-run after partial failure? Unconditional creates, non-atomic state updates, missing cleanup on retry.
 
 **Timeouts and resource limits** — `timeout-minutes` on jobs, unbounded retries, runaway bash `while` loops.
 

--- a/claude/.claude/skills/code-review/SKILL.md
+++ b/claude/.claude/skills/code-review/SKILL.md
@@ -94,13 +94,13 @@ are green.
 
 ## Domain: Data
 
-18. **Migration reversibility** — Can this migration be rolled back without data loss? Flag destructive operations (`DROP COLUMN`, `DROP TABLE`, type narrowing) that have no corresponding backup or reversal strategy.
+18. **Migration reversibility** — Destructive operations (`DROP COLUMN`, type narrowing, table drops) need a backup or reversal path.
 
-19. **Index coverage** — Do new queries or new foreign keys have supporting indexes? Flag new columns used in WHERE, JOIN, or ORDER BY clauses that lack indexes, especially on tables expected to grow.
+19. **Index coverage** — New `WHERE` / `JOIN` / `ORDER BY` columns and foreign keys need supporting indexes, especially on growing tables.
 
-20. **Lock safety** — Could this migration take a long-running lock on a large table? `ALTER TABLE` with defaults, `CREATE INDEX` without `CONCURRENTLY`, and backfills inside the migration are suspects.
+20. **Lock safety** — Flag long-locking DDL on large tables — `ALTER` with defaults, `CREATE INDEX` without `CONCURRENTLY`, in-migration backfills.
 
-21. **RLS and access control on new tables** — Do new tables have RLS enabled and appropriate policies? A new table with no RLS is accessible to any authenticated user via the PostgREST API.
+21. **RLS and access control on new tables** — New tables exposed via auto-generated APIs (PostgREST, Hasura, generated resolvers) need row-security enabled with policies.
 
 ## Domain: Frontend
 
@@ -114,11 +114,11 @@ are green.
 
 ## Domain: Backend
 
-26. **Auth boundary coverage** — Does every new endpoint or RPC have both authentication (who is the caller?) and authorization (can they do this?)? Check that auth checks are not bypassable by hitting the endpoint directly rather than through the expected UI flow.
+26. **Auth boundary coverage** — Every new endpoint or RPC needs both authentication (who) and authorization (can they) — and the check must not be bypassable by hitting the endpoint outside the UI flow.
 
-27. **Input validation at system boundaries** — Is user input validated/sanitized before use in SQL queries, shell commands, file paths, or external API calls? Framework-provided parameterization counts; string concatenation does not.
+27. **Input validation at system boundaries** — Validate/sanitize user input before SQL, shell, file paths, or outbound API calls — framework parameterization counts, string concatenation does not.
 
-28. **Error response leakage** — Do error responses expose internal details (stack traces, internal IDs, database error messages, file paths) to the caller? Internal errors should be logged server-side and return a generic message to the client.
+28. **Error response leakage** — Error responses must not expose internal details (stack traces, internal IDs, DB error text, file paths) — log server-side, return generic to the client.
 
 29. **Dependency upgrades** — Does the change upgrade a runtime or build dependency? Read the changelog for breaking changes and behavioral differences. Check for peer dependency conflicts and, for frontend dependencies, bundle size regression.
 

--- a/claude/.claude/skills/plan-review/SKILL.md
+++ b/claude/.claude/skills/plan-review/SKILL.md
@@ -130,23 +130,18 @@ B15. **Effort section reality** — If the plan has an "Estimated Effort" (or
 
 Apply when the plan touches CI/CD, workflows, deployment, or config.
 
-I1. **Environment parity** — Will the change work in all environments (local dev,
-    CI, staging, production)? Plans that work locally but fail in CI (different OS,
-    missing tools, permission differences) are common.
+I1. **Environment parity** — Does the plan work the same across local, CI, staging,
+    and production (OS, installed tools, permissions)?
 
-I2. **Idempotency** — Can the infrastructure change be applied multiple times safely?
-    Migrations, deployments, and config changes should not fail on re-run.
+I2. **Idempotency** — Can each infrastructure change be applied multiple times
+    safely (migrations, deployments, config rollouts)?
 
-I3. **Deployment ordering** — Does the plan require infrastructure changes to be
-    deployed in a specific order relative to application changes? A backend that
-    expects a new env var before it's provisioned, or a migration that must run
-    before new code reads the column, are ordering dependencies that the plan
-    should make explicit.
+I3. **Deployment ordering** — Does the plan make infrastructure ordering explicit
+    when application changes depend on it (env var provisioned before code reads it,
+    migration before new column access)?
 
-I4. **Secret and config provisioning** — Does the plan introduce new secrets,
-    environment variables, or config values? If so, does it specify where and how
-    they are provisioned in each environment? Missing a secret in production while
-    it works locally is a common deployment failure.
+I4. **Secret and config provisioning** — Does the plan specify where and how new
+    secrets / env vars / config values are provisioned in each environment?
 
 ## Domain: Data
 
@@ -157,28 +152,24 @@ DDL execution shape, and `staff-analytics-engineer` reviews the change for
 ELT-readiness when the schema feeds the warehouse. See **Item ownership** below
 for per-item routing.
 
-D1. **Migration safety** — Can the migration run on a live database without downtime?
-    Flag schema changes that take locks on large tables, backfills that run inside
-    transactions, or destructive operations without backup strategy. Also flag
-    `NOT NULL` additions without defaults, column type changes that require rewrites,
-    and `CREATE INDEX` without `CONCURRENTLY` on large tables.
+D1. **Migration safety** — Does the plan describe how the migration runs on a live
+    database without downtime — avoiding long-locking ALTERs, in-transaction
+    backfills, rewrite-triggering type changes, and `CREATE INDEX` without
+    `CONCURRENTLY` on large tables?
 
-D2. **Migration reversibility** — Can this migration be rolled back without data loss?
-    Flag destructive operations (`DROP COLUMN`, `DROP TABLE`, type narrowing) that
-    have no corresponding backup or reversal strategy.
+D2. **Migration reversibility** — Does the plan name a backup or reversal path for
+    destructive operations (`DROP COLUMN`, `DROP TABLE`, type narrowing)?
 
-D3. **Deploy-time compatibility** — During deployment, old code may run against the
-    new schema (or vice versa). Does the plan account for this? Renaming a column
-    that old code still references, or adding a `NOT NULL` constraint before new code
-    populates the column, will cause failures during the deploy window.
+D3. **Deploy-time compatibility** — Does the plan account for the deploy window when
+    old code runs against new schema (or vice versa) — column renames, premature
+    `NOT NULL` constraints?
 
-D4. **Access control on new objects** — Do new tables, views, or functions have
-    appropriate access control? A new table without RLS is accessible to any
-    authenticated user.
+D4. **Access control on new objects** — Does the plan declare row security / grants
+    on new tables, views, and functions exposed via auto-generated APIs?
 
-D5. **Index coverage** — Do new queries, new foreign keys, or new filter patterns
-    have supporting indexes? Flag new columns used in `WHERE`, `JOIN`, or
-    `ORDER BY` clauses that lack indexes, especially on tables expected to grow.
+D5. **Index coverage** — Does the plan provide indexes for new query patterns
+    (`WHERE` / `JOIN` / `ORDER BY` columns, foreign keys), especially on growing
+    tables?
 
 ## Domain: Frontend
 
@@ -230,24 +221,17 @@ S2. **Defense in depth** — Does the plan rely on a single control, or are ther
     layered defenses? A plan that says "RLS will handle it" without in-code checks
     is single-layer.
 
-S3. **Auth boundary coverage** — Does every new endpoint, RPC, or data path have
-    both authentication (who is the caller?) and authorization (can they do this
-    specific action on this specific resource)? Plans that mention "add auth" without
-    specifying both layers leave gaps.
+S3. **Auth boundary coverage** — Does the plan specify both authentication (who)
+    and authorization (can they) on every new endpoint, RPC, or data path?
 
-S4. **Privilege escalation paths** — Could a user exploit the planned changes to
-    gain access to another user's data or perform actions beyond their role? Check
-    for IDOR vectors, role-check gaps, and cases where user-supplied IDs are trusted
-    without ownership verification.
+S4. **Privilege escalation paths** — Does the plan close IDOR vectors, role-check
+    gaps, and ownership-verification gaps for user-supplied IDs?
 
-S5. **Data minimization** — Does the plan expose more data than necessary in API
-    responses, logs, or error messages? Check for full object returns where only
-    specific fields are needed, and for internal details (stack traces, query text,
-    internal IDs) leaking to callers.
+S5. **Data minimization** — Does the plan minimize exposure in API responses, logs,
+    and error payloads (full-object returns, stack traces, internal IDs)?
 
-S6. **Secret lifecycle** — If the plan introduces, rotates, or references secrets
-    (API keys, tokens, credentials), does it account for how they are provisioned,
-    where they are stored, and what happens when they expire or are compromised?
+S6. **Secret lifecycle** — Does the plan describe provisioning, storage, rotation,
+    and revocation for secrets it introduces or references?
 
 ## Exclusions — do NOT flag these
 

--- a/claude/.claude/skills/plan-review/SKILL.md
+++ b/claude/.claude/skills/plan-review/SKILL.md
@@ -160,9 +160,9 @@ D1. **Migration safety** — Does the plan describe how the migration runs on a 
 D2. **Migration reversibility** — Does the plan name a backup or reversal path for
     destructive operations (`DROP COLUMN`, `DROP TABLE`, type narrowing)?
 
-D3. **Deploy-time compatibility** — Does the plan account for the deploy window when
-    old code runs against new schema (or vice versa) — column renames, premature
-    `NOT NULL` constraints?
+D3. **Deploy-time compatibility** — Does the plan account for failures users hit
+    mid-deploy when old code runs against new schema (or vice versa) — column
+    renames, premature `NOT NULL` constraints?
 
 D4. **Access control on new objects** — Does the plan declare row security / grants
     on new tables, views, and functions exposed via auto-generated APIs?


### PR DESCRIPTION
## Summary

Follow-up to #34 (specifically Q4 of the third-round review:
"Code-review and plan-review skills overlap with each other and with
agents"). Addresses the two structural overlap sources #34 deferred.

**Plan-review-vs-code-review duplication.** Items that named the same
concern in plan-shape vs code-shape were near-verbatim restatements
under different ID prefixes (`D2` ≡ `18`, `D5` ≈ `19`, `D4` ≈ `21`,
`S3` ≈ `26`, etc.). Tightened to one-liners in both skills with
distinct framings: plan-review uses plan-shape questions ("Does the
plan describe..."), code-review uses code-shape facts ("Destructive
operations need a backup path"). The Item ownership table is the
cross-reference. Approach: Option C from the handoff — accept some
duplication, but minimize it.

**Skill-item-vs-agent-angle restatement.** Pruned each agent's "Core
review angles" section to keep only perspectives the LLM needs to
hook attention onto at spawn time. Dropped pure restatements;
retained one-line anchors for angles an agent might miss when invoked
outside the skill dispatcher.

**Specialist self-review:** ran `/code-review` with all 8 reviewer
subagents. Findings filed and addressed:

| Specialist | Finding | Disposition |
|------------|---------|-------------|
| ciso | Defense in depth dropped | Restored as one-liner |
| platform | concurrency / env-parity / secret-scoping / idempotency anchors | Restored as one-liners |
| backend | per-request work shape (N+1 / sync-in-handler) anchor | Restored as one-liner |
| frontend | async cancellation / `useEffect` race / `AbortController` (pre-existing gap) | New angle added |
| product | D3 user-cohort phrasing | Restored ("failures users hit mid-deploy") |
| data, analytics, sdet | No concerns | — |

**Preserved from #34:** 8 personas, three-way schema review, no
Trigger-discipline section, single-phrase doc-inclusion mention,
pre-emptive vs retrospective scope asymmetry, item-ownership table
shape.

**Net:** trims duplication while preserving every spawn-time
attention hook the specialists identified as needed; closes one
pre-existing gap (frontend async cancellation) surfaced during
self-review.

## Test plan

- [ ] Item ownership tables in both skills still route every item to
      a primary owner; no orphaned personas
- [ ] All checklist item titles in skill bodies still match their
      Item ownership table entries (post-tightening)
- [ ] Each agent's Core review angles still names enough perspectives
      for spawn-time attention even without the skill body loaded
- [ ] On a small staged diff, `/code-review` still fires specialists
      and they file findings using their own perspectives, not by
      walking every numbered item

🤖 Generated with [Claude Code](https://claude.com/claude-code)