### PR TITLE
Add verify-primary-sources skill

### DIFF
--- a/claude/.claude/skills/verify-primary-sources/SKILL.md
+++ b/claude/.claude/skills/verify-primary-sources/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: verify-primary-sources
+description: >
+  When web research will inform a code or design decision, fetch and
+  read the primary documentation directly rather than relying on
+  agent summaries or secondary sources. Read the surrounding
+  context — "the docs say X" and "the docs say X in the context of
+  Y" often point at opposite conclusions.
+  TRIGGER when: web research is informing an
+  architectural / API-behavior / library-choice / deprecation /
+  security-posture decision; you are about to relay or act on a
+  documentation claim from a secondary source (subagent, blog
+  post, forum answer, LLM summary); the user asks Claude to
+  research a technical question online before writing code.
+  DO NOT TRIGGER when: looking up syntax (jq operators, regex
+  flags), decoding an error string, fetching a single referenced
+  URL that IS the primary source (whether the user pasted it or a
+  subagent cited it), reading a CHANGELOG entry the user pointed
+  at — quick lookups that don't drive a strategic conclusion.
+user-invocable: false
+---
+
+# Verify Primary Sources
+
+## The failure mode this prevents
+
+A subagent reports "library X has deprecated function Y in favor of
+Z." You take the claim, plan a migration, present it. On inspection
+the source docs are about a narrower migration path — one that
+applies only to callers in a specific configuration. For the default
+configuration, Y is the right choice and Z is wrong. The plan is
+built on a confident-sounding misreading.
+
+The pattern fails the same way every time: an agent (or a secondary
+source — a blog post, an LLM summary, a forum answer) presents a
+claim *without the context that scoped it*. The claim is technically
+derivable from the docs but loses the qualifier that made it true. A
+reader who only sees the relayed claim cannot tell.
+
+The cost is asymmetric. Quick lookups that go wrong waste a few
+minutes. Strategic conclusions that go wrong waste a migration plan,
+a PR, a review cycle — and the user has to push back two or three
+times before the primary source is actually fetched.
+
+## The rule
+
+When research will inform a code or design decision:
+
+1. **Treat agent summaries and secondary sources as leads.** A
+   subagent's "the docs say X" is a pointer to read the docs
+   yourself. A blog post's summary of a deprecation is a pointer to
+   the deprecation announcement.
+2. **Fetch the primary source and read the surrounding context.**
+   Primary, in rough order: the vendor's official docs / reference,
+   the project CHANGELOG / release notes / migration guide, the RFC
+   or spec, the source code itself when behavior is in dispute, or
+   an official maintainer announcement. Read enough of the
+   surrounding section to know what the claim is *scoped to* —
+   which version, which configuration, which API surface, which
+   migration path.
+3. **Distinguish "docs say X" from "docs say X in the context of
+   Y."** If the docs scope the claim — to a specific version, config
+   mode, or migration path — your conclusion has to carry the scope
+   through. The unscoped form often points at opposite code from
+   the scoped form.
+4. **Do this on the first pass.** If you find yourself relaying an
+   agent's claim verbatim, or quoting a summary as if it were the
+   source, the next user message will ask you to actually fetch it.
+   Skip the round trip.
+
+If a primary source cannot be located, say so and present the
+secondary source as a secondary source. Flag the uncertainty rather
+than launder it into a confident claim.


### PR DESCRIPTION
## Summary

New skill `claude/.claude/skills/verify-primary-sources/SKILL.md`. Captures the rule: when web research informs a code or design decision, fetch the primary documentation directly and read the surrounding context, rather than relaying agent summaries or secondary-source claims. The skill exists because the failure mode it prevents — confident-sounding but context-stripped claims, especially from subagent doc summaries — is recurrent enough to be worth a dedicated trigger.

Two body sections: the failure mode + the rule. TRIGGER and DO NOT TRIGGER live in the frontmatter description per repo convention.

## Scoping

**TRIGGER** when web research is informing an architectural / API-behavior / library-choice / deprecation / security-posture decision; OR Claude is about to relay or act on a documentation claim from a secondary source (subagent, blog, forum, LLM summary); OR the user asks Claude to research a technical question online before writing code.

**DO NOT TRIGGER** on quick lookups that don't drive a strategic conclusion: syntax (jq operators, regex flags), error string decoding, fetching a single referenced URL that IS the primary source (whether the user pasted it or a subagent cited it), or reading a CHANGELOG entry the user pointed at.

The conservative over-fire bias is intentional given the asymmetric cost the body itself describes — a wrong syntax lookup costs minutes; a wrong strategic conclusion costs a migration plan and a review cycle.

## Provenance and abstraction

Surfaced from a recurring failure pattern in research-driven decisions. Per the repo's `When a skill is surfaced by real-world work, abstract first` rule, the body uses a generic example (library X has deprecated function Y in favor of Z; on inspection the docs are about a narrower migration path) — no vendor names, no project-specific feature names, no tracker IDs.

## Out of scope

- General web-search methodology / source-ranking taxonomy beyond the primary-vs-secondary split needed for this rule.
- Citation formatting conventions.
- A hook to enforce primary-source verification (this is intentionally a soft-trigger skill, not an enforced gate).

## Test plan

- [ ] After merge, `claude/` re-stows on next `git pull`; the new skill appears in the skill list and triggers on a sample web-research-driven question (e.g. "is library X feature Y deprecated?").
- [ ] Sanity check that DO NOT TRIGGER cases (syntax lookup, single-URL fetch that IS the primary source) don't surface this skill.