### PR TITLE
tests: parse hook-alignment recipes from SKILL.md instead of hardcoding

### DIFF
--- a/claude/.claude/hooks/tests/test_hooks.py
+++ b/claude/.claude/hooks/tests/test_hooks.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import subprocess
 import time
 from pathlib import Path
@@ -24,6 +25,48 @@ REVIEW_PERMS_HOOK = HOOKS_DIR / "ask-review-permissions.sh"
 DENY_PRIVATE_PROJECT_REFS_HOOK = HOOKS_DIR / "deny-private-project-refs.sh"
 WORKTREE_HOOK = HOOKS_DIR / "require-worktree-for-git-writes.sh"
 CAPTURE_SESSION_ID_HOOK = HOOKS_DIR / "capture-session-id.sh"
+
+SKILLS_DIR = HOOKS_DIR.parent / "skills"
+CODE_REVIEW_SKILL = SKILLS_DIR / "code-review" / "SKILL.md"
+RESPOND_PR_SKILL = SKILLS_DIR / "respond-pr" / "SKILL.md"
+
+# SKILL.md fences may be indented when the fixture sits inside a
+# numbered list (e.g. respond-pr's "0. **Enable hook bypass.**"). The
+# closing-fence match has to tolerate the same leading whitespace as
+# the opening, otherwise the non-greedy body capture runs past every
+# indented fence until it finds an unindented one elsewhere in the file.
+_SKILL_FIXTURE_RE = re.compile(
+    r"<!--\s*HOOK_TEST_FIXTURE:\s*(?P<id>[A-Za-z0-9_-]+)\b[^>]*-->\s*"
+    r"```[a-z]*\n(?P<body>.*?)\n[ \t]*```",
+    re.DOTALL,
+)
+
+
+def extract_skill_command(skill_path: Path, fixture_id: str) -> str:
+    """Return the body of the fenced code block tagged with `fixture_id`.
+
+    SKILL.md files mark hook-alignment fixtures with
+    `<!-- HOOK_TEST_FIXTURE: <id> -->` immediately followed by a fenced
+    code block. Reading the recipe from SKILL.md at test time (rather
+    than embedding a hardcoded copy in the test source) makes SKILL.md
+    the single source of truth — drift between the documented recipe
+    and what the test executes can't happen silently.
+    """
+    text = skill_path.read_text()
+    matches = [m for m in _SKILL_FIXTURE_RE.finditer(text) if m.group("id") == fixture_id]
+    if not matches:
+        raise AssertionError(
+            f"HOOK_TEST_FIXTURE '{fixture_id}' not found in {skill_path} — "
+            "either the marker was removed or the immediately-following "
+            "fenced block is missing."
+        )
+    if len(matches) > 1:
+        raise AssertionError(
+            f"HOOK_TEST_FIXTURE '{fixture_id}' appears {len(matches)} times in "
+            f"{skill_path} — fixture ids must be unique so the test runs the "
+            "intended block."
+        )
+    return matches[0].group("body").strip()
 
 
 def run_hook(hook: Path, tool_input: dict, cwd: Path | None = None) -> str:
@@ -268,9 +311,10 @@ class TestRequireCodeReview:
         """Regression guard against the SKILL command and HOOK getting out
         of sync on path derivation.
 
-        Runs the exact shell pipeline from code-review SKILL.md that writes
-        the marker (including the session_id lookup), then verifies the
-        hook accepts the result.
+        Reads the marker-write recipe directly from code-review SKILL.md
+        via the HOOK_TEST_FIXTURE marker, executes it, and verifies the
+        hook accepts the result. SKILL.md is the source of truth — if
+        the recipe drifts from what the hook expects, this test fails.
         """
         sid = "test-session-skill-cmd"
         # Set up the session_id lookup file at the path the skill reads.
@@ -285,19 +329,18 @@ class TestRequireCodeReview:
         if markers_dir.exists():
             for f in markers_dir.glob("*"):
                 f.unlink()
-        skill_command = (
-            'SESSION_ID=$(cat "$HOME/.claude/sessions/$PPID") && '
-            '[ -n "$SESSION_ID" ] && '
-            'mkdir -p "$HOME/.claude/review-markers" && '
-            "REPO_HASH=$(git rev-parse --show-toplevel | tr -d '\\n' | sha256sum | awk '{print $1}') && "
-            "git diff --cached | sha256sum | awk '{print $1}' > "
-            '"$HOME/.claude/review-markers/$REPO_HASH.$SESSION_ID"'
-        )
+
+        skill_command = extract_skill_command(CODE_REVIEW_SKILL, "marker-write")
         subprocess.run(
             ["bash", "-c", skill_command],
             cwd=git_repo,
             env={**os.environ, "HOME": str(isolated_home)},
             check=True,
+        )
+        # Sanity check: the recipe wrote a marker at the path the hook checks.
+        assert marker_path(isolated_home, git_repo, session_id=sid).exists(), (
+            "SKILL.md marker-write recipe ran but no marker landed at the "
+            "path the hook computes — the skill and hook disagree on layout."
         )
         assert (
             run_hook(
@@ -566,6 +609,94 @@ class TestRequireRespondPr:
                 RESPOND_PR_HOOK,
                 bash_input("gh api repos/foo/bar/issues/5/comments"),
                 cwd=repo,
+            )
+            == "deny"
+        )
+
+    # -- Skill ↔ hook alignment -------------------------------------------
+    # These execute the enable/disable bypass recipes verbatim from
+    # respond-pr SKILL.md. If the skill body drifts from the marker layout
+    # require-respond-pr.sh expects, these fail.
+
+    def test_skill_enable_command_creates_bypass_marker(
+        self, isolated_home, current_repo_foo_bar
+    ):
+        """Run the SKILL.md enable-bypass recipe and verify the resulting
+        marker authorizes a previously-gated gh command."""
+        sid = "test-session-respond-pr-enable"
+        sessions_dir = isolated_home / ".claude" / "sessions"
+        sessions_dir.mkdir(parents=True)
+        (sessions_dir / str(os.getpid())).write_text(sid)
+
+        gated_command = "gh api repos/foo/bar/pulls/5/comments"
+        assert (
+            run_hook(
+                RESPOND_PR_HOOK,
+                bash_input(gated_command, session_id=sid),
+                cwd=current_repo_foo_bar,
+            )
+            == "deny"
+        ), "precondition: gh comment fetch must be gated before bypass is enabled"
+
+        enable_command = extract_skill_command(RESPOND_PR_SKILL, "enable-bypass")
+        subprocess.run(
+            ["bash", "-c", enable_command],
+            cwd=current_repo_foo_bar,
+            env={**os.environ, "HOME": str(isolated_home)},
+            check=True,
+        )
+
+        marker = isolated_home / ".claude" / ".respond-pr-active.d" / sid
+        assert marker.exists(), (
+            "SKILL.md enable-bypass recipe ran but no marker landed at the "
+            "path the hook checks — the skill and hook disagree on layout."
+        )
+        assert (
+            run_hook(
+                RESPOND_PR_HOOK,
+                bash_input(gated_command, session_id=sid),
+                cwd=current_repo_foo_bar,
+            )
+            == "allow"
+        )
+
+    def test_skill_disable_command_removes_bypass_marker(
+        self, isolated_home, current_repo_foo_bar
+    ):
+        """Run enable then disable from SKILL.md; verify the disable recipe
+        removes the marker and the hook re-gates."""
+        sid = "test-session-respond-pr-disable"
+        sessions_dir = isolated_home / ".claude" / "sessions"
+        sessions_dir.mkdir(parents=True)
+        (sessions_dir / str(os.getpid())).write_text(sid)
+
+        enable_command = extract_skill_command(RESPOND_PR_SKILL, "enable-bypass")
+        subprocess.run(
+            ["bash", "-c", enable_command],
+            cwd=current_repo_foo_bar,
+            env={**os.environ, "HOME": str(isolated_home)},
+            check=True,
+        )
+        marker = isolated_home / ".claude" / ".respond-pr-active.d" / sid
+        assert marker.exists(), "enable-bypass setup did not create the marker"
+
+        disable_command = extract_skill_command(RESPOND_PR_SKILL, "disable-bypass")
+        subprocess.run(
+            ["bash", "-c", disable_command],
+            cwd=current_repo_foo_bar,
+            env={**os.environ, "HOME": str(isolated_home)},
+            check=True,
+        )
+
+        assert not marker.exists(), (
+            "SKILL.md disable-bypass recipe ran but the marker is still "
+            "present — the skill and hook disagree on the marker path."
+        )
+        assert (
+            run_hook(
+                RESPOND_PR_HOOK,
+                bash_input("gh api repos/foo/bar/pulls/5/comments", session_id=sid),
+                cwd=current_repo_foo_bar,
             )
             == "deny"
         )

--- a/claude/.claude/skills/code-review/SKILL.md
+++ b/claude/.claude/skills/code-review/SKILL.md
@@ -301,6 +301,7 @@ If the review is **clean** (no blockers, no unresolved critical findings,
 and you reviewed the currently staged changes), record it by running this
 command exactly once:
 
+<!-- HOOK_TEST_FIXTURE: marker-write — the hook-alignment test suite reads this exact fenced block from this file (claude/.claude/skills/code-review/SKILL.md) to verify it matches require-code-review.sh's marker layout. Do not duplicate the recipe elsewhere; the test re-reads it from here. -->
 ```
 SESSION_ID=$(cat "$HOME/.claude/sessions/$PPID") && [ -n "$SESSION_ID" ] && mkdir -p "$HOME/.claude/review-markers" && REPO_HASH=$(git rev-parse --show-toplevel | tr -d '\n' | sha256sum | awk '{print $1}') && git diff --cached | sha256sum | awk '{print $1}' > "$HOME/.claude/review-markers/$REPO_HASH.$SESSION_ID"
 ```

--- a/claude/.claude/skills/respond-pr/SKILL.md
+++ b/claude/.claude/skills/respond-pr/SKILL.md
@@ -11,6 +11,7 @@ Fetch all review comments on the current branch's open pull request and address 
 ## Steps
 
 0. **Enable hook bypass.** Run:
+   <!-- HOOK_TEST_FIXTURE: enable-bypass — the hook-alignment test suite reads this exact fenced block to verify it creates the marker layout require-respond-pr.sh expects. Do not duplicate elsewhere; the test re-reads it from here. -->
    ```
    SESSION_ID=$(cat "$HOME/.claude/sessions/$PPID") && [ -n "$SESSION_ID" ] && mkdir -p "$HOME/.claude/.respond-pr-active.d" && touch "$HOME/.claude/.respond-pr-active.d/$SESSION_ID"
    ```
@@ -28,6 +29,7 @@ Fetch all review comments on the current branch's open pull request and address 
 4. Post replies using the GitHub API with `in_reply_to` (use `-F` for integer IDs)
 5. Commit and push any code changes in a single commit
 6. **Remove this session's hook bypass marker:**
+   <!-- HOOK_TEST_FIXTURE: disable-bypass — the hook-alignment test suite reads this exact fenced block to verify it removes the marker the enable step created. Do not duplicate elsewhere; the test re-reads it from here. -->
    ```
    SESSION_ID=$(cat "$HOME/.claude/sessions/$PPID" 2>/dev/null) && [ -n "$SESSION_ID" ] && rm -f "$HOME/.claude/.respond-pr-active.d/$SESSION_ID"
    ```


### PR DESCRIPTION
## Summary

Closes the gap discussed in the prior session: the existing code-review hook ↔ skill alignment test embedded a hardcoded copy of the SKILL.md marker-write recipe inline. If SKILL.md drifted from what the hook expected, the test still passed — it was testing its own copy, not the file. Same shape applies to respond-pr's enable/disable bypass commands, which had no alignment test at all.

This PR makes SKILL.md the single source of truth for the alignment tests by tagging the fenced blocks with HTML-comment markers and reading them at test time.

## Changes

- **`extract_skill_command(skill_path, fixture_id)`** in `test_hooks.py`. Reads SKILL.md, finds the `<!-- HOOK_TEST_FIXTURE: <id> -->` marker, returns the contents of the immediately-following fenced block. Asserts each fixture id resolves to exactly one block (catches accidental copy-paste duplication).
- **Three fixture markers added:**
  - `code-review/SKILL.md` → `marker-write`
  - `respond-pr/SKILL.md` → `enable-bypass`, `disable-bypass`

  HTML comments are invisible in rendered markdown but searchable in source. Each marker has a self-documenting note explaining the test contract.
- **Existing code-review test refactored** to read from SKILL.md instead of holding an inline copy. Also adds a sanity assertion that the marker landed at the path the hook computes — failures now localize to skill-side (wrong write path) vs hook-side (wrong read path).
- **Two new respond-pr tests** that execute the enable / disable recipes from SKILL.md and verify (a) the marker file is created/removed at the expected path, and (b) the hook flips between deny and allow accordingly.

## Notes on the parser

The regex tolerates indented closing fences. The respond-pr fixtures sit inside numbered list items (`0. **Enable hook bypass.**`, `6. **Remove this session's hook bypass marker:**`), so their fences carry the list's 3-space indent. Initial cut of the regex required column-0 closing fences and ran greedily across half the file — fixed by making the closing fence tolerate `[ \t]*` indent.

## Drift scenarios this now catches

- SKILL.md path swap (e.g., `$REPO_HASH.$SESSION_ID` → `$SESSION_ID.$REPO_HASH`): the file-existence assertion fires before the hook check, so the failure message names the marker path mismatch directly.
- SKILL.md write-method drift (e.g., recipe uses `mkdir` and `touch` but the file lands somewhere unexpected because of a quoting bug): the hook check fires.
- Recipe deletion or renaming: the parser raises `AssertionError` naming the missing fixture id.
- Duplicate fixture id (copy-paste mistake): parser raises `AssertionError` naming the duplication.

## Out of scope

- A test that asserts the SKILL recipe's hash matches a Python re-derivation. The reviewer suggested this; I dropped it because the canonical digest IS `git diff --cached | sha256sum` — re-deriving in Python tests bash, not skill-vs-hook alignment.
- Backporting the parser to other skill ↔ hook pairs (none exist beyond these two).

## Test plan

- [x] `pytest claude/.claude/hooks/tests/test_hooks.py` → 203 passed
- [x] Manually confirmed the regex captures only the targeted fence and not subsequent content (the indented-fence trap).
- [ ] CI run on the PR.