### PR TITLE
Add require-stow-reminder PreToolUse hook

### DIFF
--- a/claude/.claude/hooks/require-stow-reminder.sh
+++ b/claude/.claude/hooks/require-stow-reminder.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+# Gate: when a PR being opened/edited against claude-config introduces a
+# new top-level entry under `claude/.claude/`, require the PR body (or a
+# referenced body-source file, or a referenced commit message via
+# `--fill`) to mention `install.sh` or `stow`. Reason: GNU Stow links
+# each child of `claude/.claude/` individually into `~/.claude/`, but a
+# *new* child only appears after re-running stow — `git pull` alone
+# doesn't create the symlink. Without a reminder in the PR body,
+# whoever merges and pulls won't know to re-run install.sh, and the new
+# folder/file silently fails to load (Claude Code reads from
+# ~/.claude/<X>, which is empty until stow links it).
+#
+# NOTE — `if`-dispatch is advisory; the real gate is the internal regex
+# below. settings.json wires two `if` entries (`Bash(gh pr create *)`,
+# `Bash(gh pr edit *)`) for early dispatch, but any drift between those
+# patterns and the IS_GH_PR regex here creates silent coverage gaps.
+# Update both surfaces when extending coverage.
+#
+# Scope:
+# - Fires only when origin URL contains `claude-config` (parallel to
+#   deny-private-project-refs.sh's scoping).
+# - Detects new top-level entries by diffing `main...HEAD` for added
+#   files under `claude/.claude/<X>/...` or `claude/.claude/<X>`, then
+#   checking whether `<X>` exists on `main`. New file directly at the
+#   top level (e.g. `claude/.claude/foo.md`) and new directory (e.g.
+#   `claude/.claude/agents/`) are both flagged — both need a fresh
+#   stow run to materialize their symlink in `~/.claude/`.
+# - For `gh pr edit`: only enforces when the edit is changing the body
+#   (`--body`, `--body-file`, `-F`, `--template`, `-T`). Title-only or
+#   label-only edits don't need the reminder.
+# - Marker is satisfied by case-insensitive substring match of
+#   `install.sh` or `stow` in: the inline command (covers `--body
+#   "..."`, `--title "..."`), any `--body-file`/`--template` file
+#   contents, and — if `--fill`/`-f`/`--fill-first`/`--fill-verbose` is
+#   used — the commit messages on the branch since `main`.
+#
+# Known gaps (documented, not closed):
+# - `gh pr create --body "$(cat file)"` or backtick command substitution
+#   inside `--body`/`--title` hides content behind shell expansion the
+#   hook doesn't execute. Same gap as deny-private-project-refs.sh.
+# - `gh pr edit` without any body-modifying flag is allowed through —
+#   the gate cannot see the existing PR body without a `gh api` call,
+#   and adding a network round-trip to a PreToolUse hook is too costly.
+#   Acceptable: the create-time check guarantees the marker landed in
+#   the body initially; an edit that doesn't touch the body can't
+#   remove it.
+# - If `main` doesn't exist locally (fresh clone, weird state), the
+#   gate exits 0 (fail-open). The cost of a missed reminder is one
+#   confused user; the cost of fail-closed in this rare case is
+#   blocking every PR until they fetch main.
+
+set -uo pipefail
+
+INPUT=$(cat)
+COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+JQ_EXIT=$?
+CWD=$(printf '%s\n' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)
+[ -z "$CWD" ] && CWD="$PWD"
+
+emit_deny() {
+  local reason="$1"
+  local reason_json
+  reason_json=$(printf '%s' "$reason" | jq -Rs .)
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' \
+    "$reason_json"
+}
+
+# Fail-closed on malformed input. Same posture as the other gates.
+if [ "$JQ_EXIT" -ne 0 ]; then
+  emit_deny "Blocked by stow-reminder gate: could not parse tool-input JSON. Refusing to evaluate under malformed input."
+  exit 0
+fi
+
+# Internal filter (defense-in-depth against settings.json `if` drift).
+# Only fire on `gh pr create` or `gh pr edit` invocations.
+if ! printf '%s\n' "$COMMAND" | grep -qE '(^|&&?|;|\|\|?)\s*gh\s+pr\s+(create|edit)(\s|$)'; then
+  exit 0
+fi
+
+REPO_ROOT=$(cd "$CWD" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$REPO_ROOT" ]; then
+  exit 0
+fi
+
+# Scope: claude-config only. Other repos don't use stow this way.
+REMOTE_URL=$(cd "$REPO_ROOT" && git config --get remote.origin.url 2>/dev/null)
+if [[ "$REMOTE_URL" != *claude-config* ]]; then
+  exit 0
+fi
+
+# Need a `main` ref to compute the new-top-level diff. If absent, fail
+# open — see "Known gaps" in the header.
+if ! (cd "$REPO_ROOT" && git rev-parse --verify main >/dev/null 2>&1); then
+  exit 0
+fi
+
+# Added paths on the branch since main, scoped to the stow source dir.
+ADDED_PATHS=$(cd "$REPO_ROOT" && git diff --name-only --diff-filter=A main...HEAD -- 'claude/.claude/' 2>/dev/null || true)
+if [ -z "$ADDED_PATHS" ]; then
+  exit 0
+fi
+
+# Extract immediate-child names under claude/.claude/ and keep only the
+# ones that don't exist on `main`. An added path can be either:
+#   claude/.claude/<X>           (new top-level file)
+#   claude/.claude/<X>/...       (new file inside a directory; <X> is
+#                                 either a brand-new directory OR an
+#                                 existing one — we filter to brand-new
+#                                 below).
+NEW_TOPLEVEL_ENTRIES=""
+SEEN_CHILDREN=""
+while IFS= read -r added_path; do
+  [ -z "$added_path" ] && continue
+  rest="${added_path#claude/.claude/}"
+  # If stripping the prefix produced no change, the path didn't have it.
+  [ "$rest" = "$added_path" ] && continue
+  child="${rest%%/*}"
+  [ -z "$child" ] && continue
+  # Dedup: only check each child once.
+  case " $SEEN_CHILDREN " in *" $child "*) continue ;; esac
+  SEEN_CHILDREN="$SEEN_CHILDREN $child"
+  # Does `<child>` exist on main? `git cat-file -e` succeeds for both
+  # files and directories at that ref.
+  if ! (cd "$REPO_ROOT" && git cat-file -e "main:claude/.claude/$child" 2>/dev/null); then
+    NEW_TOPLEVEL_ENTRIES="$NEW_TOPLEVEL_ENTRIES $child"
+  fi
+done <<< "$ADDED_PATHS"
+
+# Trim leading space.
+NEW_TOPLEVEL_ENTRIES="${NEW_TOPLEVEL_ENTRIES# }"
+if [ -z "$NEW_TOPLEVEL_ENTRIES" ]; then
+  exit 0
+fi
+
+# For `gh pr edit`, only enforce when the edit modifies the body. The
+# create-time gate guarantees the marker landed initially; a non-body
+# edit can't remove it.
+IS_GH_PR_EDIT=0
+if printf '%s\n' "$COMMAND" | grep -qE '(^|&&?|;|\|\|?)\s*gh\s+pr\s+edit(\s|$)'; then
+  IS_GH_PR_EDIT=1
+fi
+if [ "$IS_GH_PR_EDIT" -eq 1 ]; then
+  if ! printf '%s\n' "$COMMAND" | grep -qE '(--body([[:space:]=]|$)|--body-file|-F([[:space:]=]|$)|--template|-T([[:space:]=]|$))'; then
+    exit 0
+  fi
+fi
+
+# Extract paths passed to body-source flags. Same parser shape as
+# deny-private-project-refs.sh.
+extract_body_source_paths() {
+  local cmd="$1"
+  printf '%s\n' "$cmd" \
+    | grep -oE '(--body-file|--template|-F|-T)(=|[[:space:]]+)[^[:space:];&|]+' \
+    | sed -E 's/^(--body-file|--template|-F|-T)(=|[[:space:]]+)//' \
+    | sed -E "s/^['\"](.*)['\"]$/\\1/"
+}
+
+is_pseudo_file_path() {
+  case "$1" in
+    -|/dev/stdin|/dev/fd/*|/proc/*/fd/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Build scan target: command (covers inline --body / --title), body-
+# source file contents, and — if --fill is in play — commit messages on
+# the branch since main.
+SCAN_TARGET="$COMMAND"
+
+BODY_SOURCES=$(extract_body_source_paths "$COMMAND")
+if [ -n "$BODY_SOURCES" ]; then
+  while IFS= read -r body_source_path; do
+    [ -z "$body_source_path" ] && continue
+    is_pseudo_file_path "$body_source_path" && continue
+    [ ! -r "$body_source_path" ] && continue
+    SCAN_TARGET+=$'\n'"$(cat "$body_source_path" 2>/dev/null || true)"
+  done <<< "$BODY_SOURCES"
+fi
+
+# `--fill` family: body comes from commit messages. Add those to the
+# scan target so a properly-worded commit message satisfies the gate.
+if printf '%s\n' "$COMMAND" | grep -qE '(--fill(-first|-verbose)?|[[:space:]]-f([[:space:]]|$))'; then
+  COMMIT_MESSAGES=$(cd "$REPO_ROOT" && git log --format='%B' main..HEAD 2>/dev/null || true)
+  SCAN_TARGET+=$'\n'"$COMMIT_MESSAGES"
+fi
+
+# Marker check: case-insensitive substring match for install.sh or stow.
+if printf '%s' "$SCAN_TARGET" | grep -qiE '(install\.sh|stow)'; then
+  exit 0
+fi
+
+# Format the entry list compactly for the deny message.
+ENTRIES_HUMAN=$(printf '%s' "$NEW_TOPLEVEL_ENTRIES" | tr ' ' '\n' | sed 's/^/`claude\/.claude\//; s/$/`/' | tr '\n' ' ' | sed 's/ $//')
+
+emit_deny "Blocked by stow-reminder gate: this PR adds new top-level entries under claude/.claude/ ($ENTRIES_HUMAN). Stow links each top-level child individually, and a brand-new child only appears in ~/.claude/ after re-running install.sh — git pull alone does not create the symlink. Without a reminder in the PR body, whoever merges won't know to re-stow, and the new content will silently fail to load. Add a line to the PR body (or a commit message if using --fill) mentioning install.sh or stow — for example: 'Post-merge: run \`./install.sh\` to link the new top-level entry.' The gate is satisfied by a case-insensitive substring match for 'install.sh' or 'stow' in the PR body, any --body-file/--template file, or commit messages reachable from --fill."
+
+exit 0

--- a/claude/.claude/hooks/tests/test_hooks.py
+++ b/claude/.claude/hooks/tests/test_hooks.py
@@ -22,6 +22,7 @@ CODE_REVIEW_HOOK = HOOKS_DIR / "require-code-review.sh"
 RESPOND_PR_HOOK = HOOKS_DIR / "require-respond-pr.sh"
 REVIEW_PERMS_HOOK = HOOKS_DIR / "ask-review-permissions.sh"
 DENY_PRIVATE_PROJECT_REFS_HOOK = HOOKS_DIR / "deny-private-project-refs.sh"
+STOW_REMINDER_HOOK = HOOKS_DIR / "require-stow-reminder.sh"
 WORKTREE_HOOK = HOOKS_DIR / "require-worktree-for-git-writes.sh"
 CAPTURE_SESSION_ID_HOOK = HOOKS_DIR / "capture-session-id.sh"
 
@@ -2063,3 +2064,223 @@ class TestRequireWorktreeForGitWrites:
             )
             == "allow"
         )
+
+
+# --- require-stow-reminder.sh ----------------------------------------
+#
+# The hook fires only on `gh pr create` / `gh pr edit` in a repo whose
+# origin URL contains `claude-config`, and only when the diff against
+# `main` introduces a brand-new immediate child of `claude/.claude/`.
+# The marker that satisfies the gate is a case-insensitive substring
+# match for `install.sh` or `stow` in the inline command, any
+# referenced body-source file, or — if `--fill` is in play — the commit
+# messages reachable on the branch.
+
+
+@pytest.fixture
+def stow_repo(tmp_path):
+    """A claude-config-shaped repo with `main` containing one already-
+    stowed top-level entry under `claude/.claude/`, and a `feature`
+    branch checked out for tests to add new content on top of.
+
+    Tests that want a new top-level entry to be detected should add it
+    on `feature` and commit there — the hook diffs `main...HEAD` from
+    inside the repo's cwd."""
+    repo = tmp_path / "stow-repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "test"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "remote", "add", "origin", "git@github.com:jcdendrite/claude-config.git"],
+        cwd=repo,
+        check=True,
+    )
+    # Existing top-level entry on main: claude/.claude/skills/foo.md.
+    # Tests can add files inside `skills/` without tripping the gate
+    # (skills/ is not a new top-level), or add a sibling like
+    # `agents/` to trip it.
+    skills = repo / "claude" / ".claude" / "skills"
+    skills.mkdir(parents=True)
+    (skills / "foo.md").write_text("# existing skill\n")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=repo, check=True)
+    subprocess.run(["git", "checkout", "-q", "-b", "feature"], cwd=repo, check=True)
+    return repo
+
+
+def commit_new_toplevel_dir(repo: Path, name: str) -> None:
+    """Create `claude/.claude/<name>/file.md` and commit on the current
+    branch. Used to simulate adding a brand-new top-level directory."""
+    target_dir = repo / "claude" / ".claude" / name
+    target_dir.mkdir(parents=True)
+    (target_dir / "file.md").write_text(f"# {name}\n")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", f"add {name}"], cwd=repo, check=True)
+
+
+def commit_new_toplevel_file(repo: Path, name: str) -> None:
+    """Create `claude/.claude/<name>` (top-level file) and commit."""
+    (repo / "claude" / ".claude" / name).write_text("data\n")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", f"add {name}"], cwd=repo, check=True)
+
+
+def commit_inside_existing_toplevel(repo: Path) -> None:
+    """Add a file inside the already-stowed `skills/` directory. Should
+    NOT trip the gate — `skills/` already exists on main."""
+    (repo / "claude" / ".claude" / "skills" / "bar.md").write_text("# new skill\n")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "add skill bar"], cwd=repo, check=True)
+
+
+class TestRequireStowReminder:
+    def test_non_pr_command_allowed(self, stow_repo):
+        commit_new_toplevel_dir(stow_repo, "agents")
+        assert run_hook(STOW_REMINDER_HOOK, bash_input("git status"), cwd=stow_repo) == "allow"
+
+    def test_unrelated_remote_repo_allowed(self, tmp_path):
+        """The gate is scoped to claude-config. Other repos may legitimately
+        add top-level directories without any stow workflow."""
+        repo = tmp_path / "other-repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.name", "t"], cwd=repo, check=True)
+        subprocess.run(
+            ["git", "remote", "add", "origin", "git@github.com:someone/other-app.git"],
+            cwd=repo,
+            check=True,
+        )
+        (repo / "README.md").write_text("x")
+        subprocess.run(["git", "add", "."], cwd=repo, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=repo, check=True)
+        subprocess.run(["git", "checkout", "-q", "-b", "feature"], cwd=repo, check=True)
+        (repo / "claude").mkdir()
+        (repo / "claude" / ".claude").mkdir()
+        (repo / "claude" / ".claude" / "agents").mkdir()
+        (repo / "claude" / ".claude" / "agents" / "foo.md").write_text("x")
+        subprocess.run(["git", "add", "."], cwd=repo, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "add agents"], cwd=repo, check=True)
+        cmd = "gh pr create --title T --body 'no marker here'"
+        assert run_hook(STOW_REMINDER_HOOK, bash_input(cmd), cwd=repo) == "allow"
+
+    def test_no_new_toplevel_allowed(self, stow_repo):
+        """File added inside an already-stowed directory does not need
+        a stow re-run; gate must not fire."""
+        commit_inside_existing_toplevel(stow_repo)
+        cmd = "gh pr create --title T --body 'just a new skill'"
+        assert run_hook(STOW_REMINDER_HOOK, bash_input(cmd), cwd=stow_repo) == "allow"
+
+    def test_new_toplevel_dir_without_marker_denied(self, stow_repo):
+        commit_new_toplevel_dir(stow_repo, "agents")
+        cmd = "gh pr create --title 'Add agents' --body 'Adds reviewer agents.'"
+        assert run_hook(STOW_REMINDER_HOOK, bash_input(cmd), cwd=stow_repo) == "deny"
+
+    def test_new_toplevel_file_without_marker_denied(self, stow_repo):
+        """A new file directly under claude/.claude/ also requires
+        re-stow — stow links each top-level child individually."""
+        commit_new_toplevel_file(stow_repo, "newfile.md")
+        cmd = "gh pr create --title T --body 'add file'"
+        assert run_hook(STOW_REMINDER_HOOK, bash_input(cmd), cwd=stow_repo) == "deny"
+
+    def test_marker_install_sh_in_body_allowed(self, stow_repo):
+        commit_new_toplevel_dir(stow_repo, "agents")
+        cmd = "gh pr create --title T --body 'After merging, run ./install.sh'"
+        assert run_hook(STOW_REMINDER_HOOK, bash_input(cmd), cwd=stow_repo) == "allow"
+
+    def test_marker_stow_in_body_allowed(self, stow_repo):
+        commit_new_toplevel_dir(stow_repo, "agents")
+        cmd = "gh pr create --title T --body 'remember to re-stow'"
+        assert run_hook(STOW_REMINDER_HOOK, bash_input(cmd), cwd=stow_repo) == "allow"
+
+    def test_marker_case_insensitive_allowed(self, stow_repo):
+        commit_new_toplevel_dir(stow_repo, "agents")
+        cmd = "gh pr create --title T --body 'Run INSTALL.SH after merge'"
+        assert run_hook(STOW_REMINDER_HOOK, bash_input(cmd), cwd=stow_repo) == "allow"
+
+    def test_body_file_with_marker_allowed(self, stow_repo, tmp_path):
+        commit_new_toplevel_dir(stow_repo, "agents")
+        body = tmp_path / "body.md"
+        body.write_text("Adds agents/.\n\nPost-merge: run ./install.sh.\n")
+        cmd = f"gh pr create --title T --body-file {body}"
+        assert run_hook(STOW_REMINDER_HOOK, bash_input(cmd), cwd=stow_repo) == "allow"
+
+    def test_body_file_without_marker_denied(self, stow_repo, tmp_path):
+        commit_new_toplevel_dir(stow_repo, "agents")
+        body = tmp_path / "body.md"
+        body.write_text("Adds agents/. No reminder here.\n")
+        cmd = f"gh pr create --title T --body-file {body}"
+        assert run_hook(STOW_REMINDER_HOOK, bash_input(cmd), cwd=stow_repo) == "deny"
+
+    def test_fill_with_marker_in_commit_message_allowed(self, stow_repo):
+        """`gh pr create --fill` sources body from commits — a marker
+        in any commit message on the branch satisfies the gate."""
+        # Commit the new top-level with a message that mentions install.sh.
+        target = stow_repo / "claude" / ".claude" / "agents"
+        target.mkdir(parents=True)
+        (target / "foo.md").write_text("x")
+        subprocess.run(["git", "add", "."], cwd=stow_repo, check=True)
+        subprocess.run(
+            ["git", "commit", "-q", "-m", "add agents (post-merge: run install.sh)"],
+            cwd=stow_repo,
+            check=True,
+        )
+        cmd = "gh pr create --fill"
+        assert run_hook(STOW_REMINDER_HOOK, bash_input(cmd), cwd=stow_repo) == "allow"
+
+    def test_fill_without_marker_denied(self, stow_repo):
+        commit_new_toplevel_dir(stow_repo, "agents")  # commit msg: "add agents"
+        cmd = "gh pr create --fill"
+        assert run_hook(STOW_REMINDER_HOOK, bash_input(cmd), cwd=stow_repo) == "deny"
+
+    def test_pr_edit_label_only_allowed(self, stow_repo):
+        """gh pr edit without any body-modifying flag must not be gated.
+        The create-time check already enforced the marker initially; a
+        non-body edit can't remove it."""
+        commit_new_toplevel_dir(stow_repo, "agents")
+        cmd = "gh pr edit 42 --add-label needs-review"
+        assert run_hook(STOW_REMINDER_HOOK, bash_input(cmd), cwd=stow_repo) == "allow"
+
+    def test_pr_edit_body_without_marker_denied(self, stow_repo):
+        commit_new_toplevel_dir(stow_repo, "agents")
+        cmd = "gh pr edit 42 --body 'rewritten body, no marker'"
+        assert run_hook(STOW_REMINDER_HOOK, bash_input(cmd), cwd=stow_repo) == "deny"
+
+    def test_pr_edit_body_with_marker_allowed(self, stow_repo):
+        commit_new_toplevel_dir(stow_repo, "agents")
+        cmd = "gh pr edit 42 --body 'updated: post-merge run ./install.sh'"
+        assert run_hook(STOW_REMINDER_HOOK, bash_input(cmd), cwd=stow_repo) == "allow"
+
+    def test_no_main_ref_fails_open(self, tmp_path):
+        """Fresh-clone state without a local `main` ref: hook must not
+        block PR creation. Documented as a known fail-open in the
+        header."""
+        repo = tmp_path / "no-main"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q", "-b", "trunk"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.name", "t"], cwd=repo, check=True)
+        subprocess.run(
+            ["git", "remote", "add", "origin", "git@github.com:jcdendrite/claude-config.git"],
+            cwd=repo,
+            check=True,
+        )
+        (repo / "README.md").write_text("x")
+        subprocess.run(["git", "add", "."], cwd=repo, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=repo, check=True)
+        cmd = "gh pr create --title T --body 'no marker'"
+        assert run_hook(STOW_REMINDER_HOOK, bash_input(cmd), cwd=repo) == "allow"
+
+    def test_malformed_input_denied(self, stow_repo):
+        """Fail-closed on unparseable JSON, parallel to the other gates."""
+        result = subprocess.run(
+            [str(STOW_REMINDER_HOOK)],
+            input="not json",
+            capture_output=True,
+            text=True,
+            cwd=stow_repo,
+            check=False,
+        )
+        payload = json.loads(result.stdout)
+        assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -40,6 +40,18 @@
           },
           {
             "type": "command",
+            "command": "~/.claude/hooks/require-stow-reminder.sh",
+            "if": "Bash(gh pr create *)",
+            "statusMessage": "Checking stow reminder..."
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/require-stow-reminder.sh",
+            "if": "Bash(gh pr edit *)",
+            "statusMessage": "Checking stow reminder..."
+          },
+          {
+            "type": "command",
             "command": "~/.claude/hooks/require-respond-pr.sh",
             "statusMessage": "Checking respond-pr gate..."
           },


### PR DESCRIPTION
## Summary

- Adds `require-stow-reminder.sh` PreToolUse hook that fires on `gh pr create` / `gh pr edit` in the claude-config repo.
- Detects when a PR adds a new immediate child of `claude/.claude/` (file or directory) by diffing `main...HEAD` against the stow source.
- Requires the PR body, a `--body-file`/`--template` file, or a `--fill`-sourced commit message to mention `install.sh` or `stow` (case-insensitive). Denies otherwise with a remediation message.
- Wired in `settings.json` under PreToolUse → Bash with `if`-dispatch on `Bash(gh pr create *)` and `Bash(gh pr edit *)`, parallel to `deny-private-project-refs.sh`.

## Why

GNU Stow links each top-level child of `claude/.claude/` individually into `~/.claude/`. A brand-new child only materializes after re-running stow — `git pull` alone doesn't create the symlink, and Claude Code reads from `~/.claude/<X>` which stays empty. The `agents/` folder added in #51 hit exactly this failure mode: agents present in the repo, invisible to sessions until someone manually re-ran the install step.

The gate fires at PR-creation time (not commit time) so the reminder lands in the artifact you read at merge time.

## Scope and posture

- Repo-scoped: only fires when `origin.url` contains `claude-config`. Other repos pass through.
- Internal regex filter inside the hook (defense-in-depth against settings.json `if`-pattern drift), parallel to existing gates.
- For `gh pr edit`: only enforces when the edit is changing the body. Title-only / label-only edits pass through, since the create-time gate guarantees the marker landed initially.
- Fail-closed on malformed JSON; fail-open when local `main` ref is missing (rare fresh-clone state). Both documented in the header.
- Known gaps documented inline (matches the `deny-private-project-refs.sh` known-gaps section): shell command-substitution inside `--body`/`--title`, body-file pseudo-paths.

## Test plan

- [x] 17 new cases under `TestRequireStowReminder` covering allow paths (no new top-level, marker in body, marker in body-file, marker in `--fill` commit, label-only edit), deny paths (new dir/file without marker, body-file/edit-body without marker, `--fill` without marker), and edge cases (unrelated repo, missing `main`, malformed JSON).
- [x] Full hook suite green: 218/218.
- [x] Self-test against this PR: this PR adds files inside the existing `hooks/` and `hooks/tests/` top-level entries (no NEW top-level child), so the gate would not fire on it — verifying the false-positive direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)