### PR TITLE
code-review: ripple-triage row for reviewer-routing table edits

### DIFF
--- a/claude/.claude/skills/code-review/SKILL.md
+++ b/claude/.claude/skills/code-review/SKILL.md
@@ -232,6 +232,7 @@ table as new patterns emerge.
 | Adds or changes CDC / change-stream / ETL/ELT pipeline / warehouse ingestion connector | `staff-data-engineer` (transport, schema-drift, observability) + `staff-platform-engineer` (operational footprint) |
 | Modifies CI/CD pipelines or deploy config | `staff-platform-engineer` + `staff-backend-engineer` — verify pipelines and environment consistency |
 | Changes runtime config (env vars, secrets, feature flags) | `staff-platform-engineer` + `ciso-reviewer` — verify config is consistent across environments, check for leaked secrets |
+| Reshapes reviewer ownership (substantive edits to plan-review/code-review skill routing tables, or scope language in `agents/*.md`) | Spawn every persona named in the pre- or post-edit table — each evaluates whether their row (or its removal) is accurate, scoped, and not bleeding into another lane. The pre/post union ensures a row deletion still spawns the affected persona. For an `agents/*.md` edit, spawn the edited persona plus their Item-ownership co-owners. Skip whitespace / typo / copy-edit-only diffs. File-path domain detection cannot infer this; the personas can. |
 
 **Output:** If no impacts, state which boundaries you checked and why
 none are affected. If impacts exist, spawn the named subagents in


### PR DESCRIPTION
## The gap PR #49 left open

PR #49 generalized the self-scoping principle to all rows in the
ripple-triage table — markdown taxonomy diffs that "establish, document,
restructure, or formalize the taxonomy operators use" should still fire
the named reviewers. That made the dispatcher more likely to do the
right thing on routing-table edits, but didn't *guarantee* it. A diff
that edits the reviewer-routing table itself looks like a docs change
to file-path heuristics, so the dispatcher can still infer "no
specialists needed" and skip the spawn.

A specific row removes the inference.

## Evidence the gap manifests

A real review (markdown-only diff to a reviewer-roles table in a
private project's plan-review skill) returned "no cross-boundary impact,
skip specialist spawn" on first pass. The user pushed back; spawning all
listed personas in a follow-up turn surfaced multiple load-bearing
routing issues (lock-budget misroute, observability co-ownership) that
had to be fixed in a follow-up commit. Without the prompt, those
misroutes would have shipped.

PR #49 makes that first pass less likely to skip — but doesn't
guarantee it. A specific row removes the inference.

## The new row

```
| Reshapes reviewer ownership (substantive edits to plan-review/code-review skill routing tables, or scope language in `agents/*.md`) | Spawn every persona named in the pre- or post-edit table — each evaluates whether their row (or its removal) is accurate, scoped, and not bleeding into another lane. The pre/post union ensures a row deletion still spawns the affected persona. For an `agents/*.md` edit, spawn the edited persona plus their Item-ownership co-owners. Skip whitespace / typo / copy-edit-only diffs. File-path domain detection cannot infer this; the personas can. |
```

## Recursive self-review

The new row's rule applies to this PR's own diff. All 8 personas
named in the spawn column of any ripple-triage row were consulted.
Substantive findings folded into the row before commit:

- **Pre/post-edit union** (ciso-reviewer + staff-product-engineer):
  a diff that *removes* a persona's row would not spawn them under
  "every persona listed in the table being edited" — they're no
  longer listed. Fixed by phrasing as pre- or post-edit union.
- **Voice convention** (staff-product-engineer): the Change-type
  column keys on what the change does for an operator, not file
  patterns. Reworded "Modifies a reviewer-routing table" →
  "Reshapes reviewer ownership".
- **`agents/*.md` scope mismatch** (staff-backend-engineer +
  ciso-reviewer): an agent file describes a single persona, not a
  table — "every persona listed in the table" doesn't translate.
  Resolved by spawning the edited persona plus their Item-ownership
  co-owners for agent-file edits.
- **Typo carve-out** (staff-platform-engineer): 8-persona fan-out on
  a whitespace fix trains people to skip the step. Carved out
  whitespace / typo / copy-edit-only diffs.

Out-of-scope finding (captured for a future plan): staff-sdet
proposed a mechanical-trigger hook fixture and a required PR-body
marker line. Worth considering separately; not in this PR's scope.

## Test plan

- [x] Self-review: all 8 personas spawned per new row's own rule
- [x] Reviewer findings folded into row text
- [ ] Future routing-table edits exercise the new row in practice

🤖 Generated with [Claude Code](https://claude.com/claude-code)