### PR TITLE
code-review: require Consulted: line in output for grep-able spawn audit

### DIFF
--- a/claude/.claude/skills/code-review/SKILL.md
+++ b/claude/.claude/skills/code-review/SKILL.md
@@ -182,6 +182,8 @@ Apply when changed files match `.lovable/**`.
 
 Start with a one-line summary of which domains were detected (e.g., "Domains: Infrastructure, Backend").
 
+If ripple-effect subagents were spawned, follow with a `Consulted:` line listing every persona by name, comma-separated and case-exact (e.g., "Consulted: ciso-reviewer, staff-backend-engineer"). Omit the line entirely when no subagents were spawned. The fixed prefix `Consulted: ` makes the spawn grep-able post hoc.
+
 For each finding, state:
 
 1. **Which checklist item** (by number and name)


### PR DESCRIPTION
## What

Addresses the deferred staff-sdet finding from PR #56: the routing-table row mandates spawning every persona, but the spawn produced no audit artifact a future reviewer could verify. This adds a fixed-prefix `Consulted:` line to the `Output format` section requiring the dispatcher to enumerate every persona spawned, making the spawn grep-able post hoc.

## Diff

```
+ If ripple-effect subagents were spawned, follow with a `Consulted:` line listing every persona by name, comma-separated and case-exact (e.g., "Consulted: ciso-reviewer, staff-backend-engineer"). Omit the line entirely when no subagents were spawned. The fixed prefix `Consulted: ` makes the spawn grep-able post hoc.
```

## Why this placement (Output format, not row 235)

Initial draft was a one-line addition to row 235 (the routing-table row added in PR #56). staff-product-engineer's recursive review flagged the placement as scope-asymmetric: every other ripple-fire (RLS edits, API shape changes, etc.) also benefits from a `Consulted:` audit, so the requirement belongs in the global Output format section, not bolted onto one row. Net effect: same prose budget, broader coverage, no asymmetry.

## Format pinning

staff-sdet flagged the original draft as underspecified — `Consulted -`, lowercase, or space-separated would have all looked compliant to a generating agent but broken `grep -E '^Consulted: '` audits. Pinned: case-exact `Consulted: ` prefix, comma-separated, omit entirely on zero spawns.

## Recursive self-review

This PR substantively edits the spawn-cell semantics indirectly (the new global Output requirement applies to all ripple-fires, including future routing-table edits). The new row 235's own rule fires; all 8 personas were spawned. Findings folded in:

- **staff-product-engineer (Request changes → resolved)**: lift to Output format, drop from row 235. Done.
- **staff-sdet (Approve with concerns → resolved)**: pin case-exact prefix and comma-separator. Done.
- **ciso-reviewer**: confirmed `Consulted:` is observability, not a security control; no provenance / sidecar marker needed.
- **staff-platform-engineer**: confirmed `Consulted:` must NOT be coupled to require-code-review.sh marker (would conflate audit with cleanliness).
- **staff-backend-engineer, staff-frontend-engineer, staff-data-engineer, staff-analytics-engineer**: out of lane.

## Out of scope (explicitly deferred)

A hook that mechanically validates the `Consulted:` line on commit. Discussed with the user; the prose-only approach was chosen because the marginal value over PR #49's general nudge + PR #56's specific row + this audit artifact does not justify ~50 LOC + tests + skill/hook coupling.

## Test plan

- [x] Recursive self-review by all 8 personas
- [x] Reviewer findings folded into final placement and format
- [ ] Future ripple-fire reviews exercise the new `Consulted:` line in practice

Consulted: ciso-reviewer, staff-backend-engineer, staff-product-engineer, staff-sdet, staff-frontend-engineer, staff-data-engineer, staff-analytics-engineer, staff-platform-engineer

🤖 Generated with [Claude Code](https://claude.com/claude-code)