### PR TITLE
require-worktree hook: append cwd-anchor note on chained cd && git

### DIFF
--- a/claude/.claude/hooks/require-worktree-for-git-writes.sh
+++ b/claude/.claude/hooks/require-worktree-for-git-writes.sh
@@ -31,6 +31,23 @@ emit_deny() {
     "$reason_json"
 }
 
+# When the command chains `cd ... <op> ... git ...`, the agent likely
+# expected the inline `cd` to land inside a worktree. This hook reads
+# CWD from the JSON tool_input — which reflects Claude Code's bash
+# tool's *persisted* cwd from prior calls, not the cwd produced by the
+# inline `cd` in the current command. The hook fires before the
+# subshell runs, so the inline `cd` hasn't taken effect yet. Returns a
+# self-correction note for the agent when this pattern is detected;
+# empty otherwise. Pattern requires `cd` as a word, then a chain
+# operator, then `git` somewhere later — this targets the precise
+# failure mode (`cd /worktree && git ...`) and avoids false positives
+# on path strings containing `cd` as a substring.
+cwd_anchor_note_if_chained() {
+  if printf '%s' "$1" | grep -qE '(^|[[:space:]])cd[[:space:]].*(&&|\|\||;).*git'; then
+    printf '%s' " If you just chained 'cd /path/to/worktree && git ...' and expected the inline cd to land you in the worktree: this hook reads cwd from Claude Code's session-persisted bash state (set by prior Bash calls), not from your inline cd, because the hook fires before the subshell runs. Anchor cwd by running 'cd /path/to/worktree' as its own Bash call first, then retry the git op in a follow-up call."
+  fi
+}
+
 # Fail-closed on malformed input: if jq couldn't parse the stdin JSON, we
 # can't tell what Claude is about to run, so deny rather than silently allow.
 if [ "$JQ_EXIT" -ne 0 ]; then
@@ -178,12 +195,12 @@ while IFS= read -r fragment; do
 
   subcmd=$(extract_git_subcmd "$fragment")
   if [ -z "$subcmd" ]; then
-    emit_deny "Blocked by worktree-enforcement hook: could not determine the git subcommand in '$fragment'. This repo has opted into worktree discipline (.claude/worktree-required is committed). Run git write operations from inside a linked worktree — either change the session cwd into an existing worktree under .claude/worktrees/, use the EnterWorktree tool, or spawn an agent with isolation: worktree."
+    emit_deny "Blocked by worktree-enforcement hook: could not determine the git subcommand in '$fragment'. This repo has opted into worktree discipline (.claude/worktree-required is committed). Run git write operations from inside a linked worktree — either change the session cwd into an existing worktree under .claude/worktrees/, use the EnterWorktree tool, or spawn an agent with isolation: worktree.$(cwd_anchor_note_if_chained "$COMMAND")"
     exit 0
   fi
 
   if ! [[ "$subcmd" =~ ^($ALLOWED_RE)$ ]]; then
-    emit_deny "Blocked by worktree-enforcement hook: 'git $subcmd' is not on the read-only allowlist, and this session is running in the main working tree of a repo that has opted into worktree discipline (.claude/worktree-required is committed). Run git write operations from inside a linked worktree — cd into an existing worktree under .claude/worktrees/, create one with 'git worktree add .claude/worktrees/<branch> -b <branch>' (that specific command is allowed on the main tree), or spawn an agent with isolation: worktree. See claude-config README 'Worktree enforcement' for details."
+    emit_deny "Blocked by worktree-enforcement hook: 'git $subcmd' is not on the read-only allowlist, and this session is running in the main working tree of a repo that has opted into worktree discipline (.claude/worktree-required is committed). Run git write operations from inside a linked worktree — cd into an existing worktree under .claude/worktrees/, create one with 'git worktree add .claude/worktrees/<branch> -b <branch>' (that specific command is allowed on the main tree), or spawn an agent with isolation: worktree. See claude-config README 'Worktree enforcement' for details.$(cwd_anchor_note_if_chained "$COMMAND")"
     exit 0
   fi
 done <<< "$FRAGMENTS"

--- a/claude/.claude/hooks/tests/test_hooks.py
+++ b/claude/.claude/hooks/tests/test_hooks.py
@@ -90,6 +90,24 @@ def run_hook(hook: Path, tool_input: dict, cwd: Path | None = None) -> str:
     return payload["hookSpecificOutput"]["permissionDecision"]
 
 
+def run_hook_reason(hook: Path, tool_input: dict, cwd: Path | None = None) -> str | None:
+    """Like `run_hook` but returns the deny `permissionDecisionReason` string
+    (or `None` if the hook allowed silently). Used by tests that need to
+    assert on the contents of the deny message, not just the decision."""
+    result = subprocess.run(
+        [str(hook)],
+        input=json.dumps(tool_input),
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+        check=False,
+    )
+    if not result.stdout.strip():
+        return None
+    payload = json.loads(result.stdout)
+    return payload["hookSpecificOutput"].get("permissionDecisionReason")
+
+
 def bash_input(command: str, session_id: str | None = None) -> dict:
     payload: dict = {"tool_name": "Bash", "tool_input": {"command": command}}
     if session_id is not None:
@@ -2195,6 +2213,69 @@ class TestRequireWorktreeForGitWrites:
             )
             == "allow"
         )
+
+    # The cwd-anchor note is appended to the deny reason ONLY when the
+    # command shows a `cd ... && git ...` (or `;` / `||`) pattern. This
+    # is the precise failure mode where the agent expected its inline cd
+    # to put it in a worktree, but the hook reads cwd from the JSON
+    # tool_input — Claude Code's persisted bash cwd from prior calls,
+    # not the cwd the inline cd would produce after this hook returns.
+    # Tests cover three positive cases (each chain operator) and a
+    # negative case (no chained cd → no note appended).
+
+    def test_chained_cd_amp_git_appends_anchor_note(self, opted_in_repo):
+        reason = run_hook_reason(
+            WORKTREE_HOOK,
+            bash_input("cd /tmp && git commit -m foo"),
+            cwd=opted_in_repo,
+        )
+        assert reason is not None
+        assert "session-persisted" in reason
+        assert "Anchor cwd" in reason
+
+    def test_chained_cd_semicolon_git_appends_anchor_note(self, opted_in_repo):
+        reason = run_hook_reason(
+            WORKTREE_HOOK,
+            bash_input("cd /tmp; git commit -m foo"),
+            cwd=opted_in_repo,
+        )
+        assert reason is not None
+        assert "session-persisted" in reason
+
+    def test_chained_cd_or_git_appends_anchor_note(self, opted_in_repo):
+        """`||` chain (run-if-fail) is unusual but parses the same way —
+        cwd note still appended so the agent gets the hint."""
+        reason = run_hook_reason(
+            WORKTREE_HOOK,
+            bash_input("cd /tmp || git commit -m foo"),
+            cwd=opted_in_repo,
+        )
+        assert reason is not None
+        assert "session-persisted" in reason
+
+    def test_plain_git_no_anchor_note(self, opted_in_repo):
+        """No chained cd → cwd note not appended; deny message stays
+        short for the common case."""
+        reason = run_hook_reason(
+            WORKTREE_HOOK,
+            bash_input("git commit -m foo"),
+            cwd=opted_in_repo,
+        )
+        assert reason is not None
+        assert "session-persisted" not in reason
+        assert "Anchor cwd" not in reason
+
+    def test_cd_after_git_no_anchor_note(self, opted_in_repo):
+        """`git ... && cd ...` is the reverse of the trigger pattern —
+        the cd is AFTER the git, not before. The note targets the
+        chained-cd-before-git mistake, so this case must NOT match."""
+        reason = run_hook_reason(
+            WORKTREE_HOOK,
+            bash_input("git commit -m foo && cd /tmp"),
+            cwd=opted_in_repo,
+        )
+        assert reason is not None
+        assert "session-persisted" not in reason
 
 
 # --- require-stow-reminder.sh ----------------------------------------


### PR DESCRIPTION
## Summary

- Refines the deny message in `require-worktree-for-git-writes.sh` so that when the offending command shows a `cd ... <chain> ... git ...` pattern, the deny reason appends a self-correction note explaining the hook reads cwd from Claude Code's session-persisted bash state — not from the inline `cd` — and pointing at the fix (anchor cwd via a standalone `cd /path/to/worktree` Bash call before the git op).
- Conditional append: pattern requires `cd <word> <chain-op> ... git`. Plain `git commit` from the main tree gets the original message unchanged. Targeting keeps the common deny short.
- 5 new tests on `TestRequireWorktreeForGitWrites` covering each chain operator (`&&`, `;`, `||`), a plain-git negative case, and a reverse-order (`git ... && cd ...`) negative case. Adds `run_hook_reason()` helper for tests that need to assert on deny message contents.

## Why

This session, I tripped on the same gotcha twice while opening follow-up PRs in this repo: ran `cd /worktree && git add ...` chained into a single Bash call, expected the cd to land me in the worktree, got denied because the hook reads cwd from JSON `tool_input` (the bash tool's *persisted* cwd from prior calls), not from the inline cd in the current command.

Initially I reached for an auto-memory entry to capture the workaround. Audited that against the `ai-instruction-and-memory-files` skill and the answer was clear: structural enforcement at moment-of-need beats always-loaded prose. The hook is the natural place — it's already 100% effective at denying, and the deny reason is the artifact the agent reads when it self-corrects. Adding the explanation there delivers the lesson exactly when it's needed and costs zero session-context budget when irrelevant.

## Test plan

- [x] 5 new tests under `TestRequireWorktreeForGitWrites` covering both append paths and non-append paths.
- [x] Full suite 225/225 green (added 5; was 220 after #55 + #57 landed).
- [x] Manual trace: regex `(^|[[:space:]])cd[[:space:]].*(&&|\|\||;).*git` is ERE-compatible; `\|\|` correctly matches literal `||`. Word-anchored `cd` boundary prevents false positives on substring matches inside paths or other tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)