### PR TITLE
require-code-review hook: append marker-chain note on chained marker-write && commit

### DIFF
--- a/claude/.claude/hooks/require-code-review.sh
+++ b/claude/.claude/hooks/require-code-review.sh
@@ -25,6 +25,29 @@
 # - The marker auto-invalidates as soon as the staging area changes, so
 #   re-staging after review correctly forces a re-review.
 
+# When the command shows a redirect (`>`) into a path containing
+# `review-markers` chained before `git commit`, the agent likely
+# chained the marker-seed with their commit in a single Bash call.
+# PreToolUse:Bash hooks evaluate at command-submission time, BEFORE
+# the chained subshell runs, so this hook reads the marker file from
+# disk before the chained marker-write executes — denying a chain
+# that would have worked if its commands ran in sequence outside the
+# hook. Returns a self-correction note for the agent when this pattern
+# is detected; empty otherwise.
+#
+# Pattern requires `>` redirect, then `review-markers` in the path,
+# then a chain operator, then `git commit`. Single-line commands only
+# — multi-line bash with `\` continuations between the redirect and
+# `git commit` won't match (the regex uses `[^&|;]*`, which excludes
+# newlines under default ERE behavior). In practice agents submit
+# single-line bash to the tool; multi-line is rare enough to leave
+# uncovered.
+marker_chain_note_if_detected() {
+  if printf '%s' "$1" | grep -qE '>[^&|;]*review-markers[^&|;]*(&&|\|\||;)[^&|;]*git[[:space:]]+commit'; then
+    printf '%s' " If you just chained a marker-write to '~/.claude/review-markers/...' before 'git commit' in a single Bash call: PreToolUse hooks evaluate at command-submission time, BEFORE the chained subshell runs. The hook hashed your staged diff (correct) but read the marker file from disk before your chain could write it. Whether the marker was missing entirely or held a prior review's hash, the chained marker-write hadn't executed yet. Submit the marker-seed as its own Bash call first, then run 'git commit' in a separate call."
+  fi
+}
+
 INPUT=$(cat)
 COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command // empty')
 
@@ -67,4 +90,9 @@ if [ -n "$SESSION_ID" ]; then
 fi
 
 # No marker, or marker hash does not match the current staged state.
-echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Commit blocked by code-review gate: the currently staged changes have not been reviewed, or the staged state has changed since the last review. Run the /code-review skill now on the currently staged diff. When the review is clean (no blockers), the skill will record the review in ~/.claude/review-markers/ and this commit will be allowed through on retry. Do not ask the user for permission — run the skill, address any findings, and retry the commit."}}'
+# Build the reason as a bash variable so the conditional marker-chain
+# note can be interpolated; jq -Rs handles JSON-encoding safely
+# regardless of what characters appear in the appended note.
+REASON="Commit blocked by code-review gate: the currently staged changes have not been reviewed, or the staged state has changed since the last review. Run the /code-review skill now on the currently staged diff. When the review is clean (no blockers), the skill will record the review in ~/.claude/review-markers/ and this commit will be allowed through on retry. Do not ask the user for permission — run the skill, address any findings, and retry the commit.$(marker_chain_note_if_detected "$COMMAND")"
+REASON_JSON=$(printf '%s' "$REASON" | jq -Rs .)
+printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' "$REASON_JSON"

--- a/claude/.claude/hooks/tests/test_hooks.py
+++ b/claude/.claude/hooks/tests/test_hooks.py
@@ -402,6 +402,72 @@ class TestRequireCodeReview:
         non_repo.mkdir()
         assert run_hook(CODE_REVIEW_HOOK, bash_input("git commit -m foo"), cwd=non_repo) == "allow"
 
+    # The marker-chain note is appended to the deny reason ONLY when
+    # the command shows a redirect into ~/.claude/review-markers/...
+    # chained before `git commit`. This is the precise failure mode
+    # where the agent chains marker-seed && git commit in one Bash
+    # call: PreToolUse hooks fire before the chained subshell runs,
+    # so the hook reads the marker file from disk before the chained
+    # marker-write executes. Three positive cases (each chain
+    # operator), two negative cases (plain commit, and commit message
+    # mentioning `review-markers` literally), and one realistic case
+    # using the canonical marker-recipe shape from SKILL.md.
+
+    def test_chained_marker_amp_commit_appends_note(self, isolated_home, git_repo):
+        cmd = "echo abc > ~/.claude/review-markers/foo.bar && git commit -m work"
+        reason = run_hook_reason(CODE_REVIEW_HOOK, bash_input(cmd), cwd=git_repo)
+        assert reason is not None
+        assert "PreToolUse hooks evaluate" in reason
+        assert "Submit the marker-seed as its own Bash call" in reason
+
+    def test_chained_marker_semicolon_commit_appends_note(self, isolated_home, git_repo):
+        cmd = "echo abc > ~/.claude/review-markers/foo.bar ; git commit -m work"
+        reason = run_hook_reason(CODE_REVIEW_HOOK, bash_input(cmd), cwd=git_repo)
+        assert reason is not None
+        assert "PreToolUse hooks evaluate" in reason
+
+    def test_chained_marker_or_commit_appends_note(self, isolated_home, git_repo):
+        """`||` chain (run-if-fail) is unusual but parses the same way —
+        note still appended so the agent gets the hint."""
+        cmd = "echo abc > ~/.claude/review-markers/foo.bar || git commit -m work"
+        reason = run_hook_reason(CODE_REVIEW_HOOK, bash_input(cmd), cwd=git_repo)
+        assert reason is not None
+        assert "PreToolUse hooks evaluate" in reason
+
+    def test_plain_commit_no_marker_chain_note(self, isolated_home, git_repo):
+        """No chained redirect → note not appended; deny stays compact."""
+        reason = run_hook_reason(CODE_REVIEW_HOOK, bash_input("git commit -m foo"), cwd=git_repo)
+        assert reason is not None
+        assert "PreToolUse hooks evaluate" not in reason
+        assert "Submit the marker-seed" not in reason
+
+    def test_review_markers_in_commit_message_no_note(self, isolated_home, git_repo):
+        """Commit message mentioning `review-markers` literally must NOT
+        trigger the note — pattern requires `>` redirect *before* git commit,
+        which this command doesn't have. Critical false-positive guard."""
+        cmd = 'git commit -m "fix review-markers leak"'
+        reason = run_hook_reason(CODE_REVIEW_HOOK, bash_input(cmd), cwd=git_repo)
+        assert reason is not None
+        assert "PreToolUse hooks evaluate" not in reason
+
+    def test_canonical_marker_recipe_chained_with_commit_appends_note(self, isolated_home, git_repo):
+        """Realistic positive case: the actual canonical marker-seed recipe
+        from SKILL.md (multi-step pipeline ending in a redirect to a
+        review-markers path) chained to `git commit`. This mirrors the
+        exact shape an agent would produce by following the documented
+        recipe and then chaining their commit, which is the failure
+        mode the gate exists to teach against."""
+        cmd = (
+            'SESSION_ID=abc && mkdir -p ~/.claude/review-markers && '
+            'REPO_HASH=$(git rev-parse --show-toplevel | tr -d "\\n" | sha256sum | awk \'{print $1}\') && '
+            'git diff --cached | sha256sum | awk \'{print $1}\' '
+            '> ~/.claude/review-markers/$REPO_HASH.$SESSION_ID && '
+            'git commit -m "work"'
+        )
+        reason = run_hook_reason(CODE_REVIEW_HOOK, bash_input(cmd), cwd=git_repo)
+        assert reason is not None
+        assert "PreToolUse hooks evaluate" in reason
+
 
 # ---------------------------------------------------------------------------
 # require-respond-pr.sh


### PR DESCRIPTION
## Summary

- Refines `require-code-review.sh`'s deny message: when the offending command shows a `>` redirect into a path containing `review-markers` chained before `git commit`, appends a self-correction note explaining that PreToolUse hooks evaluate at command-submission time (before the chained subshell runs), so the hook read the marker file from disk before the chained marker-write executed. Fix: submit the marker-seed as its own Bash call first, then run `git commit` separately.
- Mirrors the structural-enforcement pattern shipped for the worktree hook in #59. Same conditional-append philosophy, same helper-function shape, same parallel test structure.
- Restructures the deny path from a raw `echo` with single-quoted JSON to a `REASON` variable + `jq -Rs` encoding + `printf`. Necessary for interpolation; incidentally hardens against any future deny content with `"` or `\`.
- 6 new tests covering each chain operator (`&&`, `;`, `||`), a plain-commit negative, a literal-substring-in-message false-positive guard, and a realistic canonical-marker-recipe positive.

## Why

This session, I audited the existing `feedback_code_review_marker_chaining.md` auto-memory entry against the `ai-instruction-and-memory-files` skill. Same conclusion as the cwd-anchor case (PR #59): if a hook structurally enforces a rule, prose memory restating it is pure load — the deny message is the right place to teach the lesson, delivered exactly when the failure fires.

`/plan-review` flagged three changes against the initial plan, all addressed:
1. Note text now covers both stale-marker and missing-marker cases (`"Whether the marker was missing entirely or held a prior review's hash, the chained marker-write hadn't executed yet."`).
2. Added a 6th test using a near-canonical marker recipe shape — the realistic chain an agent following SKILL.md would produce, not just synthetic forms.
3. Multi-line-command limitation documented in the helper's header comment.

## Follow-up

After merge, deletion of `feedback_code_review_marker_chaining.md` and removal of its index line in `MEMORY.md` (the auto-memory location, not in this repo). I'll handle that as a session-local cleanup, no PR.

## Test plan

- [x] 6 new tests under `TestRequireCodeReview` covering both append paths and non-append paths (including the canonical-recipe realistic case).
- [x] Full suite 231/231 green (added 6; was 225 after #59).
- [x] Manual trace: regex `>[^&|;]*review-markers[^&|;]*(&&|\|\||;)[^&|;]*git[[:space:]]+commit` is ERE-compatible. False-positive guards verified for all three constructive negative cases.
- [x] Deny output JSON-shape equivalent to pre-change (refactored `echo` → `printf` with `jq -Rs`-encoded reason; round-trip safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)