### PR TITLE
plan-review + code-review: design-fitness gate, default-to-judgment, prior-round context

### DIFF
--- a/claude/.claude/skills/code-review/SKILL.md
+++ b/claude/.claude/skills/code-review/SKILL.md
@@ -225,25 +225,31 @@ After the implementation-fitness gate and the checklist review,
 consider whether the change crosses system boundaries in a way that
 exceeds your own judgment depth.
 
-You are the principal-engineer-generalist running this skill. The
-specialist subagents below have narrower lane depth, not broader
-context. **Form your own ripple judgment first** using the table as
-a reference for what boundaries exist in the change.
+You are the principal-engineer-generalist running this skill. Code
+review is the last gate before changes ship — a specialist miss is
+a regression in production. Be more conservative about self-judging
+than at plan-review, where misses are recoverable.
 
-Spawn a specialist only when at least one applies:
+**Form your own ripple judgment first** using the table as a reference
+for what boundaries exist. Spawn a specialist only when one of these
+applies (same escalation logic as plan-review's Reviewer roles —
+repeated because skills load on demand, not because the rule differs):
 
-- **Below-staff-level depth in a specific domain.** Specialized kernels
-  of expertise — query-planner internals, cryptography primitives,
-  fine-grained accessibility, kernel-level concurrency — not "general
-  knowledge in domain X."
-- **High-stakes domain boundary.** RLS, auth, billing, payment, data
-  migration, privileged operations. A specialist's second pair of eyes
-  is worth the spawn even at staff generalist depth.
-- **Holistic-reasoning overload.** Multi-domain ripple where you
-  genuinely can't hold all the lanes in working memory at once.
-- **Convergence-as-design-tell** from a prior round (see Reconciliation
-  below).
-- **Explicit user request** for specialist review.
+- **Below-staff-level depth** in a specialized kernel (cryptography,
+  query-planner internals, fine-grained accessibility, kernel-level
+  concurrency, etc. — not "general domain knowledge").
+- **High-stakes domain boundary**: RLS, auth, billing, payment, data
+  migration, privileged operations.
+- **Holistic-reasoning overload** across multiple domains.
+- **Convergence-as-design-tell** from a prior round (see Reconciliation).
+- **Explicit user request**.
+
+Always spawn `ciso-reviewer` when the change touches authentication or
+authorization, secrets, tokens, data exposure, logging of sensitive
+data, third-party data sharing, or infrastructure permissions —
+high-stakes-boundary case is non-optional at the last gate. Always
+spawn `staff-product-engineer` when the change alters user-facing
+behavior.
 
 Spawn per question, not per file-path domain — "change touches
 `.github/`" isn't enough; the question needs a specific shape.
@@ -289,6 +295,9 @@ to verify the checkout flow in CheckoutPage.tsx still enforces
 ownership after the new validation" is actionable.
 
 ## Reconciliation
+
+*Same logic as plan-review's Reconciliation — repeated because skills
+load on demand.*
 
 After spawned reviewers return findings, pause if findings concentrate
 on a single surface — the same feature, implementation detail, or

--- a/claude/.claude/skills/code-review/SKILL.md
+++ b/claude/.claude/skills/code-review/SKILL.md
@@ -36,35 +36,28 @@ content; the dispatcher only has paths.
 
 ## Step 1 — Implementation-fitness gate
 
-Before reviewing for gaps in the change, answer one question: **is the
-implementation appropriately sized for what the change needed to
-accomplish?**
-
-A change can pass every checklist item and still be the wrong artifact —
-adding machinery, layers, or instrumentation that serve no consumer.
-Gap-finding on an over-elaborate change elaborates it further; the
-checklist won't surface "the whole implementation is the wrong shape."
+Before reviewing for gaps, answer: **is the implementation appropriately
+sized for what the change needed to accomplish?** Gap-finding on an
+over-elaborate change elaborates it further, and the checklist won't
+surface "the whole implementation is the wrong shape."
 
 Markers of over-elaboration:
 
 - Captured outputs / artifacts / fields with no reader downstream.
-- Layers that duplicate a higher-level abstraction that already runs
+- Layers that duplicate a higher-level abstraction already running
   the same work.
 - Defensive paths against attack scenarios that haven't been observed.
 - Granularity exceeding the actual consumer's need.
 - Conditional logic for future phases that may not arrive.
 
-If the implementation is over-elaborated: stop. Surface the simpler
-implementation as the primary review output before any checklist
-item. Gap-finding on the over-elaborate version drives elaboration
-further; the simpler implementation must be considered first.
+If over-elaborated: stop. Surface the simpler implementation as the
+primary review output before any checklist item.
 
-If under-elaborated (missing required handling): proceed to the
-checklist; gap-finding will surface what's missing.
+Otherwise (fit, or under-elaborated): proceed to the checklist;
+gap-finding will surface what's missing.
 
-Question implementation choices (how the change is built), not feature
-scope (what the change is required to do). Feature scope is fixed by
-the ticket; implementation choice is reviewer-tunable.
+Question implementation choices, not feature scope. Feature scope is
+fixed by the ticket; implementation choice is reviewer-tunable.
 
 ## Base checklist
 
@@ -252,23 +245,15 @@ Spawn a specialist only when at least one applies:
   below).
 - **Explicit user request** for specialist review.
 
-Spawn per question, not per file-path domain. "The change touches
-`.github/`" is not enough to spawn `staff-platform-engineer`; "the
-change introduces a deploy-window-sensitive migration in the workflow
-and I want a specialist read on lock-budget under load" is.
+Spawn per question, not per file-path domain — "change touches
+`.github/`" isn't enough; the question needs a specific shape.
 
-When you do spawn:
-
-- Spawn on the CODE, not on this review's output. Each subagent reads
-  the diff fresh; passing a summarized review as a substitute for the
-  source drops the signal specialist review is designed to catch.
-- Pick the specific specialist that serves your question (table is
-  reference, not roster).
-- Pass the diff scope, the specific question you're escalating, AND —
-  for re-review rounds — the prior round's findings plus what's been
-  applied since. Reviewers without prior context re-discover; that's
-  wasted spawn.
-- Each agent returns findings-only; reconcile per Reconciliation below.
+When you spawn: spawn on the CODE, not on this review's output (each
+subagent reads the diff fresh); pick the specific specialist that
+serves the question (table is reference, not roster); pass the diff
+scope, the specific question, AND — for re-review rounds — the prior
+round's findings + what's been applied since. Reviewers without prior
+context re-discover; that's wasted spawn.
 
 The Change type column below keys on what the change *does for an
 operator or consumer*, not on which file types changed. A markdown-only
@@ -293,12 +278,10 @@ longer a default-fire trigger.
 | Reshapes reviewer ownership (substantive edits to plan-review/code-review skill routing tables, or scope language in `agents/*.md`) | Spawn every persona named in the pre- or post-edit table — each evaluates whether their row (or its removal) is accurate, scoped, and not bleeding into another lane. The pre/post union ensures a row deletion still spawns the affected persona. For an `agents/*.md` edit, spawn the edited persona plus their Item-ownership co-owners. Skip whitespace / typo / copy-edit-only diffs. File-path domain detection cannot infer this; the personas can. |
 
 **Output:** State which boundaries you considered and what your
-generalist judgment was on each. If you escalated to specialists,
-list which ones and why; if you didn't, name the boundary and your
-read. Empty findings on a boundary you considered is a valid result —
-"considered DB-access boundary; the change touches RLS but only adds
-a deny-by-default policy on a new admin-only table, no escalation
-path I can't evaluate" — write that, don't omit it.
+generalist judgment was on each. If you escalated, list which
+specialists and why; if you didn't, name the boundary and your read.
+Empty findings on a boundary you considered is a valid result — write
+the read, don't omit it.
 
 When you do spawn a specialist, be specific about what to check.
 "Spawn `ciso-reviewer`" is useless; "Spawn `ciso-reviewer` and ask it
@@ -307,30 +290,21 @@ ownership after the new validation" is actionable.
 
 ## Reconciliation
 
-After spawned reviewers return findings, before applying anything,
-pause if findings concentrate on a single surface — the same feature,
-implementation detail, or design choice attracting multiple gaps from
-different reviewers. Concentration is a tell, but the tell has two
-readings:
+After spawned reviewers return findings, pause if findings concentrate
+on a single surface — the same feature, implementation detail, or
+design choice attracting multiple gaps. Two readings:
 
 - **Implementation-wrong-shape.** The surface is the wrong abstraction;
-  gaps will keep multiplying as you patch, because each patch closes
-  one gap by adding machinery that opens another. Replacement, not
-  patch-by-patch closure, is the fix.
-- **Prompt-overlap artifact.** The reviewers were given similar prompts
-  and produced N voices of the same observation. Convergence looks
-  like signal but is framing-induced repetition.
+  gaps will keep multiplying as you patch. Replace, don't patch-by-patch.
+- **Prompt-overlap artifact.** Reviewers given similar prompts produce
+  N voices of the same observation. Convergence looks like signal but
+  is framing-induced.
 
-You judge which reading applies. Both happen. The wrong move is to
-treat convergence as automatic authority for "patch each gap" — that's
-how an over-elaborate change accumulates more elaboration until the
-diff doubles in size.
-
-If the reading is implementation-wrong-shape, replace the surface and
-re-run the implementation-fitness gate. If it's prompt-overlap, apply
-the underlying finding once and skip the redundant copies; note the
-overlap so you write tighter, less-overlapping prompts on the next
-spawn.
+You judge which applies. Don't treat convergence as automatic authority
+for "patch each gap." If implementation-wrong-shape, replace the
+surface and re-run Step 1. If prompt-overlap, apply the underlying
+finding once, skip duplicates, and note the overlap so the next spawn
+uses tighter prompts.
 
 ## Item ownership
 

--- a/claude/.claude/skills/code-review/SKILL.md
+++ b/claude/.claude/skills/code-review/SKILL.md
@@ -34,6 +34,38 @@ returns early when the change is out of its lane. Trust the agents'
 self-scoping rather than gating at the dispatcher — agents have the diff
 content; the dispatcher only has paths.
 
+## Step 1 — Implementation-fitness gate
+
+Before reviewing for gaps in the change, answer one question: **is the
+implementation appropriately sized for what the change needed to
+accomplish?**
+
+A change can pass every checklist item and still be the wrong artifact —
+adding machinery, layers, or instrumentation that serve no consumer.
+Gap-finding on an over-elaborate change elaborates it further; the
+checklist won't surface "the whole implementation is the wrong shape."
+
+Markers of over-elaboration:
+
+- Captured outputs / artifacts / fields with no reader downstream.
+- Layers that duplicate a higher-level abstraction that already runs
+  the same work.
+- Defensive paths against attack scenarios that haven't been observed.
+- Granularity exceeding the actual consumer's need.
+- Conditional logic for future phases that may not arrive.
+
+If the implementation is over-elaborated: stop. Surface the simpler
+implementation as the primary review output before any checklist
+item. Gap-finding on the over-elaborate version drives elaboration
+further; the simpler implementation must be considered first.
+
+If under-elaborated (missing required handling): proceed to the
+checklist; gap-finding will surface what's missing.
+
+Question implementation choices (how the change is built), not feature
+scope (what the change is required to do). Feature scope is fixed by
+the ticket; implementation choice is reviewer-tunable.
+
 ## Base checklist
 
 Evaluate the code against each item. Only flag items where there is a concrete issue — do not flag items just to show you checked them.
@@ -196,31 +228,55 @@ If no issues are found, say: "No issues found" — do not pad with praise or gen
 
 ## Ripple effect triage
 
-After the checklist review, identify whether the change crosses system
-boundaries and spawn specialist reviewer subagents via the Agent tool
-to evaluate the cross-boundary impact. This step is **always required** —
-even if the checklist found no issues, ripple effects may exist that only
-a domain specialist would catch.
+After the implementation-fitness gate and the checklist review,
+consider whether the change crosses system boundaries in a way that
+exceeds your own judgment depth.
 
-Spawn on the CODE, not on this review's output. Each subagent reads the
-diff fresh from its own perspective; passing a summarized review as a
-substitute for the source drops the signal that specialist review is
-designed to catch.
+You are the principal-engineer-generalist running this skill. The
+specialist subagents below have narrower lane depth, not broader
+context. **Form your own ripple judgment first** using the table as
+a reference for what boundaries exist in the change.
 
-The Change type column keys on what the change *does for an operator
-or consumer*, not on which file types changed. A markdown-only diff
-can still cross a runtime-config or CI/CD boundary if it establishes,
-documents, restructures, or formalizes the taxonomy operators use to
-provision secrets, identify deploy targets, or reason about config
-layering. When a row's trigger language is plausibly in scope but the
-file types don't make it obvious, default to firing the named
-reviewers — they self-scope against the diff and return early when the
-change is out of their lane. The cost is one subagent turn returning
-"no concerns"; the upside is catching impacts the dispatcher can't
-see from file paths alone.
+Spawn a specialist only when at least one applies:
 
-Evaluate the change against these cross-boundary patterns. Update this
-table as new patterns emerge.
+- **Below-staff-level depth in a specific domain.** Specialized kernels
+  of expertise — query-planner internals, cryptography primitives,
+  fine-grained accessibility, kernel-level concurrency — not "general
+  knowledge in domain X."
+- **High-stakes domain boundary.** RLS, auth, billing, payment, data
+  migration, privileged operations. A specialist's second pair of eyes
+  is worth the spawn even at staff generalist depth.
+- **Holistic-reasoning overload.** Multi-domain ripple where you
+  genuinely can't hold all the lanes in working memory at once.
+- **Convergence-as-design-tell** from a prior round (see Reconciliation
+  below).
+- **Explicit user request** for specialist review.
+
+Spawn per question, not per file-path domain. "The change touches
+`.github/`" is not enough to spawn `staff-platform-engineer`; "the
+change introduces a deploy-window-sensitive migration in the workflow
+and I want a specialist read on lock-budget under load" is.
+
+When you do spawn:
+
+- Spawn on the CODE, not on this review's output. Each subagent reads
+  the diff fresh; passing a summarized review as a substitute for the
+  source drops the signal specialist review is designed to catch.
+- Pick the specific specialist that serves your question (table is
+  reference, not roster).
+- Pass the diff scope, the specific question you're escalating, AND —
+  for re-review rounds — the prior round's findings plus what's been
+  applied since. Reviewers without prior context re-discover; that's
+  wasted spawn.
+- Each agent returns findings-only; reconcile per Reconciliation below.
+
+The Change type column below keys on what the change *does for an
+operator or consumer*, not on which file types changed. A markdown-only
+diff can still cross a runtime-config or CI/CD boundary if it
+restructures the taxonomy operators use to provision secrets, identify
+deploy targets, or reason about config layering. Use the table as a
+checklist of boundaries to *consider* during your own review; it is no
+longer a default-fire trigger.
 
 | Change type | Spawn |
 |-------------|-------|
@@ -236,16 +292,45 @@ table as new patterns emerge.
 | Changes runtime config (env vars, secrets, feature flags) | `staff-platform-engineer` + `ciso-reviewer` — verify config is consistent across environments, check for leaked secrets |
 | Reshapes reviewer ownership (substantive edits to plan-review/code-review skill routing tables, or scope language in `agents/*.md`) | Spawn every persona named in the pre- or post-edit table — each evaluates whether their row (or its removal) is accurate, scoped, and not bleeding into another lane. The pre/post union ensures a row deletion still spawns the affected persona. For an `agents/*.md` edit, spawn the edited persona plus their Item-ownership co-owners. Skip whitespace / typo / copy-edit-only diffs. File-path domain detection cannot infer this; the personas can. |
 
-**Output:** If no impacts, state which boundaries you checked and why
-none are affected. If impacts exist, spawn the named subagents in
-parallel against the current diff; each runs in its own context and
-returns findings independently. Reconcile the results and present a
-combined summary.
+**Output:** State which boundaries you considered and what your
+generalist judgment was on each. If you escalated to specialists,
+list which ones and why; if you didn't, name the boundary and your
+read. Empty findings on a boundary you considered is a valid result —
+"considered DB-access boundary; the change touches RLS but only adds
+a deny-by-default policy on a new admin-only table, no escalation
+path I can't evaluate" — write that, don't omit it.
 
-Be specific about what each reviewer should check. Name the file, flow,
-or function. "Spawn `ciso-reviewer`" is useless; "Spawn `ciso-reviewer`
-and ask it to verify the checkout flow in CheckoutPage.tsx still
-enforces ownership after the new validation" is actionable.
+When you do spawn a specialist, be specific about what to check.
+"Spawn `ciso-reviewer`" is useless; "Spawn `ciso-reviewer` and ask it
+to verify the checkout flow in CheckoutPage.tsx still enforces
+ownership after the new validation" is actionable.
+
+## Reconciliation
+
+After spawned reviewers return findings, before applying anything,
+pause if findings concentrate on a single surface — the same feature,
+implementation detail, or design choice attracting multiple gaps from
+different reviewers. Concentration is a tell, but the tell has two
+readings:
+
+- **Implementation-wrong-shape.** The surface is the wrong abstraction;
+  gaps will keep multiplying as you patch, because each patch closes
+  one gap by adding machinery that opens another. Replacement, not
+  patch-by-patch closure, is the fix.
+- **Prompt-overlap artifact.** The reviewers were given similar prompts
+  and produced N voices of the same observation. Convergence looks
+  like signal but is framing-induced repetition.
+
+You judge which reading applies. Both happen. The wrong move is to
+treat convergence as automatic authority for "patch each gap" — that's
+how an over-elaborate change accumulates more elaboration until the
+diff doubles in size.
+
+If the reading is implementation-wrong-shape, replace the surface and
+re-run the implementation-fitness gate. If it's prompt-overlap, apply
+the underlying finding once and skip the redundant copies; note the
+overlap so you write tighter, less-overlapping prompts on the next
+spawn.
 
 ## Item ownership
 

--- a/claude/.claude/skills/code-review/SKILL.md
+++ b/claude/.claude/skills/code-review/SKILL.md
@@ -225,31 +225,31 @@ After the implementation-fitness gate and the checklist review,
 consider whether the change crosses system boundaries in a way that
 exceeds your own judgment depth.
 
-You are the principal-engineer-generalist running this skill. Code
-review is the last gate before changes ship — a specialist miss is
-a regression in production. Be more conservative about self-judging
-than at plan-review, where misses are recoverable.
+You are the principal-engineer-generalist running this skill. The
+specialist subagents below have narrower lane depth, not broader
+context. **Form your own ripple judgment first** using the table as
+a reference for what boundaries exist in the change.
 
-**Form your own ripple judgment first** using the table as a reference
-for what boundaries exist. Spawn a specialist only when one of these
-applies (same escalation logic as plan-review's Reviewer roles —
-repeated because skills load on demand, not because the rule differs):
+Spawn a specialist only when at least one applies:
 
-- **Below-staff-level depth** in a specialized kernel (cryptography,
-  query-planner internals, fine-grained accessibility, kernel-level
-  concurrency, etc. — not "general domain knowledge").
-- **High-stakes domain boundary**: RLS, auth, billing, payment, data
-  migration, privileged operations.
-- **Holistic-reasoning overload** across multiple domains.
-- **Convergence-as-design-tell** from a prior round (see Reconciliation).
-- **Explicit user request**.
+- **Below-staff-level depth in a specific domain.** Specialized kernels
+  of expertise — query-planner internals, cryptography primitives,
+  fine-grained accessibility, kernel-level concurrency — not "general
+  knowledge in domain X."
+- **High-stakes domain boundary.** RLS, auth, billing, payment, data
+  migration, privileged operations. A specialist's second pair of eyes
+  is worth the spawn even at staff generalist depth.
+- **Holistic-reasoning overload.** Multi-domain ripple where you
+  genuinely can't hold all the lanes in working memory at once.
+- **Convergence-as-design-tell** from a prior round (see Reconciliation
+  below).
+- **Explicit user request** for specialist review.
 
 Always spawn `ciso-reviewer` when the change touches authentication or
 authorization, secrets, tokens, data exposure, logging of sensitive
 data, third-party data sharing, or infrastructure permissions —
-high-stakes-boundary case is non-optional at the last gate. Always
-spawn `staff-product-engineer` when the change alters user-facing
-behavior.
+high-stakes-boundary case is non-optional. Always spawn
+`staff-product-engineer` when the change alters user-facing behavior.
 
 Spawn per question, not per file-path domain — "change touches
 `.github/`" isn't enough; the question needs a specific shape.
@@ -295,9 +295,6 @@ to verify the checkout flow in CheckoutPage.tsx still enforces
 ownership after the new validation" is actionable.
 
 ## Reconciliation
-
-*Same logic as plan-review's Reconciliation — repeated because skills
-load on demand.*
 
 After spawned reviewers return findings, pause if findings concentrate
 on a single surface — the same feature, implementation detail, or

--- a/claude/.claude/skills/plan-review/SKILL.md
+++ b/claude/.claude/skills/plan-review/SKILL.md
@@ -270,25 +270,27 @@ S6. **Secret lifecycle** — Does the plan describe provisioning, storage, rotat
 
 ## Reviewer roles
 
-You are the principal-engineer-generalist running this skill. Plan
-review is the design-stage gate — specialist subagents pressure-test
-the design before code is written. Implementation-stage concerns can
-still be caught during code-review, so self-judge on borderline calls
-without committing to specialist depth.
+You are the principal-engineer-generalist running this skill. The
+specialist subagents below have narrower lane depth, not broader
+context — you have the conversation, the plan in full, prior rounds
+of review, and the user's calibration cues; they have one lane each.
 
 **Default to your own review across all detected domains using the
-checklists.** Spawn a specialist only when one of these applies (same
-escalation logic as code-review's Ripple-effect triage — repeated
-because skills load on demand, not because the rule differs):
+checklists.** Spawn a specialist subagent only when at least one
+escalation criterion applies:
 
-- **Below-staff-level depth** in a specialized kernel (cryptography,
-  query-planner internals, fine-grained accessibility, kernel-level
-  concurrency, etc. — not "general domain knowledge").
-- **High-stakes domain boundary**: RLS, auth, billing, payment, data
-  migration, privileged operations.
-- **Holistic-reasoning overload** across multiple domains.
-- **Convergence-as-design-tell** from a prior round (see Reconciliation).
-- **Explicit user request**.
+- **Below-staff-level depth in a specific domain.** "General backend
+  knowledge" doesn't qualify; specialized kernels do — query-planner
+  internals, cryptography primitives, fine-grained accessibility,
+  kernel-level concurrency, etc.
+- **High-stakes domain boundary.** RLS, auth, billing, payment, data
+  migration, privileged operations. A specialist's second pair of eyes
+  is worth the spawn even at staff generalist depth.
+- **Holistic-reasoning overload.** A multi-domain change where you
+  genuinely can't hold all the lanes in working memory simultaneously.
+- **Convergence-as-design-tell signal** from a prior round (see
+  Reconciliation below).
+- **Explicit user request** for specialist review.
 
 Always spawn `ciso-reviewer` when the plan touches authentication or
 authorization, secrets, tokens, data exposure, logging of sensitive
@@ -322,9 +324,6 @@ project-specific reviewer roles and focus areas, but must not remove or
 narrow the `ciso-reviewer` trigger conditions.
 
 ## Reconciliation
-
-*Same logic as code-review's Reconciliation — repeated because skills
-load on demand.*
 
 After spawned reviewers return findings, pause if findings concentrate
 on a single surface — the same feature, implementation detail, or

--- a/claude/.claude/skills/plan-review/SKILL.md
+++ b/claude/.claude/skills/plan-review/SKILL.md
@@ -270,27 +270,25 @@ S6. **Secret lifecycle** — Does the plan describe provisioning, storage, rotat
 
 ## Reviewer roles
 
-You are the principal-engineer-generalist running this skill. The
-specialist subagents below have narrower lane depth, not broader
-context — you have the conversation, the plan in full, prior rounds
-of review, and the user's calibration cues; they have one lane each.
+You are the principal-engineer-generalist running this skill. Plan
+review is the design-stage gate — specialist subagents pressure-test
+the design before code is written. Implementation-stage concerns can
+still be caught during code-review, so self-judge on borderline calls
+without committing to specialist depth.
 
 **Default to your own review across all detected domains using the
-checklists.** Spawn a specialist subagent only when at least one
-escalation criterion applies:
+checklists.** Spawn a specialist only when one of these applies (same
+escalation logic as code-review's Ripple-effect triage — repeated
+because skills load on demand, not because the rule differs):
 
-- **Below-staff-level depth in a specific domain.** "General backend
-  knowledge" doesn't qualify; specialized kernels do — query-planner
-  internals, cryptography primitives, fine-grained accessibility,
-  kernel-level concurrency, etc.
-- **High-stakes domain boundary.** RLS, auth, billing, payment, data
-  migration, privileged operations. A specialist's second pair of eyes
-  is worth the spawn even at staff generalist depth.
-- **Holistic-reasoning overload.** A multi-domain change where you
-  genuinely can't hold all the lanes in working memory simultaneously.
-- **Convergence-as-design-tell signal** from a prior round (see
-  Reconciliation below).
-- **Explicit user request** for specialist review.
+- **Below-staff-level depth** in a specialized kernel (cryptography,
+  query-planner internals, fine-grained accessibility, kernel-level
+  concurrency, etc. — not "general domain knowledge").
+- **High-stakes domain boundary**: RLS, auth, billing, payment, data
+  migration, privileged operations.
+- **Holistic-reasoning overload** across multiple domains.
+- **Convergence-as-design-tell** from a prior round (see Reconciliation).
+- **Explicit user request**.
 
 Always spawn `ciso-reviewer` when the plan touches authentication or
 authorization, secrets, tokens, data exposure, logging of sensitive
@@ -324,6 +322,9 @@ project-specific reviewer roles and focus areas, but must not remove or
 narrow the `ciso-reviewer` trigger conditions.
 
 ## Reconciliation
+
+*Same logic as code-review's Reconciliation — repeated because skills
+load on demand.*
 
 After spawned reviewers return findings, pause if findings concentrate
 on a single surface — the same feature, implementation detail, or

--- a/claude/.claude/skills/plan-review/SKILL.md
+++ b/claude/.claude/skills/plan-review/SKILL.md
@@ -34,7 +34,43 @@ Read the plan and classify which domains it touches:
 - **Backend**: Server-side code (HTTP/RPC handlers, edge functions, background jobs, queue consumers, SDK integrations, shared utilities) AND application data-store schema design
 - **Security**: Authentication or authorization, token handling, secret management, data exposure, RLS / RBAC / ACL changes
 
-## Step 2 — Evaluate
+## Step 2 — Design-fitness gate
+
+Before evaluating gaps, answer one question: **is the design appropriately
+sized for the ticket scope?**
+
+A plan can have zero gap-level findings and still be the wrong artifact —
+gold-plated, defensively over-elaborated, carrying machinery that serves
+no ticket-scoped feature. Gap-finding on an over-elaborate design
+elaborates it further: each finding closes a gap by adding more
+machinery. The gate runs first because the checklist won't surface
+"this whole design is the wrong shape."
+
+Markers of over-elaboration:
+
+- Conditional logic for future phases that may not arrive.
+- Defensive paths against attack scenarios that haven't been observed.
+- Layers that duplicate a higher-level abstraction.
+- Granularity exceeding any concrete consumer's need.
+- Captured outputs / fields with no reader downstream.
+
+Three answers:
+
+- **Yes, fit for scope.** Proceed to Step 3.
+- **No, over-elaborated.** Stop. Surface the simpler design as the
+  primary review output before any checklist findings. Gap-finding on
+  the over-elaborate version drives elaboration further; the simpler
+  design must be considered first.
+- **No, under-elaborated.** Proceed to Step 3 — the gap-finding will
+  surface what's missing.
+
+Question implementation choices (how the feature is built), not feature
+scope (what the ticket asks for). A ticket says "implement X"; whether
+X is built with one layer or three is a plan choice the gate inspects.
+A gap-finding pass is not the place to question the ticket itself — that
+goes back to the author.
+
+## Step 3 — Evaluate
 
 Evaluate the plan against the **Base checklist** first, then each detected
 **Domain checklist**. For multi-phase plans, evaluate each phase against the
@@ -76,9 +112,12 @@ B5. **Evidence** — Does the plan cite the source for each finding or assertion
 
 ### Scope
 
-B6. **Proportionality** — Is the solution proportional to the problem? Flag both
-   over-engineering (abstractions for one-time operations, premature extensibility)
-   and under-engineering (band-aids that will need immediate follow-up).
+B6. **Proportionality** — Whole-design proportionality is the design-fitness
+   gate's job (Step 2). At checklist time, focus on local proportionality:
+   a single helper that's overkill for its caller, a comment block that's too
+   long for the invariant it explains, an abstraction introduced for one
+   call site. If the whole plan reads as over-elaborated, the gate caught
+   it; don't double-flag here.
 
 B7. **Scope creep** — Does the plan include work that isn't required to solve the
    stated problem? Improvements to adjacent code, premature optimizations, or
@@ -244,12 +283,49 @@ S6. **Secret lifecycle** — Does the plan describe provisioning, storage, rotat
 
 ## Reviewer roles
 
-For multi-domain plans, spawn the matching reviewer subagents via the
-Agent tool — one per detected domain — and reconcile their findings.
-Different personas catch different things: a security reviewer thinks
-about attack vectors while a backend reviewer thinks about API contracts.
-Spawning real subagents (not in-context role-play) keeps each reviewer
-isolated to its scope and restricts it to read-only tools.
+You are the principal-engineer-generalist running this skill. The
+specialist subagents below have narrower lane depth, not broader
+context — you have the conversation, the plan in full, prior rounds
+of review, and the user's calibration cues; they have one lane each.
+
+**Default to your own review across all detected domains using the
+checklists.** Spawn a specialist subagent only when at least one
+escalation criterion applies:
+
+- **Below-staff-level depth in a specific domain.** "General backend
+  knowledge" doesn't qualify; specialized kernels do — query-planner
+  internals, cryptography primitives, fine-grained accessibility,
+  kernel-level concurrency, etc.
+- **High-stakes domain boundary.** RLS, auth, billing, payment, data
+  migration, privileged operations. A specialist's second pair of eyes
+  is worth the spawn even at staff generalist depth.
+- **Holistic-reasoning overload.** A multi-domain change where you
+  genuinely can't hold all the lanes in working memory simultaneously.
+- **Convergence-as-design-tell signal** from a prior round (see
+  Reconciliation below).
+- **Explicit user request** for specialist review.
+
+Always spawn `ciso-reviewer` when the plan touches authentication or
+authorization, secrets, tokens, data exposure, logging of sensitive
+data, third-party data sharing, or infrastructure permissions —
+high-stakes-boundary case is non-optional. Always spawn
+`staff-product-engineer` when the plan changes user-facing behavior.
+
+Spawn per question, not per file-path domain. "The plan touches
+backend" is not enough; "the plan changes the idempotency contract on
+the order-creation endpoint and I want a specialist read on retry
+semantics under load" is.
+
+When you do spawn:
+
+- Pick the specific specialist that serves your question (table below
+  is reference, not roster).
+- Pass the plan scope, the section under review, the specific question
+  you're escalating, the items routed to that specialist per **Item
+  ownership**, AND — for re-review rounds — the prior round's findings
+  plus what's been applied since. Reviewers without prior context
+  re-discover; that's wasted spawn.
+- Each agent returns findings-only; reconcile per Reconciliation below.
 
 | Domain | Agent | Focus |
 |--------|-------|-------|
@@ -262,20 +338,36 @@ isolated to its scope and restricts it to read-only tools.
 | Testing | `staff-sdet` | Testability of the design, edge cases the plan omits, test strategy coverage vs risk areas, test data requirements; production code with non-trivial logic that lacks tests |
 | Product | `staff-product-engineer` | Whether the plan solves the actual user problem, UX impact during migrations, feature interactions, user-facing regressions hidden behind technical framing, telemetry event semantics |
 
-Spawn each relevant reviewer in parallel. Always include
-`staff-product-engineer` when the plan changes user-facing behavior.
-Always include `ciso-reviewer` when the plan touches authentication or
-authorization, secrets, tokens, data exposure, logging of sensitive
-data, third-party data sharing, or infrastructure permissions.
-
-When invoking a reviewer, pass the plan scope, the phase or section
-under review, and the items routed to that reviewer per the **Item
-ownership** table below. Each agent returns a findings-only output;
-reconcile the set and present a combined verdict.
-
 Project-level plan-review skills may extend this table with
 project-specific reviewer roles and focus areas, but must not remove or
 narrow the `ciso-reviewer` trigger conditions.
+
+## Reconciliation
+
+After spawned reviewers return findings, before applying anything,
+pause if findings concentrate on a single surface — the same feature,
+implementation detail, or design choice attracting multiple gaps from
+different reviewers. Concentration is a tell, but the tell has two
+readings:
+
+- **Design-wrong-shape.** The surface is the wrong abstraction; gaps
+  will keep multiplying as you patch, because each patch closes one
+  gap by adding machinery that opens another. Replacement, not
+  patch-by-patch closure, is the fix.
+- **Prompt-overlap artifact.** The reviewers were given similar
+  prompts and produced N voices of the same observation. Convergence
+  looks like signal but is framing-induced repetition.
+
+You judge which reading applies. Both happen. The wrong move is to
+treat convergence as automatic authority for "patch each gap" — that's
+how an over-elaborate design accumulates more elaboration until the
+PR doubles in size.
+
+If the reading is design-wrong-shape, replace the surface and re-review
+(send the simpler design back through Step 2). If it's prompt-overlap,
+apply the underlying finding once and skip the redundant copies; note
+the overlap so you write tighter, less-overlapping prompts on the next
+spawn.
 
 ## Item ownership
 

--- a/claude/.claude/skills/plan-review/SKILL.md
+++ b/claude/.claude/skills/plan-review/SKILL.md
@@ -36,15 +36,10 @@ Read the plan and classify which domains it touches:
 
 ## Step 2 — Design-fitness gate
 
-Before evaluating gaps, answer one question: **is the design appropriately
-sized for the ticket scope?**
-
-A plan can have zero gap-level findings and still be the wrong artifact —
-gold-plated, defensively over-elaborated, carrying machinery that serves
-no ticket-scoped feature. Gap-finding on an over-elaborate design
-elaborates it further: each finding closes a gap by adding more
-machinery. The gate runs first because the checklist won't surface
-"this whole design is the wrong shape."
+Before evaluating gaps, answer: **is the design appropriately sized for
+the ticket scope?** Gap-finding on an over-elaborate design elaborates
+it further (each finding closes a gap by adding more machinery), and
+the checklist won't surface "this whole design is the wrong shape."
 
 Markers of over-elaboration:
 
@@ -54,21 +49,16 @@ Markers of over-elaboration:
 - Granularity exceeding any concrete consumer's need.
 - Captured outputs / fields with no reader downstream.
 
-Three answers:
+If over-elaborated: stop. Surface the simpler design as the primary
+review output before any checklist findings.
 
-- **Yes, fit for scope.** Proceed to Step 3.
-- **No, over-elaborated.** Stop. Surface the simpler design as the
-  primary review output before any checklist findings. Gap-finding on
-  the over-elaborate version drives elaboration further; the simpler
-  design must be considered first.
-- **No, under-elaborated.** Proceed to Step 3 — the gap-finding will
-  surface what's missing.
+Otherwise (fit, or under-elaborated): proceed to Step 3 — gap-finding
+will surface what's missing.
 
-Question implementation choices (how the feature is built), not feature
-scope (what the ticket asks for). A ticket says "implement X"; whether
-X is built with one layer or three is a plan choice the gate inspects.
-A gap-finding pass is not the place to question the ticket itself — that
-goes back to the author.
+Question implementation choices, not feature scope. A ticket says
+"implement X"; whether X is built with one layer or three is the gate's
+inspection. The ticket itself isn't reviewed here — that goes back to
+the author.
 
 ## Step 3 — Evaluate
 
@@ -112,12 +102,9 @@ B5. **Evidence** — Does the plan cite the source for each finding or assertion
 
 ### Scope
 
-B6. **Proportionality** — Whole-design proportionality is the design-fitness
-   gate's job (Step 2). At checklist time, focus on local proportionality:
-   a single helper that's overkill for its caller, a comment block that's too
-   long for the invariant it explains, an abstraction introduced for one
-   call site. If the whole plan reads as over-elaborated, the gate caught
-   it; don't double-flag here.
+B6. **Proportionality** — Whole-design proportionality belongs to the gate
+   (Step 2). At checklist time, flag local issues only: a helper that's
+   overkill for one caller, an abstraction at a single call site.
 
 B7. **Scope creep** — Does the plan include work that isn't required to solve the
    stated problem? Improvements to adjacent code, premature optimizations, or
@@ -311,21 +298,15 @@ data, third-party data sharing, or infrastructure permissions —
 high-stakes-boundary case is non-optional. Always spawn
 `staff-product-engineer` when the plan changes user-facing behavior.
 
-Spawn per question, not per file-path domain. "The plan touches
-backend" is not enough; "the plan changes the idempotency contract on
-the order-creation endpoint and I want a specialist read on retry
-semantics under load" is.
+Spawn per question, not per file-path domain — "plan touches backend"
+isn't enough; the question needs a specific shape.
 
-When you do spawn:
-
-- Pick the specific specialist that serves your question (table below
-  is reference, not roster).
-- Pass the plan scope, the section under review, the specific question
-  you're escalating, the items routed to that specialist per **Item
-  ownership**, AND — for re-review rounds — the prior round's findings
-  plus what's been applied since. Reviewers without prior context
-  re-discover; that's wasted spawn.
-- Each agent returns findings-only; reconcile per Reconciliation below.
+When you spawn, pick the specific specialist that serves the question
+(table below is reference, not roster) and pass: the plan scope, the
+section under review, the specific question, the items routed per
+**Item ownership**, AND — for re-review rounds — the prior round's
+findings + what's been applied since. Reviewers without prior context
+re-discover; that's wasted spawn.
 
 | Domain | Agent | Focus |
 |--------|-------|-------|
@@ -344,30 +325,21 @@ narrow the `ciso-reviewer` trigger conditions.
 
 ## Reconciliation
 
-After spawned reviewers return findings, before applying anything,
-pause if findings concentrate on a single surface — the same feature,
-implementation detail, or design choice attracting multiple gaps from
-different reviewers. Concentration is a tell, but the tell has two
-readings:
+After spawned reviewers return findings, pause if findings concentrate
+on a single surface — the same feature, implementation detail, or
+design choice attracting multiple gaps. Two readings:
 
 - **Design-wrong-shape.** The surface is the wrong abstraction; gaps
-  will keep multiplying as you patch, because each patch closes one
-  gap by adding machinery that opens another. Replacement, not
-  patch-by-patch closure, is the fix.
-- **Prompt-overlap artifact.** The reviewers were given similar
-  prompts and produced N voices of the same observation. Convergence
-  looks like signal but is framing-induced repetition.
+  will keep multiplying as you patch. Replace, don't patch-by-patch.
+- **Prompt-overlap artifact.** Reviewers given similar prompts produce
+  N voices of the same observation. Convergence looks like signal but
+  is framing-induced.
 
-You judge which reading applies. Both happen. The wrong move is to
-treat convergence as automatic authority for "patch each gap" — that's
-how an over-elaborate design accumulates more elaboration until the
-PR doubles in size.
-
-If the reading is design-wrong-shape, replace the surface and re-review
-(send the simpler design back through Step 2). If it's prompt-overlap,
-apply the underlying finding once and skip the redundant copies; note
-the overlap so you write tighter, less-overlapping prompts on the next
-spawn.
+You judge which applies. Don't treat convergence as automatic authority
+for "patch each gap." If design-wrong-shape, replace the surface and
+re-run Step 2. If prompt-overlap, apply the underlying finding once,
+skip duplicates, and note the overlap so the next spawn uses tighter
+prompts.
 
 ## Item ownership
 


### PR DESCRIPTION
## Summary

Three connected changes targeting review-process drift surfaced by real-world use:

- **Design-fitness gate** (Step 2 in plan-review, Step 1 in code-review). Before any gap-finding, answer "is the design / implementation appropriately sized for the ticket scope?" The skill stops on over-elaboration and surfaces the simpler design as the primary review output. Lists five concrete markers of over-elaboration (dormant Phase-N logic, defensive paths against unobserved attacks, duplicate layers, granularity exceeding consumer needs, captured outputs with no reader). Distinguishes implementation choice (reviewer-tunable) from feature scope (ticket-fixed).

- **Default-to-judgment** in Reviewer roles (plan-review) and Ripple-effect triage (code-review). The dispatcher is the principal-engineer-generalist; specialist subagents have narrower lane depth, not broader context. Spawn only when an escalation criterion applies: below-staff-level domain depth, high-stakes domain boundary, holistic-reasoning overload, convergence-as-design-tell signal, or explicit user request. The always-spawn carve-out for `ciso-reviewer` on auth/secrets/etc. is preserved as a high-stakes-domain case. Spawn per question, not per file-path domain.

- **Prior-round context** mandated on re-spawn. Reviewers without prior context re-discover; that's wasted spawn. The skill now requires the dispatcher to pass prior findings + applied fixes when re-invoking on a re-review round.

- **Reconciliation section** added to both skills. When reviewer findings concentrate on a single surface, the dispatcher pauses and asks two questions, not one: "design-wrong-shape (replace and re-review) or prompt-overlap artifact (apply once, skip duplicates)?" Refines the convergence-as-design-tell signal without picking an arbitrary number threshold.

- B6 (Proportionality) in plan-review updated to defer whole-design proportionality to the gate; checklist focuses on local proportionality only.

## Why

Review rounds were producing more elaboration rather than less: each round's reviewers found gaps in the prior round's defensive infrastructure, the dispatcher patched them mechanically, and the design accumulated complexity until the wrong abstraction was visibly wrong. Three layered fixes target the actual root causes:
- The skills had no design-fitness gate before gap-finding, so over-elaborate designs accumulated patches indefinitely.
- The skills defaulted to spawning the full specialist panel on cross-boundary changes, regardless of whether the dispatcher's own judgment would have sufficed.
- Reviewer subagents had no memory across rounds, re-discovering concerns each round.

The over-elaboration markers in the gate are real patterns from recent debugging, not theoretical risks. The default-to-judgment change ships with explicit escalation criteria rather than a new principal-engineer-generalist persona — the main agent already inhabits that role; what was missing was clear escalation criteria.

## Test plan

- [ ] Read both skill bodies in full to check internal consistency (B6 reference to gate, Reconciliation reference from Reviewer roles, etc.)
- [ ] Apply the design-fitness gate to a sample plan that's over-elaborated; confirm the skill instructs the reviewer to stop and surface the simpler design rather than proceed to gap-finding.
- [ ] Apply the default-to-judgment change to a single-domain change; confirm the dispatcher forms its own review without spawning specialists, and that the output describes which boundaries were considered.
- [ ] Apply the prior-round context change on a re-review; confirm prior findings are passed to specialists.
- [ ] Confirm the always-spawn carve-out for `ciso-reviewer` still fires on auth/secrets changes despite the default-to-judgment reframe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)