### PR TITLE
ai-instruction-and-memory-files: add the behavior test

### DIFF
--- a/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
+++ b/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
@@ -97,6 +97,14 @@ and [Chroma's Context Rot research](https://research.trychroma.com/context-rot):
 - Attention decay hits the **middle** of long files — "lost in the middle." Burying critical rules past line ~150 reduces their effective load.
 - Compliance with prose rules tops out around **70%**. Structural tests and hooks hit 100%. When a rule can be encoded as either, prefer the mechanical enforcement.
 
+### The behavior test
+
+Every line should change Claude's behavior on at least one realistic
+input. If removing the line wouldn't change any behavior, cut it.
+Specific incident references, editorial meta-commentary, and narrative
+case studies almost always fail this test; rationale that arms Claude
+for an unenumerated edge case almost always passes.
+
 ### Don't embed PR or ticket refs in always-loaded files
 
 `Precedent: PR #105` and `See TICKET-123` rot the moment the next PR


### PR DESCRIPTION
## Summary

Adds a short "behavior test" rule under "Length targets" in the `ai-instruction-and-memory-files` skill:

> Every line should change Claude's behavior on at least one realistic input. If removing the line wouldn't change any behavior, cut it. Specific incident references, editorial meta-commentary, and narrative case studies almost always fail this test; rationale that arms Claude for an unenumerated edge case almost always passes.

Generalizes the existing "Don't embed PR or ticket refs" rule into the broader principle: content-shaping for instruction files, not just length.

## Why

Existing length-target rules cover *how much* (under 200 / past 300 / 70% compliance ceiling). They don't cover *what earns its line count*. The behavior test is the missing content rule. Future audits of CLAUDE.md, AGENTS.md, `.lovable/*.md`, or skill bodies pick it up automatically instead of each audit re-deriving the rule.

## Sizing

The skill argues for brevity, so the addition itself passes its own test:

- Test sentence operationalizes the rule (no test = no behavior change in audits — keeps).
- "Almost always fail" examples tell the reader what's cuttable (without them, "behavior change" is too abstract to apply — keeps).
- "Almost always pass" prevents over-cutting rationale-stripping (without it, the rule unbalanced — keeps).

File: 198 → 206 lines (+8: heading + 5 content + blanks). Marginally over the 200 target but well under the 300 diminishing-returns point.

## Test plan

- [ ] Read the addition with the rest of the "Length targets" section to confirm flow
- [ ] Confirm the addition itself passes the behavior test (every line operationalizes the rule)
- [ ] Confirm no contradiction with the adjacent "Don't embed PR or ticket refs" subsection (the new rule generalizes it; both still hold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)