### PR TITLE
plan-review: route staff-analytics-engineer on B2 (warehouse-consumer fitness)

### DIFF
--- a/claude/.claude/skills/plan-review/SKILL.md
+++ b/claude/.claude/skills/plan-review/SKILL.md
@@ -221,7 +221,7 @@ The dispatcher fires reviewers per touched domain. Each agent self-scopes agains
 | Item | Primary owner | Co-owners |
 |------|---------------|-----------|
 | **B1. Unstated assumptions** | `staff-backend-engineer` (runtime / SDK assumptions) | `staff-platform-engineer` (CI / build tools) |
-| **B2. Missing consumer analysis** | `staff-backend-engineer` (API consumers) | `staff-frontend-engineer`, `staff-product-engineer`, `staff-data-engineer` (per consumer type) |
+| **B2. Missing consumer analysis** | `staff-backend-engineer` (API consumers) | `staff-frontend-engineer`, `staff-product-engineer`, `staff-data-engineer` (per consumer type), `staff-analytics-engineer` (warehouse-consumer fitness — source shape suits modeling) |
 | **B3. Breaking intermediate states** | `staff-backend-engineer`, `staff-data-engineer` | `staff-platform-engineer` (deploy-window) |
 | **B4. Unresolved external dependencies** | `staff-backend-engineer` | — |
 | **B5, B6, B7, B13, B15. Judgment items** (evidence, proportionality, scope creep, ambiguous instructions, effort section) | judgment (any reviewer) | — |


### PR DESCRIPTION
## Summary

Closes the routing gap `staff-analytics-engineer` flagged during PR #63's specialist review: plan-review's Item-ownership table had no row that named `staff-analytics-engineer` as primary or co-owner on any item, so the dispatcher would not fire them on a backend schema change that feeds the warehouse — even though the Reviewer-roles Focus cell and Step 1 both named the agent for that case.

## Change

Single-line edit to the B2 row in `claude/.claude/skills/plan-review/SKILL.md`:

```diff
- | **B2. Missing consumer analysis** | `staff-backend-engineer` (API consumers) | `staff-frontend-engineer`, `staff-product-engineer`, `staff-data-engineer` (per consumer type) |
+ | **B2. Missing consumer analysis** | `staff-backend-engineer` (API consumers) | `staff-frontend-engineer`, `staff-product-engineer`, `staff-data-engineer` (per consumer type), `staff-analytics-engineer` (warehouse-consumer fitness — source shape suits modeling) |
```

B2 ("Missing consumer analysis") is the right home — the warehouse *is* a consumer of the backend schema, and analytics-eng reviews whether the source shape is suitable for warehouse modeling.

## Why this exact qualifier

An earlier draft used `(warehouse consumer / ELT-readiness)`. `staff-data-engineer`'s review flagged that "ELT-readiness" overloads their lane: the **E** (extract) and **L** (load) are pipeline transport — *their* turf — and only the **T** (transform / modeling) is analytics-eng's. Their proposed tighter qualifier — adopted here — pins the analytics-eng angle to *source shape suits modeling*, leaving transport unambiguously with data-eng. This maps cleanly to `staff-analytics-engineer`'s stated self-scoping rule (engage on schema / JSONB / NoSQL shape; return early on pure-transport).

## Out-of-scope rabbit holes considered, declined

- **D5 (Index coverage) ripple:** declined per `staff-backend-engineer` review. Warehouse queries run against replicated copies in the warehouse, where indexing is governed by warehouse modeling — not OLTP index design. Adding analytics-eng to D5 would conflate the two.
- **B3 (Breaking intermediate states) ripple:** declined per `staff-analytics-engineer`'s own review. B3 is pipeline-transport / dual-write / backfill-window territory — operational, `staff-data-engineer`'s lane. If a transitional schema would also be bound by warehouse models, that surfaces under B2, which now routes to analytics-eng.

## Specialist review

Consulted: `staff-analytics-engineer`, `staff-backend-engineer`, `staff-data-engineer`, `staff-frontend-engineer`, `staff-product-engineer` (the personas named in the B2 row pre- and post-edit).

- analytics: pass
- backend: pass — primary ownership preserved, no D5 ripple needed
- data: pass with concerns → addressed (qualifier tightened)
- frontend: pass — split is clean
- product: pass — cleanly orthogonal

## Test plan

- [x] No line-count change to `plan-review/SKILL.md` (264 lines, was 264 — single-line in-place edit)
- [x] All 231 hook tests pass against the worktree
- [x] No frontmatter / `description` / TRIGGER changes (skill triggering accuracy preserved)
- [x] No other rows in any routing table touched
- [ ] Reviewer ack on the qualifier wording

🤖 Generated with [Claude Code](https://claude.com/claude-code)