### PR TITLE
ready-for-review: semantic triggers + cumulative-scope step 3

### DIFF
--- a/claude/.claude/skills/ready-for-review/SKILL.md
+++ b/claude/.claude/skills/ready-for-review/SKILL.md
@@ -14,8 +14,9 @@ description: >
   has just pushed (or is about to push) commits to a branch that
   already has an open PR and is wrapping up rather than continuing to
   iterate; (c) before spawning a multi-persona ripple review (CISO +
-  multiple staff-* engineers) via the Agent tool on a PR-stage diff,
-  or before invoking /ultrareview.
+  multiple staff-* engineers) via the Agent tool on a PR-stage diff
+  outside an active /ready-for-review or /pre-merge flow, or before
+  invoking /ultrareview.
   DO NOT TRIGGER when: work is still being iterated (more commits
   planned before handoff); only a diff review or single verification
   step was requested; on the default branch; or when a project-specific

--- a/claude/.claude/skills/ready-for-review/SKILL.md
+++ b/claude/.claude/skills/ready-for-review/SKILL.md
@@ -2,20 +2,25 @@
 name: ready-for-review
 description: >
   Pre-handoff gate run before a human reviewer looks at an open PR:
-  verifies tests/lint/typecheck, runs /code-review, syncs PR description
-  against branch state, checks CI, and confirms tree hygiene.
-  TRIGGER when: the user signals work is ready for their review ("ready
-  for review", "ready for human review", "ready for your review", "ship
-  it"); OR Claude is about to emit a handoff line such as "Ready for
-  your review.", "PR #N is ready for your review", "PR #N is ready for
-  merge", "the branch is ready for handoff", or "take a look when you're
-  back" — run this skill first and do not emit the handoff line until
-  it passes; OR before invoking /ultrareview or inviting external
-  reviewers on a PR.
-  DO NOT TRIGGER when: work is still being iterated, only a diff review
-  or a single verification step was requested, on the default branch,
-  or when a project-specific pre-merge-style skill already wraps these
-  checks (let that skill delegate here instead).
+  verifies tests/lint/typecheck, runs /code-review against the
+  cumulative PR-vs-default-branch diff, syncs PR description against
+  branch state, checks CI, and confirms tree hygiene.
+  TRIGGER when: (a) the user signals work is reviewer-ready, OR Claude
+  is about to summarize what landed and implicitly hand back — fire on
+  the *intent* (work-is-done-for-now-and-the-user-is-the-next-actor),
+  not on specific phrases. Examples that should fire: "ready for
+  review", "ship it", "PR is up", "take a look", "your turn", "PR is
+  now full-scope X", "implementation pushed and reviewable"; (b) Claude
+  has just pushed (or is about to push) commits to a branch that
+  already has an open PR and is wrapping up rather than continuing to
+  iterate; (c) before spawning a multi-persona ripple review (CISO +
+  multiple staff-* engineers) via the Agent tool on a PR-stage diff,
+  or before invoking /ultrareview.
+  DO NOT TRIGGER when: work is still being iterated (more commits
+  planned before handoff); only a diff review or single verification
+  step was requested; on the default branch; or when a project-specific
+  pre-merge-style skill already wraps these checks (let that skill
+  delegate here instead).
 argument-hint: "[optional scope note]"
 ---
 
@@ -65,10 +70,31 @@ genuinely changed.
 
 ## 3. Code review (halt on findings)
 
-Run `/code-review` over the full branch diff. Unskippable — markdown,
-skill, and config diffs benefit from the same pass. Fix all findings,
-then return to step 2 and re-run fast checks on the fixes. Do not
-re-run `/code-review` on its own output (loop risk).
+Run `/code-review` against the **cumulative** PR-vs-default-branch
+diff — not staged changes, not per-commit deltas:
+
+```bash
+BASE_REF=$(gh pr view --json baseRefName --jq .baseRefName 2>/dev/null || echo main)
+git diff $(git merge-base origin/$BASE_REF HEAD)...HEAD
+```
+
+The squash-merge artifact reviewers ultimately see is this diff.
+Cumulative review surfaces cross-commit findings — defense-in-depth
+gaps spanning two commits, deprecations exposed only when a new test
+exercises an unmodified call site, idempotency-key shape mismatches
+across modules — that per-commit review misses. Per-commit
+`/code-review` during iteration remains valuable for fast feedback;
+treat its findings as inputs here, not substitutes.
+
+Because the reviewed diff is not the staged diff, do NOT write the
+review-completion marker (per `/code-review`'s own rule). If findings
+are produced, fix them in a new commit; that commit goes through the
+normal staged-diff `/code-review` + marker gate, then return to
+step 2 and re-run fast checks. Do not re-run `/code-review` on its
+own output (loop risk).
+
+Unskippable — markdown, skill, and config diffs benefit from the
+same pass.
 
 ## 4. Sync PR description (warn + fix; skip if no PR)
 


### PR DESCRIPTION
## Summary

Closes two gaps that caused `/ready-for-review` to never fire in a recent session despite three natural handoff moments, and sharpens step 3's scope mismatch with `/code-review`.

### Trigger gaps (frontmatter `description`)

The old trigger description enumerated literal phrases (e.g. `"ready for review"`, `"PR #N is ready for your review"`, `"take a look when you're back"`). A model that paraphrases — `"PR is up to date and reviewable"`, `"PR is now full-scope X"`, `"implementation pushed and reviewable"` — slips past every literal. Two further trigger conditions were absent entirely: post-push-to-existing-PR wrap-up, and Agent-tool ripple-review dispatch (CISO + multiple staff-* engineers — functionally `/ultrareview` but not covered).

The new description:

- Fires on the **intent** (`work-is-done-for-now-and-the-user-is-the-next-actor`), with phrases as illustrative examples, not a closed set.
- Adds **(b)** post-push-to-existing-PR wrap-up.
- Adds **(c)** spawning a multi-persona ripple review on a PR-stage diff *outside an active `/ready-for-review` or `/pre-merge` flow* (carve-out added in fixup commit `f285f4c` to prevent re-entrancy when step 3's `/code-review` invocation spawns ripples internally).
- Keeps the existing DO-NOT-TRIGGER carve-outs (work still being iterated, default branch, project-specific pre-merge wrappers) so the broader (a) clause doesn't over-fire mid-iteration.

### Step 3 scope mismatch

Step 3 claimed `"full branch diff"` but invoked `/code-review` without scope, so it deferred to that skill's default (staged changes). During iteration, that's often just the latest commit's delta — exactly the per-commit-only review pattern that misses:

- Defense-in-depth gaps spanning two commits.
- Deprecations exposed only when a new test exercises an unmodified call site.
- Cross-module idempotency-key shape mismatches.

New step 3 scopes explicitly to `git diff $(git merge-base origin/<base> HEAD)...HEAD` — the squash-merge artifact reviewers ultimately see. Per-commit `/code-review` runs during iteration remain valuable as **inputs** to the cumulative pass, not substitutes.

### Marker-gate caveat

Because the cumulative diff is not the staged diff, step 3 explicitly says **do not** write the `/code-review` completion marker — that's reserved for staged-diff reviews. Fix-commits go through the normal staged-diff `/code-review` + marker gate.

## Test plan

- [ ] Read the updated `description` in a fresh session and confirm `(a)` / `(b)` / `(c)` cover the three gap moments without over-firing during iteration.
- [ ] Walk a hypothetical branch through step 3 — confirm the `BASE_REF` fallback (`gh pr view ... || echo main`) handles both PR and no-PR cases.
- [ ] Confirm `/code-review` SKILL.md's marker-write rule (lines 282–289) still aligns with step 3's new caveat.
- [x] Skill-on-its-own-diff: re-read SKILL.md with the diff in mind — no contradictions with the existing intro ("After fixes produced by step 3, re-run step 2") or section header (`halt on findings`). Pass surfaced one re-entrancy ambiguity in trigger (c); resolved via fixup commit `f285f4c`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)