### PR TITLE
Extract Lovable knowledge into dedicated skill

### DIFF
--- a/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
+++ b/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
@@ -1,28 +1,31 @@
 ---
 name: ai-instruction-and-memory-files
 description: >
-  How Claude Code, Lovable, and other AI coding agents load instruction
-  files (CLAUDE.md, AGENTS.md, Cursor rules, Copilot instructions, Lovable
-  project/workspace knowledge) and Claude Code auto-memory (MEMORY.md
-  index + topic files): precedence, duplication rules, length targets,
-  the `@AGENTS.md` import pattern Anthropic officially endorses, and the
-  split between user-written instructions and Claude-written memory.
-  TRIGGER when: editing CLAUDE.md or AGENTS.md, editing `.lovable/*.md`,
-  creating a new instruction file, creating, editing, auditing, or
-  pruning Claude Code auto-memory in `~/.claude/projects/*/memory/`,
-  deciding whether a rule belongs in CLAUDE.md vs auto-memory,
-  evaluating whether rules should be duplicated across files, or
-  debating file length and context budget for AI coding agents.
-  DO NOT TRIGGER when: editing README.md or other project docs that are
-  not loaded by AI coding agents, or writing code.
+  How Claude Code loads CLAUDE.md (and AGENTS.md via the `@AGENTS.md`
+  import pattern); how AGENTS.md serves as the cross-agent standard
+  (also read by Codex, Cursor, Gemini CLI, Windsurf, Amp, Aider, etc.);
+  Claude Code auto-memory (MEMORY.md index + topic files); and general
+  principles for editing any of these surfaces — precedence, duplication
+  rules, length targets, lost-in-the-middle, the user-vs-Claude-written
+  split.
+  TRIGGER when: editing CLAUDE.md or AGENTS.md; creating, editing,
+  auditing, or pruning Claude Code auto-memory in
+  `~/.claude/projects/*/memory/`; deciding whether a rule belongs in
+  CLAUDE.md vs AGENTS.md vs auto-memory; debating file length or
+  context budget for these surfaces.
+  DO NOT TRIGGER when: editing `.lovable/*.md` (use `lovable-knowledge`);
+  editing agent-specific rules files like `.cursorrules` or
+  `.github/copilot-instructions.md` (out of current scope); editing
+  README.md or other project docs not loaded by AI coding agents; or
+  writing code.
 user-invocable: false
 ---
 
 # AI Instruction & Memory Files — Architecture
 
-The facts below come from primary sources (Anthropic docs, Lovable docs,
-agents.md standard). Treat them as durable context: when CLAUDE.md /
-AGENTS.md questions come up, start here rather than re-researching.
+The facts below come from primary sources (Anthropic docs, agents.md
+standard). Treat them as durable context: when CLAUDE.md / AGENTS.md
+questions come up, start here rather than re-researching.
 
 ## 1. Claude Code loads CLAUDE.md only — NOT AGENTS.md
 
@@ -64,29 +67,11 @@ instructions are additive, not overridden. In monorepos this means
 root-level CLAUDE.md, team-directory CLAUDE.md, and project-level
 CLAUDE.md all load together.
 
-## 2. Lovable loads all four sources, prioritizes project knowledge
+For Lovable's UI knowledge fields (Project Knowledge, Workspace
+Knowledge), the `.lovable/*.md` repo-mirror workflow, and review
+criteria for `.lovable/**` changes, see the `lovable-knowledge` skill.
 
-From [Lovable Docs — Knowledge](https://docs.lovable.dev/features/knowledge):
-
-> "When you send a message, Lovable reads your project knowledge, workspace knowledge, and project code... It also looks at instruction files in your project's GitHub repository such as AGENTS.md or CLAUDE.md."
-> "Lovable is encouraged to prioritize the instructions defined in project knowledge, since they apply specifically to the current project."
-> "Root-level AGENTS.md files are always read by the Lovable agent regardless of session length."
-
-Effective order:
-
-1. **project knowledge** (Lovable UI field — highest priority)
-2. **workspace knowledge** (Lovable UI field)
-3. **AGENTS.md / CLAUDE.md** (repo files — AGENTS.md has the explicit "always read regardless of session length" guarantee; CLAUDE.md priority vs. AGENTS.md is not documented by Lovable)
-4. **project code**
-
-All four are loaded every session. Lovable docs warn that in very long
-conversations instructions can drift; the "always read" guarantee for
-AGENTS.md is the defense-in-depth.
-
-**`.lovable/*.md` is NOT loaded by Lovable** — these files are repo-tracked
-copies of what's set in the UI editor (source 1 above); only the UI version loads.
-
-## 3. Length targets
+## 2. Length targets
 
 Per [Claude Code Best Practices](https://code.claude.com/docs/en/best-practices),
 [HumanLayer](https://www.humanlayer.dev/blog/writing-a-good-claude-md),
@@ -111,7 +96,7 @@ for an unenumerated edge case almost always passes.
 lands and cost per-session context budget. Put them in commit messages,
 PR descriptions, or plan files — state the rule, not the precedent.
 
-## 4. When to duplicate vs. reference
+## 3. When to duplicate vs. reference
 
 **Reference via `@AGENTS.md` import (Anthropic pattern):** default for
 Claude Code when both files exist. Zero maintenance, single source.
@@ -119,25 +104,24 @@ Claude Code when both files exist. Zero maintenance, single source.
 **Duplicate (defense-in-depth) when:**
 - The content is genuinely critical and one delivery mechanism could fail silently.
 - Different agents reach the file through different load paths and the rule needs to fire in all of them.
-- Example: auth-removal prohibition appearing in workspace-knowledge AND AGENTS.md — workspace knowledge catches Lovable in long conversations where AGENTS.md drift is possible per Lovable's own docs.
+- Example: a security-critical rule appearing in AGENTS.md (prose, ~70% compliance) AND enforced by a pre-commit hook (mechanical, 100% compliance) — the hook catches what prose drift misses.
 
 **Do NOT duplicate when:**
-- The import pattern covers both agents (Lovable reads AGENTS.md natively, Claude Code imports it via `@AGENTS.md`).
+- An AGENTS.md-aware agent already reads it natively and Claude Code can import it via `@AGENTS.md` — one canonical source covers both.
 - The content is enforced structurally (a test, a hook) — prose duplication adds maintenance without raising compliance above the already-100% structural enforcement.
 - The rule is process discipline enforced by `/pre-merge`, commit-review hooks, or other mechanical gates.
 
-## 5. Quick decision flow when editing
+## 4. Quick decision flow when editing
 
 | Question | Answer |
 |---|---|
-| Am I adding a new guardrail? | Put it in AGENTS.md (canonical). Claude Code gets it via `@AGENTS.md` import. Lovable reads it natively. |
-| The repo has CLAUDE.md but no AGENTS.md — should I add AGENTS.md? | Only if a non-Claude agent (Lovable, Cursor, Codex) is also using the repo. Otherwise CLAUDE.md alone is fine. |
+| Am I adding a new guardrail? | Put it in AGENTS.md (canonical, cross-agent). Claude Code gets it via `@AGENTS.md` import; other AGENTS.md-aware agents (Codex, Cursor, Aider, Gemini CLI, Windsurf, Amp, Lovable) read it natively. |
+| The repo has CLAUDE.md but no AGENTS.md — should I add AGENTS.md? | Only if a non-Claude AGENTS.md-aware agent (Lovable, Cursor, Codex, Aider, etc.) is also using the repo. Otherwise CLAUDE.md alone is fine. |
 | CLAUDE.md is over 200 lines — what should I trim? | First: delete content that duplicates AGENTS.md (use `@AGENTS.md` import instead). Then: collapse narrative case studies into one-sentence principles. Leave only Claude-Code-specific project context. |
-| Should I add Lovable-specific guidance to project-knowledge vs AGENTS.md? | project-knowledge for project-specific facts that only apply to Lovable's current project context; AGENTS.md for rules that apply across sessions and repos. |
 | A rule appears in two files — is that OK? | Only if (a) it's critical AND (b) the two files reach different agents / different load paths AND (c) one could silently fail. Otherwise use the import pattern. |
-| Where should this rule live — CLAUDE.md or auto-memory? | Team rule → CLAUDE.md (or AGENTS.md). Personal preference / calibration → memory. If CLAUDE.md, AGENTS.md, or a hook already covers it → **neither**; delete the memory. See §6. |
+| Where should this rule live — CLAUDE.md or auto-memory? | Team rule → CLAUDE.md (or AGENTS.md). Personal preference / calibration → memory. If CLAUDE.md, AGENTS.md, or a hook already covers it → **neither**; delete the memory. See §5. |
 
-## 6. Claude Code auto-memory (Claude-written, per-user)
+## 5. Claude Code auto-memory (Claude-written, per-user)
 
 Auto-memory at `~/.claude/projects/<project>/memory/` is adjacent to
 CLAUDE.md but serves a different role. It's machine-local and per
@@ -195,12 +179,11 @@ the user is and how they prefer to collaborate, feedback calibration
 (corrections **and** validated judgment calls) with the *why* story,
 time-sensitive project context, and references to external systems.
 
-## 7. Primary sources
+## 6. Primary sources
 
 - [Claude Code — How Claude remembers your project](https://code.claude.com/docs/en/memory)
 - [Claude Code — Best Practices](https://code.claude.com/docs/en/best-practices)
 - [claude-code CHANGELOG.md](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md)
-- [Lovable Docs — Knowledge](https://docs.lovable.dev/features/knowledge)
 - [agents.md standard](https://agents.md)
 - [Context Rot — Chroma Research](https://research.trychroma.com/context-rot)
 - [Writing a good CLAUDE.md — HumanLayer](https://www.humanlayer.dev/blog/writing-a-good-claude-md)

--- a/claude/.claude/skills/code-review/SKILL.md
+++ b/claude/.claude/skills/code-review/SKILL.md
@@ -140,15 +140,7 @@ Evaluate the code against each item. Only flag items where there is a concrete i
 
 ## Domain: Lovable config
 
-Apply when changed files match `.lovable/**`.
-
-37. **Perspective** — Are instructions written from Lovable's perspective (second person, addressed to Lovable)? Knowledge files reading as internal engineering notes will confuse Lovable.
-
-38. **Specificity** — Are instructions specific enough to prevent unintended behavior? Lovable follows literally and may over-apply vague guidance ("be careful with auth" → adds auth checks to public endpoints).
-
-39. **Context budget** — Are knowledge files concise enough to fit Lovable's working context without displacing active task instructions? Same principle as Claude Code skills.
-
-40. **Sync status** — If project-knowledge.md or workspace-knowledge.md changed, does the PR description mention syncing to the Lovable UI? The file is source of truth, but Lovable reads from the UI field.
+Apply when changed files match `.lovable/**`. See the `lovable-knowledge` skill for the review checklist (perspective, specificity, scope split between project/workspace knowledge, char budget, sync status).
 
 ## Exclusions — do NOT flag these
 
@@ -262,7 +254,6 @@ The dispatcher fires reviewers per file-path domain detection. Each agent self-s
 | **32. Performance-sensitive paths** | `staff-backend-engineer` (app-level query patterns) | `staff-data-engineer` (DDL / index / read-path) |
 | **35. Permission scope** | `ciso-reviewer` | — |
 | **36. Hook correctness** | `staff-platform-engineer` | `ciso-reviewer` |
-| **37–40. Lovable config** (perspective, specificity, context budget, sync status) | judgment (any reviewer) | — |
 
 ## Step — Record review completion
 

--- a/claude/.claude/skills/lovable-knowledge/SKILL.md
+++ b/claude/.claude/skills/lovable-knowledge/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: lovable-knowledge
+description: >
+  How Lovable's UI knowledge fields work (Project Knowledge vs Workspace
+  Knowledge), the `.lovable/*.md` repo-mirror workflow, content scope
+  split, precedence, character limits, and review criteria for `.lovable/**`
+  changes.
+  TRIGGER when: editing `.lovable/*.md`; drafting changes to Lovable
+  Project Knowledge or Workspace Knowledge; deciding which Lovable
+  knowledge field a given rule belongs in; reviewing `.lovable/**`
+  changes in a PR.
+  DO NOT TRIGGER when: editing CLAUDE.md or AGENTS.md (use
+  `ai-instruction-and-memory-files`); editing agent-specific rules files
+  like `.cursorrules` or `.github/copilot-instructions.md` (out of
+  current scope); or writing code.
+user-invocable: false
+---
+
+# Lovable Knowledge — Architecture & Review
+
+The facts below come from primary sources ([Lovable Docs — Knowledge](https://docs.lovable.dev/features/knowledge)).
+
+## 1. The four sources Lovable loads
+
+> "When you send a message, Lovable reads your project knowledge, workspace knowledge, and project code... It also looks at instruction files in your project's GitHub repository such as AGENTS.md or CLAUDE.md."
+
+Effective priority order:
+
+1. **Project Knowledge** (Lovable UI field — highest priority)
+2. **Workspace Knowledge** (Lovable UI field)
+3. **AGENTS.md / CLAUDE.md** (repo files — AGENTS.md has the explicit "always read regardless of session length" guarantee)
+4. **Project code**
+
+> "Lovable is encouraged to prioritize the instructions defined in project knowledge, since they apply specifically to the current project."
+
+> "Root-level AGENTS.md files are always read by the Lovable agent regardless of session length."
+
+All four are loaded every session. Lovable docs warn that in very long
+conversations instructions can drift; the "always read" guarantee for
+AGENTS.md is the defense-in-depth.
+
+## 2. Project Knowledge vs Workspace Knowledge
+
+Per Lovable docs:
+
+| | Workspace Knowledge | Project Knowledge |
+|---|---|---|
+| Scope | Cross-project (the Lovable workspace) | Single-project |
+| Use for | Coding style, naming, libraries/frameworks, architectural patterns, testing requirements, lint rules, brand/voice, **Lovable-platform behavior** | What the app does, user personas, schema/tables, architecture decisions, domain terminology, project-specific constraints, design specifics, security/compliance, links to important references |
+| Precedence | — | **Wins on conflict** |
+| Char limit | 10,000 | 10,000 |
+
+> "Keep shared rules in workspace knowledge and project-specific details in project knowledge to avoid confusion and maximize clarity."
+
+When a rule could plausibly fit in either: ask whether it would apply to
+a *different* project in the same Lovable workspace. If yes →
+workspace. If no (it's tied to *this* product's domain, schema, or
+constraints) → project.
+
+## 3. `.lovable/` repo-mirror workflow
+
+`.lovable/project-knowledge.md` and `.lovable/workspace-knowledge.md` are
+**version-controlled mirrors** of the corresponding Lovable UI fields.
+Lovable only loads the UI fields at runtime; the repo files are not
+auto-loaded — they exist for diff review and history.
+
+**Workflow** for updating Lovable knowledge:
+
+1. Draft the change in a PR against the appropriate `.lovable/` file.
+2. Bump the "Last synced to Lovable UI" date in the file header in the
+   same PR.
+3. After merge, the human pastes the merged content into Lovable →
+   Settings → Knowledge.
+
+**Do not** assume that writing to `.lovable/` propagates to Lovable. The
+UI field is the only thing Lovable reads; the repo file is the
+authoring/review surface.
+
+**Do not** skip the repo step and paste directly into the UI without a
+PR — that loses diff review, version history, and audit trail.
+
+## 4. Authoring guidance
+
+When writing content for either field:
+
+- **Perspective.** Address Lovable in second person. Knowledge files
+  reading as internal engineering notes will confuse Lovable.
+- **Specificity.** Lovable follows literally and may over-apply vague
+  guidance. "Be careful with auth" can become "add auth checks to public
+  endpoints." Spell out the boundary cases.
+- **Context budget.** Both fields cap at 10,000 chars. Beyond that,
+  Lovable drops content. Even before the cap, length displaces active
+  task instructions — apply the same length and behavior-test discipline
+  as Claude Code skills (see `ai-instruction-and-memory-files` §3).
+
+## 5. Review checklist for `.lovable/**` changes
+
+When reviewing a PR that touches `.lovable/*.md`:
+
+1. **Perspective** — Is the new content addressed to Lovable in second
+   person?
+2. **Specificity** — Could the instruction be over-applied (e.g., "be
+   careful with auth" applied to public endpoints)?
+3. **Scope** — Cross-project conventions → `workspace-knowledge.md`;
+   this-app-specific → `project-knowledge.md`. Project knowledge wins
+   on conflict.
+4. **Char budget** — Is the file approaching the 10,000-char limit?
+5. **Sync status** — If `project-knowledge.md` or
+   `workspace-knowledge.md` changed, has the "Last synced" date been
+   bumped in the same PR? Does the PR description note that the human
+   needs to paste the merged content into the Lovable UI?
+
+## 6. Sandbox-vs-`origin/main` drift
+
+Lovable's working sandbox at `/dev-server` can desync from `origin/main`
+without producing a git commit (e.g., in-product checkpoint rollbacks
+bypass git). The rendered preview serves from the sandbox, not from
+`main`. Symptom: a user reports "X was reverted," "X came back after I
+removed it," or "the change isn't showing in the preview."
+
+The fix is to merge a one-line no-op PR to `main` (e.g., a trailing
+newline in `.gitignore`). Lovable's automation resyncs the sandbox to
+`main` HEAD on the new commit. Surface this in chat when drift is
+suspected; do not re-apply edits from a stale sandbox base — diffs are
+computed against the rolled-back state and silently revert intervening
+`main` history.
+
+## 7. Primary sources
+
+- [Lovable Docs — Knowledge](https://docs.lovable.dev/features/knowledge)
+- [agents.md standard](https://agents.md) (cross-agent AGENTS.md context)

--- a/claude/.claude/skills/lovable-knowledge/SKILL.md
+++ b/claude/.claude/skills/lovable-knowledge/SKILL.md
@@ -110,22 +110,7 @@ When reviewing a PR that touches `.lovable/*.md`:
    bumped in the same PR? Does the PR description note that the human
    needs to paste the merged content into the Lovable UI?
 
-## 6. Sandbox-vs-`origin/main` drift
-
-Lovable's working sandbox at `/dev-server` can desync from `origin/main`
-without producing a git commit (e.g., in-product checkpoint rollbacks
-bypass git). The rendered preview serves from the sandbox, not from
-`main`. Symptom: a user reports "X was reverted," "X came back after I
-removed it," or "the change isn't showing in the preview."
-
-The fix is to merge a one-line no-op PR to `main` (e.g., a trailing
-newline in `.gitignore`). Lovable's automation resyncs the sandbox to
-`main` HEAD on the new commit. Surface this in chat when drift is
-suspected; do not re-apply edits from a stale sandbox base — diffs are
-computed against the rolled-back state and silently revert intervening
-`main` history.
-
-## 7. Primary sources
+## 6. Primary sources
 
 - [Lovable Docs — Knowledge](https://docs.lovable.dev/features/knowledge)
 - [agents.md standard](https://agents.md) (cross-agent AGENTS.md context)


### PR DESCRIPTION
## Summary

Creates a new `lovable-knowledge` skill consolidating Lovable-specific guidance previously scattered across two skills, plus new content not covered anywhere (workspace-vs-project content scope per Lovable docs, the `.lovable/` repo-mirror workflow, sandbox-vs-`main` drift remediation).

`ai-instruction-and-memory-files` and `code-review` get trimmed of the migrated content.

## Why this split

`ai-instruction-and-memory-files` was carrying §2 Lovable load order, a Lovable-specific duplication example in §4, a decision-flow row in §5, and a Lovable docs link in §7. Its description claimed to cover Cursor rules, Copilot instructions, and Lovable knowledge — but the body really only covered Claude+Lovable, and the description overpromised. `code-review` had four Lovable items (37–40) bolted onto its general review checklist.

The two surfaces are conceptually distinct: instruction files (CLAUDE.md, AGENTS.md, auto-memory) versus Lovable's UI knowledge fields. Each has its own load model, scope split, and review criteria. Splitting them lets each skill stay focused and gives the Lovable surface a complete end-to-end home (authoring + review).

## Changes

### New: `claude/.claude/skills/lovable-knowledge/SKILL.md`

Six sections covering the full Lovable knowledge surface:

1. The four sources Lovable loads (extracted from `ai-instruction-and-memory-files` §2 + "AGENTS.md always read regardless of session length" guarantee)
2. Project vs Workspace knowledge content scope (NEW — per [Lovable docs](https://docs.lovable.dev/features/knowledge), with 10,000-char limit and conflict-precedence rules)
3. The `.lovable/` repo-mirror workflow (NEW — captures the lesson from a recent session where Lovable knowledge changes were drafted as chat-only text instead of repo edits)
4. Authoring guidance (extracted from `code-review` items 37–39: perspective, specificity, context budget)
5. Review checklist for `.lovable/**` changes (extracted from `code-review` item 40 + repackaged 37–39)
6. Sandbox-vs-`origin/main` drift remediation (NEW — captures the no-op-PR-resync pattern from the same recent session)

131 lines, well under the 200-line target.

### Trimmed: `claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md`

207 → 189 lines.

- **Description rewritten** to honest scope (CLAUDE.md, AGENTS.md as cross-agent standard, Claude Code auto-memory). Removed overpromised claims about Cursor rules, Copilot instructions, and Lovable. Added explicit `DO NOT TRIGGER` for those.
- **§2 (Lovable load order) removed** — extracted to `lovable-knowledge`. Replaced with one-line pointer.
- **§4 Lovable example replaced** with a hook-vs-prose defense-in-depth example (more general, applies to any agent).
- **§5 Lovable decision-flow row removed**. The AGENTS.md guardrail row generalized to mention all AGENTS.md-aware agents (Codex, Cursor, Aider, Gemini CLI, Windsurf, Amp, Lovable) instead of just Lovable.
- **§7 Lovable docs link removed** (no remaining citation needs it).
- **Sections renumbered** 3→2, 4→3, 5→4, 6→5, 7→6. Internal cross-reference `See §6` → `See §5`.

### Trimmed: `claude/.claude/skills/code-review/SKILL.md`

289 → 280 lines.

- **"Domain: Lovable config"** section (items 37–40: Perspective, Specificity, Context budget, Sync status) replaced with one-line pointer to `lovable-knowledge`.
- **Item-ownership table** row "37–40. Lovable config" removed.

## Test plan

- [ ] On next session, an AI agent editing `.lovable/*.md` triggers `lovable-knowledge` (not `ai-instruction-and-memory-files`).
- [ ] An agent editing `CLAUDE.md` or `AGENTS.md` triggers `ai-instruction-and-memory-files` and finds the description honestly scoped.
- [ ] An agent reviewing a `.lovable/**` change in a PR finds the review checklist in `lovable-knowledge`, not in `code-review`.

## Followups (out of scope for this PR)

Two more dedicated skills are queued: `skill-review` (extract code-review items 33–34) and `hook-review` (extract code-review item 36). Those land as separate PRs.
