### PR TITLE
ready-for-review: PR-description shape rules in step 4

### DIFF
--- a/claude/.claude/skills/ready-for-review/SKILL.md
+++ b/claude/.claude/skills/ready-for-review/SKILL.md
@@ -103,24 +103,24 @@ The PR description is for the reviewer, not for posterity. Compare
 the body against branch state:
 
 - `gh pr view <n> --json body,title`
+- `git log <base>..HEAD --oneline`
 - `git diff <base>..HEAD --name-only`
 
 Flag and fix:
 
 - **Per-commit narratives** ("Commit X did Y, Commit Z did W").
   Reorganize "What shipped" by surface the reviewer maps to (schema /
-  handler / tests / invariants / migration-deploy notes) so they can
-  find files; `git log` already has the chronology.
-- **Reviewer-action items Claude can answer itself.** Strip items
+  handler / tests / invariants / migration-deploy notes); `git log`
+  already has the chronology.
+- **Reviewer-action items Claude can answer itself.** Strip claims
   you can verify ("all migrations match precedent" — confirm and
-  remove), test-pass claims ("977/977 pass" belongs in the commit
-  message, not the reviewer's checklist), and CI-status placeholders
-  (step 5 covers those). Legitimate items: deploy coordination,
-  security-invariant catalog approval, architectural sign-off.
-- Stale prose left behind by code changes — a guard removed in
-  commit N must also disappear from migration-ordering notes, the
-  test plan, "remaining concerns" lists, and any line counts or
-  screenshots referencing it.
+  remove), test counts (those belong in the commit message), and
+  CI placeholders (step 5 covers those). Keep items requiring
+  reviewer judgment: deploy coordination, security-invariant catalog
+  approval, architectural sign-off.
+- Stale prose left behind by code changes — a removed guard, an
+  abandoned approach, a deleted file must also disappear from the
+  migration-ordering note, test plan, and "remaining concerns" list.
 - `TBD` / `pending` / "to be updated" markers still in the body.
 - Files listed in the body that are no longer in the diff, or files
   in the diff absent from the body.

--- a/claude/.claude/skills/ready-for-review/SKILL.md
+++ b/claude/.claude/skills/ready-for-review/SKILL.md
@@ -99,20 +99,31 @@ same pass.
 
 ## 4. Sync PR description (warn + fix; skip if no PR)
 
-Compare the PR body against branch state:
+The PR description is for the reviewer, not for posterity. Compare
+the body against branch state:
 
 - `gh pr view <n> --json body,title`
-- `git log <base>..HEAD --oneline`
 - `git diff <base>..HEAD --name-only`
 
 Flag and fix:
 
+- **Per-commit narratives** ("Commit X did Y, Commit Z did W").
+  Reorganize "What shipped" by surface the reviewer maps to (schema /
+  handler / tests / invariants / migration-deploy notes) so they can
+  find files; `git log` already has the chronology.
+- **Reviewer-action items Claude can answer itself.** Strip items
+  you can verify ("all migrations match precedent" — confirm and
+  remove), test-pass claims ("977/977 pass" belongs in the commit
+  message, not the reviewer's checklist), and CI-status placeholders
+  (step 5 covers those). Legitimate items: deploy coordination,
+  security-invariant catalog approval, architectural sign-off.
+- Stale prose left behind by code changes — a guard removed in
+  commit N must also disappear from migration-ordering notes, the
+  test plan, "remaining concerns" lists, and any line counts or
+  screenshots referencing it.
 - `TBD` / `pending` / "to be updated" markers still in the body.
-- Commits on the branch not reflected in the Summary section.
 - Files listed in the body that are no longer in the diff, or files
   in the diff absent from the body.
-- Stale line counts, screenshots of removed UI, references to approaches
-  that were abandoned during iteration.
 
 Propose an updated body and apply with `gh pr edit <n> --body`. Keep
 the project's template structure intact — refresh content inside


### PR DESCRIPTION
## What shipped

**SKILL.md step 4 — Sync PR description.** Three new flag-and-fix bullets, one consolidation, and one removal.

- **New: per-commit narratives.** Step 4 now flags "Commit X did Y, Commit Z did W"-shape descriptions and prescribes the fix: reorganize by surface the reviewer maps to — schema / handler / tests / invariants / migration-deploy notes.
- **New: reviewer-action items Claude can answer itself.** Strip "all migrations match precedent" (confirm and remove), test counts (commit-message material), and CI placeholders (step 5's job). Keep items requiring reviewer judgment: deploy coordination, security-invariant catalog approval, architectural sign-off.
- **New: stale prose left behind by code changes.** A removed guard, an abandoned approach, or a deleted file must also disappear from the migration-ordering note, test plan, and "remaining concerns" list. Consolidates the previous "stale line counts / abandoned approaches" bullet into a broader rule with concrete trigger forms.
- **Removed: "Commits on the branch not reflected in the Summary section"** — directly encouraged the per-commit narrative shape the new rules disallow.

## Context

Closes Part 3 of `~/.claude/handoffs/ready-for-review-skill-trigger-gap.md`. Parts 1 and 2 (semantic triggers + cumulative-scope step 3) shipped in #65; this addresses the remaining gap where the gate could pass while the description was still wrong-shape.

## Reviewer judgment requested

- Wording of the three new bullets — particularly "Reviewer-action items Claude can answer itself" examples. Concrete enough without a framework-specific anchor (intentionally framework-agnostic)?
- Skill-on-its-own-diff was applied — the addition is consistent with shape-over-chronology and the existing terse style; ai-instruction-and-memory-files skill's behavior test was applied on the second commit. Worth a second eye on whether each new bullet still earns its lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)