### PR TITLE
ready-for-review: add push gate (marker + hook)

### DIFF
--- a/claude/.claude/hooks/require-ready-for-review.sh
+++ b/claude/.claude/hooks/require-ready-for-review.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+# Gate: require /ready-for-review to have run before pushing to a branch
+# with an open PR (or marking a draft PR ready). Verified via marker file.
+#
+# Why: pre-handoff gate (/ready-for-review) verifies tests/lint/typecheck,
+# runs cumulative /code-review, syncs PR body, and checks CI before the
+# human reviews. Without enforcement, Claude habitually pushes wrap-up
+# commits straight to a PR without running the gate. Mirrors the
+# require-code-review.sh pattern: marker keyed by session, content matches
+# the artifact about to be published (HEAD SHA, not staged-diff hash —
+# the analogue is the squash-merge artifact reviewers see, not the
+# upcoming commit).
+#
+# Two-marker pattern:
+# - Active marker (~/.claude/.ready-for-review-active.d/<session_id>):
+#   presence-only, fresh mtime <60 min. Written by /ready-for-review at
+#   step 0; removed at step 7 (completion). Bypasses the gate so the
+#   skill's own iteration pushes (step 3 fix → push → loop) don't
+#   self-deny. mtime refreshed on each bypass to handle long runs.
+# - Completion marker (~/.claude/ready-for-review-markers/<repo-hash>.<session_id>):
+#   contents are the local HEAD SHA at gate-completion time. Written at
+#   step 7 only when every halt-on-fail step passed. Pushes against the
+#   recorded HEAD are allowed; new commits invalidate the marker
+#   automatically (HEAD moves) and force a re-run.
+#
+# Bypass cases (allow without checking marker):
+# - Not Bash tool, or not git push / gh pr ready / gh pr review --approve etc.
+# - --dry-run pushes
+# - --tags-only pushes (no branch artifact change)
+# - Deletion pushes (--delete flag, or `origin :branch` source-empty form)
+# - Branch is the default branch (no PR semantics)
+# - Branch has no open PR (gh pr view returns empty)
+# - gh pr view fails (network issue, gh not configured, etc.) — fail-open
+#   to keep the user unblocked; the skill's prose triggers still fire.
+
+INPUT=$(cat)
+TOOL=$(printf '%s\n' "$INPUT" | jq -r '.tool_name // empty')
+if [ "$TOOL" != "Bash" ]; then
+  exit 0
+fi
+
+COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command // empty')
+SESSION_ID=$(printf '%s\n' "$INPUT" | jq -r '.session_id // empty')
+
+# Match the gated commands: `git push` and `gh pr ready`.
+# - `(^|&&?|;|\|\|?)\s*git\s+push(\s|$)` — git push at start or after a
+#   shell separator, ensuring `git push-other-thing` and `git pushd` don't
+#   match (no such commands today, but defensive).
+# - `(^|&&?|;|\|\|?)\s*gh\s+pr\s+ready(\s|$)` — gh pr ready, same shape.
+is_git_push=false
+is_gh_pr_ready=false
+if printf '%s\n' "$COMMAND" | grep -qE '(^|&&?|;|\|\|?)\s*git\s+push(\s|$)'; then
+  is_git_push=true
+fi
+if printf '%s\n' "$COMMAND" | grep -qE '(^|&&?|;|\|\|?)\s*gh\s+pr\s+ready(\s|$)'; then
+  is_gh_pr_ready=true
+fi
+if ! $is_git_push && ! $is_gh_pr_ready; then
+  exit 0
+fi
+
+# git push bypass shapes — none of these publish a reviewable artifact change.
+if $is_git_push; then
+  # --dry-run: doesn't actually push.
+  if printf '%s\n' "$COMMAND" | grep -qE '(^|\s)--dry-run(\s|$)'; then
+    exit 0
+  fi
+  # --delete or refspec source-empty (`origin :branch`): branch deletion.
+  if printf '%s\n' "$COMMAND" | grep -qE '(^|\s)(-d|--delete)(\s|$)'; then
+    exit 0
+  fi
+  if printf '%s\n' "$COMMAND" | grep -qE '\s:[A-Za-z0-9._/-]+(\s|$)'; then
+    exit 0
+  fi
+  # --tags with no explicit refspec other than tags: tag-only push.
+  # Conservative: only bypass when --tags is the only refspec hint. If the
+  # command also mentions a branch refspec, fall through to the gate.
+  if printf '%s\n' "$COMMAND" | grep -qE '(^|\s)--tags(\s|$)'; then
+    # If the only non-flag args after `git push` are `--tags` (and possibly
+    # a remote name), bypass. If a branch ref is also present, gate.
+    push_args=$(printf '%s\n' "$COMMAND" | sed -nE 's/.*git\s+push\s+(.*)/\1/p' | head -1)
+    # Strip flags and known-safe positional (a remote like "origin").
+    # If anything else remains, it's likely a branch ref → gate.
+    remaining=$(printf '%s\n' "$push_args" | tr ' ' '\n' | grep -vE '^(--tags|--force(-with-lease)?(=.*)?|--force-if-includes|-u|--set-upstream|origin|upstream)$' | grep -v '^$' || true)
+    if [ -z "$remaining" ]; then
+      exit 0
+    fi
+  fi
+fi
+
+# Are we in a git repo?
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$REPO_ROOT" ]; then
+  exit 0
+fi
+
+# Default-branch bypass: pushing main/master/develop has no PR review
+# semantics. Resolve the local default via the symbolic ref refs/remotes/
+# origin/HEAD; fall back to a small set of conventional names when origin/
+# HEAD isn't configured. Use `git symbolic-ref --quiet` rather than
+# `rev-parse --abbrev-ref origin/HEAD`: the latter outputs the literal
+# string "origin/HEAD" (not empty) when origin/HEAD isn't a symbolic ref,
+# which defeats the fallback path.
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+DEFAULT_BRANCH=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null | sed 's|^refs/remotes/origin/||')
+if [ -z "$DEFAULT_BRANCH" ]; then
+  for candidate in main master develop; do
+    if git rev-parse --verify "origin/$candidate" >/dev/null 2>&1; then
+      DEFAULT_BRANCH="$candidate"
+      break
+    fi
+  done
+fi
+if [ -n "$CURRENT_BRANCH" ] && [ -n "$DEFAULT_BRANCH" ] && [ "$CURRENT_BRANCH" = "$DEFAULT_BRANCH" ]; then
+  exit 0
+fi
+
+# Active-marker bypass: the skill is currently running.
+if [ -n "$SESSION_ID" ]; then
+  ACTIVE_MARKER="$HOME/.claude/.ready-for-review-active.d/$SESSION_ID"
+  if [ -f "$ACTIVE_MARKER" ] && [ -n "$(find "$ACTIVE_MARKER" -mmin -60 2>/dev/null)" ]; then
+    touch "$ACTIVE_MARKER" 2>/dev/null
+    exit 0
+  fi
+fi
+
+# PR existence check: only gate when the branch actually has an open PR.
+# Network call — wrap in `timeout` so a hanging gh doesn't stall the
+# tool-call. On error/timeout, fail-open: the skill's prose triggers
+# still fire, and we don't want to brick offline / flaky-network work.
+PR_NUMBER=$(timeout 5 gh pr view --json number --jq '.number' 2>/dev/null)
+if [ -z "$PR_NUMBER" ]; then
+  exit 0
+fi
+
+# Completion-marker check.
+if [ -n "$SESSION_ID" ]; then
+  REPO_HASH=$(printf '%s' "$REPO_ROOT" | sha256sum | awk '{print $1}')
+  MARKER="$HOME/.claude/ready-for-review-markers/$REPO_HASH.$SESSION_ID"
+  if [ -f "$MARKER" ]; then
+    MARKER_HEAD=$(tr -d '[:space:]' < "$MARKER")
+    CURRENT_HEAD=$(git rev-parse HEAD 2>/dev/null)
+    if [ -n "$MARKER_HEAD" ] && [ -n "$CURRENT_HEAD" ] && [ "$MARKER_HEAD" = "$CURRENT_HEAD" ]; then
+      exit 0
+    fi
+  fi
+fi
+
+# No active marker, no matching completion marker, gh pr view confirmed
+# the branch has an open PR — block.
+if $is_gh_pr_ready; then
+  REASON="PR ready-for-review marking blocked by ready-for-review gate: this PR has not been gated by /ready-for-review in THIS session, or HEAD has moved since the gate ran. Run the /ready-for-review skill now — it verifies tests/lint/typecheck, runs cumulative /code-review against the PR-vs-default-branch diff, syncs the PR body, and checks CI. When all halt-on-fail steps pass, the skill records completion in ~/.claude/ready-for-review-markers/ and this command will be allowed through. Do not ask the user for permission — run the skill, address any findings, and retry."
+else
+  REASON="Push to a branch with an open PR blocked by ready-for-review gate: this branch's HEAD has not been gated by /ready-for-review in THIS session, or HEAD has moved since the gate ran. Run the /ready-for-review skill now — it verifies tests/lint/typecheck, runs cumulative /code-review against the PR-vs-default-branch diff, syncs the PR body, and checks CI. When all halt-on-fail steps pass, the skill records completion in ~/.claude/ready-for-review-markers/ and this push will be allowed through. Do not ask the user for permission — run the skill, address any findings, and retry the push."
+fi
+REASON_JSON=$(printf '%s' "$REASON" | jq -Rs .)
+printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' "$REASON_JSON"

--- a/claude/.claude/hooks/tests/test_hooks.py
+++ b/claude/.claude/hooks/tests/test_hooks.py
@@ -21,6 +21,7 @@ import pytest
 HOOKS_DIR = Path(__file__).resolve().parent.parent
 CODE_REVIEW_HOOK = HOOKS_DIR / "require-code-review.sh"
 RESPOND_PR_HOOK = HOOKS_DIR / "require-respond-pr.sh"
+READY_FOR_REVIEW_HOOK = HOOKS_DIR / "require-ready-for-review.sh"
 REVIEW_PERMS_HOOK = HOOKS_DIR / "ask-review-permissions.sh"
 DENY_PRIVATE_PROJECT_REFS_HOOK = HOOKS_DIR / "deny-private-project-refs.sh"
 STOW_REMINDER_HOOK = HOOKS_DIR / "require-stow-reminder.sh"
@@ -30,6 +31,7 @@ CAPTURE_SESSION_ID_HOOK = HOOKS_DIR / "capture-session-id.sh"
 SKILLS_DIR = HOOKS_DIR.parent / "skills"
 CODE_REVIEW_SKILL = SKILLS_DIR / "code-review" / "SKILL.md"
 RESPOND_PR_SKILL = SKILLS_DIR / "respond-pr" / "SKILL.md"
+READY_FOR_REVIEW_SKILL = SKILLS_DIR / "ready-for-review" / "SKILL.md"
 
 # SKILL.md fences may be indented when the fixture sits inside a
 # numbered list (e.g. respond-pr's "0. **Enable hook bypass.**"). The
@@ -2562,3 +2564,542 @@ class TestRequireStowReminder:
         )
         payload = json.loads(result.stdout)
         assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+# ---------------------------------------------------------------------------
+# require-ready-for-review.sh
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_gh_pr_exists(tmp_path, monkeypatch):
+    """Inject a fake gh that reports an open PR (`pr view ...` returns 42)."""
+    bin_dir = tmp_path / "fake-bin-pr"
+    bin_dir.mkdir()
+    gh = bin_dir / "gh"
+    gh.write_text(
+        '#!/bin/bash\n'
+        'case "$*" in *"pr view"*) echo 42 ;; *) exit 1 ;; esac\n'
+    )
+    gh.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
+    return gh
+
+
+@pytest.fixture
+def fake_gh_no_pr(tmp_path, monkeypatch):
+    """Inject a fake gh that reports no open PR (any subcommand exits 1)."""
+    bin_dir = tmp_path / "fake-bin-nopr"
+    bin_dir.mkdir()
+    gh = bin_dir / "gh"
+    gh.write_text("#!/bin/bash\nexit 1\n")
+    gh.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
+    return gh
+
+
+@pytest.fixture
+def repo_on_feature_branch(tmp_path):
+    """Repo with `main` configured as default and a `feature` branch checked
+    out. Fakes the origin/main ref so the hook's default-branch detection
+    works without a real remote."""
+    repo = tmp_path / "rfr-repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=repo, check=True)
+    (repo / "f").write_text("a\n")
+    subprocess.run(["git", "add", "f"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-qm", "init"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "update-ref", "refs/remotes/origin/main", "HEAD"],
+        cwd=repo,
+        check=True,
+    )
+    subprocess.run(["git", "checkout", "-q", "-b", "feature"], cwd=repo, check=True)
+    return repo
+
+
+def rfr_active_marker(home: Path, session_id: str) -> Path:
+    return home / ".claude" / ".ready-for-review-active.d" / session_id
+
+
+def rfr_completion_marker(home: Path, repo: Path, session_id: str) -> Path:
+    repo_hash = hashlib.sha256(git_toplevel(repo).encode()).hexdigest()
+    return (
+        home / ".claude" / "ready-for-review-markers" / f"{repo_hash}.{session_id}"
+    )
+
+
+def head_sha(repo: Path) -> str:
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
+class TestRequireReadyForReview:
+    """Push gate: requires /ready-for-review to have run before pushing to a
+    branch with an open PR (or marking a draft PR ready). Two-marker layout:
+    active (presence-only, bypasses during skill execution) and completion
+    (HEAD SHA, allows pushes against the recorded HEAD)."""
+
+    # -- Bypass shapes (no marker required) ------------------------------
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "git status",
+            "git log --oneline",
+            "git commit -m foo",
+            "echo git push",
+        ],
+    )
+    def test_non_push_commands_allowed(
+        self, isolated_home, repo_on_feature_branch, command
+    ):
+        assert (
+            run_hook(
+                READY_FOR_REVIEW_HOOK,
+                bash_input(command, session_id="s"),
+                cwd=repo_on_feature_branch,
+            )
+            == "allow"
+        )
+
+    def test_non_bash_tool_allowed(self, isolated_home):
+        assert (
+            run_hook(READY_FOR_REVIEW_HOOK, edit_input("/tmp/foo.txt")) == "allow"
+        )
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "git push --dry-run",
+            "git push origin feature --dry-run",
+            "git push origin --delete feature",
+            "git push origin -d feature",
+            "git push origin :feature",
+        ],
+    )
+    def test_destructive_or_dry_push_shapes_allowed(
+        self,
+        isolated_home,
+        repo_on_feature_branch,
+        fake_gh_pr_exists,
+        command,
+    ):
+        """Even on a PR branch, --dry-run / --delete / colon-deletion don't
+        publish a reviewable artifact change. Bypass without checking marker."""
+        assert (
+            run_hook(
+                READY_FOR_REVIEW_HOOK,
+                bash_input(command, session_id="s"),
+                cwd=repo_on_feature_branch,
+            )
+            == "allow"
+        )
+
+    def test_tags_only_push_allowed(
+        self, isolated_home, repo_on_feature_branch, fake_gh_pr_exists
+    ):
+        assert (
+            run_hook(
+                READY_FOR_REVIEW_HOOK,
+                bash_input("git push origin --tags", session_id="s"),
+                cwd=repo_on_feature_branch,
+            )
+            == "allow"
+        )
+
+    def test_tags_with_branch_still_gated(
+        self, isolated_home, repo_on_feature_branch, fake_gh_pr_exists
+    ):
+        """`git push --tags origin feature` pushes BOTH tags AND a branch ref —
+        the branch is reviewable, so gate."""
+        assert (
+            run_hook(
+                READY_FOR_REVIEW_HOOK,
+                bash_input("git push --tags origin feature", session_id="s"),
+                cwd=repo_on_feature_branch,
+            )
+            == "deny"
+        )
+
+    def test_default_branch_push_allowed(
+        self, isolated_home, repo_on_feature_branch, fake_gh_pr_exists
+    ):
+        """Push from default branch has no PR review semantics — bypass."""
+        subprocess.run(
+            ["git", "checkout", "-q", "main"],
+            cwd=repo_on_feature_branch,
+            check=True,
+        )
+        assert (
+            run_hook(
+                READY_FOR_REVIEW_HOOK,
+                bash_input("git push", session_id="s"),
+                cwd=repo_on_feature_branch,
+            )
+            == "allow"
+        )
+
+    def test_branch_with_no_pr_allowed(
+        self, isolated_home, repo_on_feature_branch, fake_gh_no_pr
+    ):
+        """Branch hasn't had a PR opened yet — nothing to gate."""
+        assert (
+            run_hook(
+                READY_FOR_REVIEW_HOOK,
+                bash_input("git push origin feature", session_id="s"),
+                cwd=repo_on_feature_branch,
+            )
+            == "allow"
+        )
+
+    def test_outside_git_repo_allowed(self, isolated_home, tmp_path):
+        non_repo = tmp_path / "not-a-repo"
+        non_repo.mkdir()
+        assert (
+            run_hook(
+                READY_FOR_REVIEW_HOOK,
+                bash_input("git push", session_id="s"),
+                cwd=non_repo,
+            )
+            == "allow"
+        )
+
+    # -- Active-marker bypass --------------------------------------------
+
+    def test_fresh_active_marker_allows(
+        self, isolated_home, repo_on_feature_branch, fake_gh_pr_exists
+    ):
+        """During /ready-for-review's own iteration (step 3 fix → push →
+        loop), the active marker bypasses the gate so the skill doesn't
+        self-deny."""
+        sid = "session-active"
+        marker_dir = isolated_home / ".claude" / ".ready-for-review-active.d"
+        marker_dir.mkdir(parents=True)
+        (marker_dir / sid).touch()
+        assert (
+            run_hook(
+                READY_FOR_REVIEW_HOOK,
+                bash_input("git push origin feature", session_id=sid),
+                cwd=repo_on_feature_branch,
+            )
+            == "allow"
+        )
+
+    def test_stale_active_marker_falls_through(
+        self, isolated_home, repo_on_feature_branch, fake_gh_pr_exists
+    ):
+        """>60min old marker doesn't bypass; with no completion marker, deny."""
+        sid = "session-stale"
+        marker_dir = isolated_home / ".claude" / ".ready-for-review-active.d"
+        marker_dir.mkdir(parents=True)
+        marker = marker_dir / sid
+        marker.touch()
+        ninety_min_ago = time.time() - 90 * 60
+        os.utime(marker, (ninety_min_ago, ninety_min_ago))
+        assert (
+            run_hook(
+                READY_FOR_REVIEW_HOOK,
+                bash_input("git push origin feature", session_id=sid),
+                cwd=repo_on_feature_branch,
+            )
+            == "deny"
+        )
+
+    def test_other_sessions_active_marker_does_not_bypass(
+        self, isolated_home, repo_on_feature_branch, fake_gh_pr_exists
+    ):
+        """Per-session keying: A's active marker must NOT authorize B's push."""
+        marker_dir = isolated_home / ".claude" / ".ready-for-review-active.d"
+        marker_dir.mkdir(parents=True)
+        (marker_dir / "session-A").touch()
+        assert (
+            run_hook(
+                READY_FOR_REVIEW_HOOK,
+                bash_input("git push origin feature", session_id="session-B"),
+                cwd=repo_on_feature_branch,
+            )
+            == "deny"
+        )
+
+    def test_active_marker_mtime_refreshed_on_bypass(
+        self, isolated_home, repo_on_feature_branch, fake_gh_pr_exists
+    ):
+        """Long-running skill mitigation: hook touches marker on each bypass
+        so a session approaching the 60-min cutoff doesn't get blocked."""
+        sid = "session-long"
+        marker_dir = isolated_home / ".claude" / ".ready-for-review-active.d"
+        marker_dir.mkdir(parents=True)
+        marker = marker_dir / sid
+        marker.touch()
+        fifty_min_ago = time.time() - 50 * 60
+        os.utime(marker, (fifty_min_ago, fifty_min_ago))
+        pre_mtime = marker.stat().st_mtime
+        assert (
+            run_hook(
+                READY_FOR_REVIEW_HOOK,
+                bash_input("git push origin feature", session_id=sid),
+                cwd=repo_on_feature_branch,
+            )
+            == "allow"
+        )
+        assert marker.stat().st_mtime > pre_mtime, (
+            "active marker mtime must be refreshed on bypass"
+        )
+
+    # -- Completion-marker check ------------------------------------------
+
+    def test_no_marker_denies(
+        self, isolated_home, repo_on_feature_branch, fake_gh_pr_exists
+    ):
+        assert (
+            run_hook(
+                READY_FOR_REVIEW_HOOK,
+                bash_input("git push origin feature", session_id="s"),
+                cwd=repo_on_feature_branch,
+            )
+            == "deny"
+        )
+
+    def test_completion_marker_matching_head_allows(
+        self, isolated_home, repo_on_feature_branch, fake_gh_pr_exists
+    ):
+        sid = "s"
+        marker = rfr_completion_marker(isolated_home, repo_on_feature_branch, sid)
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text(head_sha(repo_on_feature_branch) + "\n")
+        assert (
+            run_hook(
+                READY_FOR_REVIEW_HOOK,
+                bash_input("git push origin feature", session_id=sid),
+                cwd=repo_on_feature_branch,
+            )
+            == "allow"
+        )
+
+    def test_completion_marker_stale_head_denies(
+        self, isolated_home, repo_on_feature_branch, fake_gh_pr_exists
+    ):
+        """New commit after gate ran → HEAD moves → marker stale → deny."""
+        sid = "s"
+        marker = rfr_completion_marker(isolated_home, repo_on_feature_branch, sid)
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text(head_sha(repo_on_feature_branch) + "\n")
+        (repo_on_feature_branch / "f").write_text("b\n")
+        subprocess.run(
+            ["git", "add", "f"], cwd=repo_on_feature_branch, check=True
+        )
+        subprocess.run(
+            ["git", "commit", "-qm", "more"],
+            cwd=repo_on_feature_branch,
+            check=True,
+        )
+        assert (
+            run_hook(
+                READY_FOR_REVIEW_HOOK,
+                bash_input("git push origin feature", session_id=sid),
+                cwd=repo_on_feature_branch,
+            )
+            == "deny"
+        )
+
+    def test_other_sessions_completion_marker_does_not_authorize(
+        self, isolated_home, repo_on_feature_branch, fake_gh_pr_exists
+    ):
+        """Per-session keying: A's completion marker must NOT authorize B's
+        push, even with the same HEAD SHA."""
+        head = head_sha(repo_on_feature_branch)
+        marker_a = rfr_completion_marker(isolated_home, repo_on_feature_branch, "A")
+        marker_a.parent.mkdir(parents=True, exist_ok=True)
+        marker_a.write_text(head + "\n")
+        assert (
+            run_hook(
+                READY_FOR_REVIEW_HOOK,
+                bash_input("git push origin feature", session_id="B"),
+                cwd=repo_on_feature_branch,
+            )
+            == "deny"
+        )
+
+    def test_no_session_id_denies_when_pr_exists(
+        self, isolated_home, repo_on_feature_branch, fake_gh_pr_exists
+    ):
+        """Without session_id in the hook payload, no per-session marker can
+        be keyed — deny when a PR exists."""
+        assert (
+            run_hook(
+                READY_FOR_REVIEW_HOOK,
+                bash_input("git push origin feature"),
+                cwd=repo_on_feature_branch,
+            )
+            == "deny"
+        )
+
+    # -- gh pr ready ------------------------------------------------------
+
+    def test_gh_pr_ready_no_marker_denies(
+        self, isolated_home, repo_on_feature_branch, fake_gh_pr_exists
+    ):
+        """Marking a draft PR ready is a handoff signal — gate it the same
+        way as push."""
+        assert (
+            run_hook(
+                READY_FOR_REVIEW_HOOK,
+                bash_input("gh pr ready", session_id="s"),
+                cwd=repo_on_feature_branch,
+            )
+            == "deny"
+        )
+
+    def test_gh_pr_ready_with_completion_marker_allowed(
+        self, isolated_home, repo_on_feature_branch, fake_gh_pr_exists
+    ):
+        sid = "s"
+        marker = rfr_completion_marker(isolated_home, repo_on_feature_branch, sid)
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text(head_sha(repo_on_feature_branch) + "\n")
+        assert (
+            run_hook(
+                READY_FOR_REVIEW_HOOK,
+                bash_input("gh pr ready", session_id=sid),
+                cwd=repo_on_feature_branch,
+            )
+            == "allow"
+        )
+
+    # -- gh failure → fail-open ------------------------------------------
+
+    def test_gh_failure_fails_open(
+        self, isolated_home, repo_on_feature_branch, fake_gh_no_pr
+    ):
+        """If gh pr view errors (network glitch, gh not configured), the gate
+        does not fire — keeps the user unblocked. The skill's prose triggers
+        still cover this case."""
+        assert (
+            run_hook(
+                READY_FOR_REVIEW_HOOK,
+                bash_input("git push origin feature", session_id="s"),
+                cwd=repo_on_feature_branch,
+            )
+            == "allow"
+        )
+
+    # -- Skill ↔ hook alignment ------------------------------------------
+
+    def test_skill_activate_command_creates_active_marker(
+        self, isolated_home, repo_on_feature_branch, fake_gh_pr_exists
+    ):
+        """SKILL.md activate-gate fixture must produce a marker the hook
+        recognizes as a fresh active-session bypass."""
+        sid = "test-session-rfr-activate"
+        sessions_dir = isolated_home / ".claude" / "sessions"
+        sessions_dir.mkdir(parents=True)
+        (sessions_dir / str(os.getpid())).write_text(sid)
+
+        assert (
+            run_hook(
+                READY_FOR_REVIEW_HOOK,
+                bash_input("git push origin feature", session_id=sid),
+                cwd=repo_on_feature_branch,
+            )
+            == "deny"
+        ), "precondition: gated push must deny before activation"
+
+        cmd = extract_skill_command(READY_FOR_REVIEW_SKILL, "activate-gate")
+        subprocess.run(
+            ["bash", "-c", cmd],
+            cwd=repo_on_feature_branch,
+            env={**os.environ, "HOME": str(isolated_home)},
+            check=True,
+        )
+
+        marker = rfr_active_marker(isolated_home, sid)
+        assert marker.exists(), (
+            "SKILL.md activate-gate recipe ran but no marker landed at the "
+            "path the hook checks — skill and hook disagree on layout."
+        )
+        assert (
+            run_hook(
+                READY_FOR_REVIEW_HOOK,
+                bash_input("git push origin feature", session_id=sid),
+                cwd=repo_on_feature_branch,
+            )
+            == "allow"
+        )
+
+    def test_skill_record_completion_command_creates_marker(
+        self, isolated_home, repo_on_feature_branch, fake_gh_pr_exists
+    ):
+        """SKILL.md record-completion fixture must produce a marker keyed by
+        repo-hash + session-id with HEAD SHA as content, recognized by the
+        hook for HEAD-matching pushes."""
+        sid = "test-session-rfr-complete"
+        sessions_dir = isolated_home / ".claude" / "sessions"
+        sessions_dir.mkdir(parents=True)
+        (sessions_dir / str(os.getpid())).write_text(sid)
+
+        cmd = extract_skill_command(READY_FOR_REVIEW_SKILL, "record-completion")
+        subprocess.run(
+            ["bash", "-c", cmd],
+            cwd=repo_on_feature_branch,
+            env={**os.environ, "HOME": str(isolated_home)},
+            check=True,
+        )
+
+        marker = rfr_completion_marker(isolated_home, repo_on_feature_branch, sid)
+        assert marker.exists(), (
+            "SKILL.md record-completion recipe ran but no marker landed at "
+            "the path the hook checks — skill and hook disagree on layout."
+        )
+        assert marker.read_text().strip() == head_sha(repo_on_feature_branch), (
+            "completion marker must hold the local HEAD SHA"
+        )
+        assert (
+            run_hook(
+                READY_FOR_REVIEW_HOOK,
+                bash_input("git push origin feature", session_id=sid),
+                cwd=repo_on_feature_branch,
+            )
+            == "allow"
+        )
+
+    def test_skill_deactivate_command_removes_active_marker(
+        self, isolated_home, repo_on_feature_branch
+    ):
+        """SKILL.md deactivate-gate fixture must remove this session's active
+        marker so a subsequent push (without completion marker) is re-gated."""
+        sid = "test-session-rfr-deactivate"
+        sessions_dir = isolated_home / ".claude" / "sessions"
+        sessions_dir.mkdir(parents=True)
+        (sessions_dir / str(os.getpid())).write_text(sid)
+
+        activate_cmd = extract_skill_command(READY_FOR_REVIEW_SKILL, "activate-gate")
+        subprocess.run(
+            ["bash", "-c", activate_cmd],
+            cwd=repo_on_feature_branch,
+            env={**os.environ, "HOME": str(isolated_home)},
+            check=True,
+        )
+        marker = rfr_active_marker(isolated_home, sid)
+        assert marker.exists(), "activate-gate setup did not create the marker"
+
+        deactivate_cmd = extract_skill_command(
+            READY_FOR_REVIEW_SKILL, "deactivate-gate"
+        )
+        subprocess.run(
+            ["bash", "-c", deactivate_cmd],
+            cwd=repo_on_feature_branch,
+            env={**os.environ, "HOME": str(isolated_home)},
+            check=True,
+        )
+        assert not marker.exists(), (
+            "SKILL.md deactivate-gate recipe ran but the marker is still "
+            "present — skill and hook disagree on the marker path."
+        )

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -57,6 +57,18 @@
           },
           {
             "type": "command",
+            "command": "~/.claude/hooks/require-ready-for-review.sh",
+            "if": "Bash(git push *)",
+            "statusMessage": "Checking ready-for-review gate..."
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/require-ready-for-review.sh",
+            "if": "Bash(gh pr ready *)",
+            "statusMessage": "Checking ready-for-review gate..."
+          },
+          {
+            "type": "command",
             "command": "~/.claude/hooks/require-worktree-for-git-writes.sh",
             "statusMessage": "Checking worktree enforcement..."
           }

--- a/claude/.claude/skills/ready-for-review/SKILL.md
+++ b/claude/.claude/skills/ready-for-review/SKILL.md
@@ -42,13 +42,10 @@ the `require-ready-for-review.sh` hook:
 SESSION_ID=$(cat "$HOME/.claude/sessions/$PPID") && [ -n "$SESSION_ID" ] && mkdir -p "$HOME/.claude/.ready-for-review-active.d" && touch "$HOME/.claude/.ready-for-review-active.d/$SESSION_ID"
 ```
 
-The hook bypasses while THIS session's marker is fresh (<60 min) and
-refreshes its mtime on each bypass so long runs don't hit the staleness
-cutoff. Per-session keying prevents parallel skill sessions from
-thrashing on cleanup or leaking bypass to unrelated sessions. If the
-chain fails (empty `SESSION_ID`, etc.), the `capture-session-id.sh`
-SessionStart hook didn't run — abort and report; do not proceed
-without the marker, since the gate would block iteration pushes.
+If the chain fails (empty `SESSION_ID`, etc.), the
+`capture-session-id.sh` SessionStart hook didn't run — abort and
+report; do not proceed without the marker, since the gate would
+block iteration pushes.
 
 ## 1. Preconditions (halt on fail)
 
@@ -171,12 +168,6 @@ and remove the active-session marker:
 ```
 SESSION_ID=$(cat "$HOME/.claude/sessions/$PPID") && [ -n "$SESSION_ID" ] && mkdir -p "$HOME/.claude/ready-for-review-markers" && REPO_HASH=$(git rev-parse --show-toplevel | tr -d '\n' | sha256sum | awk '{print $1}') && git rev-parse HEAD > "$HOME/.claude/ready-for-review-markers/$REPO_HASH.$SESSION_ID"
 ```
-
-The completion marker holds the local HEAD SHA. The gate hook compares
-it against the HEAD of the branch about to be pushed (or marked
-ready-for-review): match means the gate ran on this artifact, allow.
-Any new commit invalidates the marker automatically (HEAD moves), so
-"fix one more thing then push" forces a re-run.
 
 Then remove the active-session marker:
 

--- a/claude/.claude/skills/ready-for-review/SKILL.md
+++ b/claude/.claude/skills/ready-for-review/SKILL.md
@@ -31,6 +31,25 @@ Run steps in order. Halt on failures unless the step is marked **warn
 only**. After fixes produced by step 3, re-run step 2 — do not re-run
 step 3 on its own output.
 
+## 0. Activate gate session
+
+Write the active-session marker so this skill's own iteration pushes
+(step 3 fix → push → loop back to step 2) are not self-blocked by
+the `require-ready-for-review.sh` hook:
+
+<!-- HOOK_TEST_FIXTURE: activate-gate — the hook-alignment test suite reads this exact fenced block from this file (claude/.claude/skills/ready-for-review/SKILL.md) to verify it matches require-ready-for-review.sh's active-marker layout. Do not duplicate the recipe elsewhere; the test re-reads it from here. -->
+```
+SESSION_ID=$(cat "$HOME/.claude/sessions/$PPID") && [ -n "$SESSION_ID" ] && mkdir -p "$HOME/.claude/.ready-for-review-active.d" && touch "$HOME/.claude/.ready-for-review-active.d/$SESSION_ID"
+```
+
+The hook bypasses while THIS session's marker is fresh (<60 min) and
+refreshes its mtime on each bypass so long runs don't hit the staleness
+cutoff. Per-session keying prevents parallel skill sessions from
+thrashing on cleanup or leaking bypass to unrelated sessions. If the
+chain fails (empty `SESSION_ID`, etc.), the `capture-session-id.sh`
+SessionStart hook didn't run — abort and report; do not proceed
+without the marker, since the gate would block iteration pushes.
+
 ## 1. Preconditions (halt on fail)
 
 - Current branch is not the default branch (`main` / `master` / `develop`).
@@ -142,6 +161,41 @@ If the branch has no PR and no remote tracking, surface this: the
 human can't review what isn't pushed. A project-specific pre-merge or
 PR-creation skill should handle the actual open; this skill does not
 create PRs.
+
+## 7. Record gate completion + deactivate session
+
+If every halt-on-fail step above passed, record the completed gate
+and remove the active-session marker:
+
+<!-- HOOK_TEST_FIXTURE: record-completion — the hook-alignment test suite reads this exact fenced block from this file (claude/.claude/skills/ready-for-review/SKILL.md) to verify it matches require-ready-for-review.sh's completion-marker layout. Do not duplicate the recipe elsewhere; the test re-reads it from here. -->
+```
+SESSION_ID=$(cat "$HOME/.claude/sessions/$PPID") && [ -n "$SESSION_ID" ] && mkdir -p "$HOME/.claude/ready-for-review-markers" && REPO_HASH=$(git rev-parse --show-toplevel | tr -d '\n' | sha256sum | awk '{print $1}') && git rev-parse HEAD > "$HOME/.claude/ready-for-review-markers/$REPO_HASH.$SESSION_ID"
+```
+
+The completion marker holds the local HEAD SHA. The gate hook compares
+it against the HEAD of the branch about to be pushed (or marked
+ready-for-review): match means the gate ran on this artifact, allow.
+Any new commit invalidates the marker automatically (HEAD moves), so
+"fix one more thing then push" forces a re-run.
+
+Then remove the active-session marker:
+
+<!-- HOOK_TEST_FIXTURE: deactivate-gate — the hook-alignment test suite reads this exact fenced block from this file (claude/.claude/skills/ready-for-review/SKILL.md) to verify it matches require-ready-for-review.sh's active-marker cleanup. Do not duplicate the recipe elsewhere; the test re-reads it from here. -->
+```
+SESSION_ID=$(cat "$HOME/.claude/sessions/$PPID" 2>/dev/null) && [ -n "$SESSION_ID" ] && rm -f "$HOME/.claude/.ready-for-review-active.d/$SESSION_ID"
+```
+
+Removes only this session's file. If the skill errors out before
+reaching this step, don't manually clean up — the hook's 60-minute
+staleness cutoff handles the orphan automatically.
+
+**Do NOT write the completion marker if:**
+
+- Any halt-on-fail step (1, 2, 3, 6) produced findings that weren't
+  fixed in this session.
+- The user asked you to present findings without finishing the gate.
+- You are not in a git repository.
+- The branch has no PR and no remote tracking (nothing to gate).
 
 ## Completion
 


### PR DESCRIPTION
## Summary

Mechanically enforces that `/ready-for-review` has run on the artifact about to be published. Closes the failure mode where Claude pushes wrap-up commits to a PR branch (or runs `gh pr ready`) without going through the gate.

Layered on top of #65, which fixed the trigger conditions; this PR adds the marker + hook so the gate is enforced at the tool boundary, not just by skill prose.

## What it does

**Two-marker pattern** (mirrors `require-respond-pr.sh`'s active-bypass shape and `require-code-review.sh`'s content-hash shape):

- **Active marker** `~/.claude/.ready-for-review-active.d/<session>` — presence-only, fresh <60min, mtime refreshed on bypass. Written at step 0, removed at step 7. Bypasses the gate during the skill's own iteration (step 3 fix → push → loop back to step 2) so the skill can't self-deny.
- **Completion marker** `~/.claude/ready-for-review-markers/<repo-hash>.<session>` — contents are local HEAD SHA at gate-completion time. Written at step 7 only when every halt-on-fail step passed. Pushes against the recorded HEAD are allowed; new commits invalidate it (HEAD moves) and force a re-run.

**Gated commands:** `git push` to a branch with an open PR, and `gh pr ready` (draft → ready transition — explicit handoff signal).

**Bypass shapes (no marker required):**
- `--dry-run`
- `--delete` / `-d` / `origin :branch` (deletion forms)
- `--tags`-only (no branch refspec)
- Default-branch pushes
- Branches without an open PR
- `gh pr view` failure (network glitch / gh not configured) — fails open to keep the user unblocked; the skill's prose triggers still cover the case

**Settings registration** uses scoped `if` clauses (`Bash(git push *)` and `Bash(gh pr ready *)`) plus internal command filtering inside the hook — defense-in-depth per `feedback_hook_defense_in_depth`.

## Bug caught during testing

`git rev-parse --abbrev-ref origin/HEAD` returns the literal string `"origin/HEAD"` (not empty) when origin/HEAD isn't a symbolic ref, which silently defeated the default-branch fallback path. Switched to `git symbolic-ref --quiet refs/remotes/origin/HEAD`. This was the only finding from running the test suite.

## Test plan

- [x] 30 new tests in `TestRequireReadyForReview`: bypass shapes (non-push, --dry-run, --delete, :branch, --tags-only, default-branch, no-PR, outside-repo); active-marker (fresh / stale / cross-session leak / mtime refresh); completion-marker (matching / stale-HEAD / cross-session leak / no-session-id); gh-failure fail-open; gh pr ready gating; skill-hook alignment via HOOK_TEST_FIXTURE recipes.
- [x] All 261 tests pass (231 pre-existing + 30 new).
- [x] Skill-on-its-own-diff: no contradictions with the existing intro (`Run steps in order. Halt on failures unless...`) or step semantics. Step 0 (setup) and step 7 (teardown) bracket the existing 1–6 flow without altering them.

## Notes

- The hook is only live for users who pull this PR (after merge); pushing this branch doesn't activate the gate against itself.
- This makes #65's trigger fix mechanically enforceable. Per `feedback_dont_auto_merge_user_prs`: not merging — that's your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)