### PR TITLE
plan-review: add user-surface declaration + threat-model bounding to Step 2

### DIFF
--- a/claude/.claude/skills/plan-review/SKILL.md
+++ b/claude/.claude/skills/plan-review/SKILL.md
@@ -34,15 +34,22 @@ Read the plan and classify which domains it touches:
 
 ## Step 2 — Design-fitness gate
 
-Before evaluating gaps, answer: **is the design appropriately sized for the ticket scope?** Gap-finding on an over-elaborate design elaborates it further (each finding closes a gap by adding more machinery), and the checklist won't surface "this whole design is the wrong shape."
+Before evaluating gaps, answer two questions in order:
+
+1. **What user surface does this serve?** Production users, internal-only (engineers / admins), dev-only (CI / test harness / IDE preview), or mixed (name the path each surface takes). The threat model follows from the surface — a dev-only smoke-test flow has no external attacker; an internal-only admin tool has no anonymous attacker. Persona reviewers must scope findings to the declared surface, not default to the worst-case external-attacker model.
+
+2. **Is the design appropriately sized for the user pain it solves on that surface?** Gap-finding on an over-elaborate design elaborates it further (each finding closes a gap by adding more machinery), and the checklist won't surface "this whole design is the wrong shape."
+
+If the plan doesn't declare a surface, demand one before proceeding — "an internal-only DX fix" or "production users never reach this code path" is a valid one-line declaration. Without it, persona reviewers default to worst-case threat models and inflate plan size for changes that don't warrant it.
 
 Markers of over-elaboration:
 
+- Defensive layers stacked beyond what the declared user surface and threat model justify.
 - Conditional logic for future phases that may not arrive.
-- Defensive paths against attack scenarios that haven't been observed.
 - Layers that duplicate a higher-level abstraction.
 - Granularity exceeding any concrete consumer's need.
 - Captured outputs / fields with no reader downstream.
+- "Could be done in N lines" stays a valid challenge even after persona reviewers have shaped the plan — persona-shaped is not persona-locked.
 
 If over-elaborated: stop. Surface the simpler design as the primary review output before any checklist findings. Otherwise proceed to Step 3 — gap-finding will surface what's missing.
 
@@ -182,7 +189,7 @@ This is the design-stage gate. Specialist misses here are recoverable in code-re
 - **Convergence-as-design-tell** from a prior round (see Reconciliation).
 - **Explicit user request.**
 
-Always spawn `ciso-reviewer` when the plan touches auth/authz, secrets, tokens, data exposure, sensitive-data logging, third-party data sharing, or infra permissions — high-stakes-boundary case is non-optional. Always spawn `staff-product-engineer` when the plan changes user-facing behavior.
+Always spawn `ciso-reviewer` when the plan touches auth/authz, secrets, tokens, data exposure, sensitive-data logging, third-party data sharing, or infra permissions — high-stakes-boundary case is non-optional, **unless** the Step 2 user-surface declaration puts the change outside `ciso-reviewer`'s threat model (e.g., a dev-only flow with no production reachability, or an internal-only path where engineers themselves are the only callers and the change crosses no privilege boundary they shouldn't cross). When skipping on those grounds, name the surface in the review output — never silently skip. Always spawn `staff-product-engineer` when the plan changes user-facing behavior.
 
 Spawn per question (not per file-path domain) — "plan touches backend" isn't enough; the question needs a specific shape.
 

--- a/claude/.claude/skills/plan-review/SKILL.md
+++ b/claude/.claude/skills/plan-review/SKILL.md
@@ -36,11 +36,9 @@ Read the plan and classify which domains it touches:
 
 Before evaluating gaps, answer two questions in order:
 
-1. **What user surface does this serve?** Production users, internal-only (engineers / admins), dev-only (CI / test harness / IDE preview), or mixed (name the path each surface takes). The threat model follows from the surface — a dev-only smoke-test flow has no external attacker; an internal-only admin tool has no anonymous attacker. Persona reviewers must scope findings to the declared surface, not default to the worst-case external-attacker model.
+1. **What user surface and threat model does this serve?** A line or two — production users, internal-only, dev-only, or whatever framing fits. Persona reviewers must scope findings to the declared surface, not default to a worst-case external-attacker model.
 
 2. **Is the design appropriately sized for the user pain it solves on that surface?** Gap-finding on an over-elaborate design elaborates it further (each finding closes a gap by adding more machinery), and the checklist won't surface "this whole design is the wrong shape."
-
-If the plan doesn't declare a surface, demand one before proceeding — "an internal-only DX fix" or "production users never reach this code path" is a valid one-line declaration. Without it, persona reviewers default to worst-case threat models and inflate plan size for changes that don't warrant it.
 
 Markers of over-elaboration:
 


### PR DESCRIPTION
## Summary

- Reframes the design-fitness gate (Step 2) around two questions: which user surface the change serves (production / internal-only / dev-only / mixed), and whether the design is sized for the user pain on that surface. Threat model follows from the surface — persona reviewers must scope findings to the declared surface, not default to a worst-case external attacker.
- Adds a surface-bounded skip clause to the always-spawn `ciso-reviewer` rule: a dev-only flow with no production reachability, or an internal path where engineers are the only callers and no privilege boundary is crossed, can skip the CISO spawn — but the surface must be named in the review output, never silently skipped.
- Refines the over-elaboration markers list — replaces "scenarios that haven't been observed" with "defensive layers beyond what the declared user surface and threat model justify"; adds "could be done in N lines" as a valid challenge even after persona-shaping.

## Why

`/plan-review` already had a design-fitness gate (Step 2). What it lacked was a way for plan authors to declare the user surface up front, so persona reviewers could scope their threat models accordingly. Without that, persona reviewers default to worst-case (external attacker, anonymous reachability) on every plan, inflating defensive layers for changes that don't warrant them — internal-only DX fixes, dev-only smoke-test tooling, IDE-preview-only flows.

The change is +10/-3 lines, augmenting Step 2 in place rather than introducing a new step. Surfaced after a recent change where persona-shaped plan elaboration shipped a heavy popup-with-postMessage flow for what was fundamentally an internal-only DX fix on a code path production users never reach.

## Test plan

- [x] `/code-review` run on the diff (no findings; recorded marker)
- [x] Self-check against the skill's own design-fitness gate — not over-elaborated, one marker swap rather than addition, structure preserved
- [ ] Reviewer: confirm the surface-bounded skip clause is sound (named-surface requirement + downstream `code-review` `ciso-reviewer` spawn intact = adequate safety net)
- [ ] Reviewer: confirm Step 2 reads as parallel to `/code-review`'s Step 1 without unnecessary divergence

🤖 Generated with [Claude Code](https://claude.com/claude-code)