### PR TITLE
Set default model to opusplan

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Schema-change diffs nominally route three ways — `staff-backend-engineer` (des
 ### Other
 
 - **`CLAUDE.md`** — baseline engineering instructions (judgment heuristics, working style, safety rules).
-- **`settings.json`** — global settings wiring up the hooks and statusline. Configured with **opusplan** as the default model (cost-effective and recommended by Anthropic). Session-only overrides (model, effortLevel) are intentionally not tracked — use the `ANTHROPIC_MODEL` and `CLAUDE_CODE_EFFORT_LEVEL` env vars, or `/effort max` mid-session.
+- **`settings.json`** — global settings wiring up the hooks and statusline. Configured with **opusplan** as the default model (cost-effective and [recommended by Anthropic](https://support.claude.com/en/articles/14552983-models-usage-and-limits-in-claude-code)). Session-only overrides (model, effortLevel) are intentionally not tracked — use the `ANTHROPIC_MODEL` and `CLAUDE_CODE_EFFORT_LEVEL` env vars, or `/effort max` mid-session.
 - **`statusline-command.sh`** — status bar showing model, context usage, session cost, working directory, and git branch.
 
 ## Worktree enforcement

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Schema-change diffs nominally route three ways — `staff-backend-engineer` (des
 ### Other
 
 - **`CLAUDE.md`** — baseline engineering instructions (judgment heuristics, working style, safety rules).
-- **`settings.json`** — global settings wiring up the hooks and statusline. Session-only overrides (model, effortLevel) are intentionally not tracked — use the `ANTHROPIC_MODEL` and `CLAUDE_CODE_EFFORT_LEVEL` env vars, or `/effort max` mid-session.
+- **`settings.json`** — global settings wiring up the hooks and statusline. Configured with **opusplan** as the default model (cost-effective and recommended by Anthropic). Session-only overrides (model, effortLevel) are intentionally not tracked — use the `ANTHROPIC_MODEL` and `CLAUDE_CODE_EFFORT_LEVEL` env vars, or `/effort max` mid-session.
 - **`statusline-command.sh`** — status bar showing model, context usage, session cost, working directory, and git branch.
 
 ## Worktree enforcement

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -102,5 +102,6 @@
         "repo": "anthropics/claude-plugins-official"
       }
     }
-  }
+  },
+  "model": "opusplan"
 }


### PR DESCRIPTION
## Summary
Set opusplan as the default model in settings.json. Anthropic recommends opusplan as the cost-effective default model (see https://support.claude.com/en/articles/14552983-models-usage-and-limits-in-claude-code). Update README to document this configuration.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)