### PR TITLE
Add Agent Briefing section documenting worktree isolation

### DIFF
--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -31,6 +31,10 @@
 
 - After writing or modifying an implementation plan, run `/plan-review` before presenting the plan to the user. If the review finds issues, address them first, then present the final version.
 
+## Agent Briefing
+
+- When spawning sub-agents with `isolation: "worktree"`, do NOT include an explicit `Working directory: /path/to/repo` line. The harness sets the agent's CWD to the isolated worktree automatically; naming the main repo path causes the agent to use `git -C <main-path>` operations that bypass isolation and mutate the main working tree directly.
+
 ## Safety
 
 - Never run sudo commands directly.


### PR DESCRIPTION
## Summary

Documents the issue where sub-agents spawned from plan mode with `isolation: "worktree"` should not include an explicit "Working directory" line. When included, the harness reads it as a base path for `git -C` operations, which bypasses worktree isolation and mutates the main working tree directly.

This prevents a failure mode observed with Opus spawning Sonnet for execution after exiting plan mode — the subprocess's git operations would unwittingly operate on the main tree instead of the isolated worktree.

## Why this matters

Worktree isolation is a core safety mechanism to prevent concurrent agents from stepping on each other. The briefing ensures agent authors won't inadvertently break it.