### PR TITLE
Extract hook review into dedicated hook-review skill

### DIFF
--- a/claude/.claude/skills/claude-hook-review/SKILL.md
+++ b/claude/.claude/skills/claude-hook-review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: hook-review
+name: claude-hook-review
 description: >
   How to review Claude Code hook scripts (`claude/.claude/hooks/*.sh`)
   and hook entries in `settings.json` (PreToolUse, PostToolUse,

--- a/claude/.claude/skills/code-review/SKILL.md
+++ b/claude/.claude/skills/code-review/SKILL.md
@@ -134,7 +134,7 @@ For `.claude/skills/**/SKILL.md` review (frontmatter, trigger design, voice, len
 
 35. **Permission scope** — Do `permissions.allow` rules in settings.json follow least-privilege? Flag blanket allows (`"Bash"`) where scoped (`"Bash(git:*)"`) would suffice. If permissions.allow rules were added or modified, invoke `/review-permissions` for deep security analysis.
 
-36. **Hook correctness** — Do PreToolUse/PostToolUse hooks block the right operations without false positives? A hook that blocks legitimate work is worse than no hook — it trains users to bypass the system.
+For hook reviews (`claude/.claude/hooks/*.sh`, hook entries in `settings.json`), see the `hook-review` skill.
 
 ## Domain: Lovable config
 
@@ -251,7 +251,7 @@ The dispatcher fires reviewers per file-path domain detection. Each agent self-s
 | **31. Sensitive data in logs** | `staff-backend-engineer` | `ciso-reviewer` |
 | **32. Performance-sensitive paths** | `staff-backend-engineer` (app-level query patterns) | `staff-data-engineer` (DDL / index / read-path) |
 | **35. Permission scope** | `ciso-reviewer` | — |
-| **36. Hook correctness** | `staff-platform-engineer` | `ciso-reviewer` |
+| **36. Hook correctness** — reviewed via `hook-review` skill | `staff-platform-engineer` | `ciso-reviewer` |
 
 ## Step — Record review completion
 

--- a/claude/.claude/skills/code-review/SKILL.md
+++ b/claude/.claude/skills/code-review/SKILL.md
@@ -134,7 +134,7 @@ For `.claude/skills/**/SKILL.md` review (frontmatter, trigger design, voice, len
 
 35. **Permission scope** — Do `permissions.allow` rules in settings.json follow least-privilege? Flag blanket allows (`"Bash"`) where scoped (`"Bash(git:*)"`) would suffice. If permissions.allow rules were added or modified, invoke `/review-permissions` for deep security analysis.
 
-For hook reviews (`claude/.claude/hooks/*.sh`, hook entries in `settings.json`), see the `hook-review` skill.
+For hook reviews (`claude/.claude/hooks/*.sh`, hook entries in `settings.json`), see the `claude-hook-review` skill.
 
 ## Domain: Lovable config
 
@@ -251,7 +251,7 @@ The dispatcher fires reviewers per file-path domain detection. Each agent self-s
 | **31. Sensitive data in logs** | `staff-backend-engineer` | `ciso-reviewer` |
 | **32. Performance-sensitive paths** | `staff-backend-engineer` (app-level query patterns) | `staff-data-engineer` (DDL / index / read-path) |
 | **35. Permission scope** | `ciso-reviewer` | — |
-| **36. Hook correctness** — reviewed via `hook-review` skill | `staff-platform-engineer` | `ciso-reviewer` |
+| **36. Hook correctness** — reviewed via `claude-hook-review` skill | `staff-platform-engineer` | `ciso-reviewer` |
 
 ## Step — Record review completion
 

--- a/claude/.claude/skills/hook-review/SKILL.md
+++ b/claude/.claude/skills/hook-review/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: hook-review
+description: >
+  How to review Claude Code hook scripts (`claude/.claude/hooks/*.sh`)
+  and hook entries in `settings.json` (PreToolUse, PostToolUse,
+  SessionStart): event/matcher selection, dispatch design,
+  fail-open vs fail-closed posture, the `emit_deny` JSON shape,
+  performance budget, and test patterns.
+  TRIGGER when: reviewing a change to a hook script under
+  `.claude/hooks/`; reviewing a change to a hook entry in
+  `settings.json` (`hooks.PreToolUse`, `hooks.PostToolUse`,
+  `hooks.SessionStart`, etc.); designing a new hook.
+  DO NOT TRIGGER when: editing `permissions.allow` rules (use
+  `review-permissions`); editing other `settings.json` fields (env,
+  model, theme — use `update-config`); reviewing non-Claude hook
+  systems (git hooks, husky, lefthook).
+allowed-tools: Read, Grep, Glob, Bash
+user-invocable: false
+---
+
+## 1. Hook events and matchers
+
+**Event type** selects when a hook fires: `PreToolUse` (fires before the tool call; can deny), `PostToolUse` (fires after; observation only), `SessionStart` (setup state at session open).
+
+**Matcher** selects *which* tool calls fire the hook. `Bash` is the most common, but `Edit|Write|MultiEdit` is also in active use (`ask-review-permissions.sh` gates write-side tools, not Bash). Verify the matcher matches the operation surface being gated.
+
+**`if`-dispatch** narrows further within a matcher (e.g., `"if": "Bash(git commit *)"`) and is **advisory** — zero-cost early exit, but the real gate is the script's internal filter. If `if`-dispatch and the internal regex diverge, you get silent coverage gaps.
+
+## 2. Script skeleton
+
+The idiomatic pattern from `deny-private-project-refs.sh` and `require-stow-reminder.sh`:
+
+```bash
+#!/bin/bash
+set -uo pipefail   # explicit failure modes: unbound vars fail loudly,
+                   # pipeline failures aren't masked. -e omitted: the
+                   # hook inspects non-zero exits rather than aborting.
+                   # Older hooks predate this convention; don't perpetuate
+                   # the gap in new gates.
+
+INPUT=$(cat)
+COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+JQ_EXIT=$?
+
+emit_deny() {
+  local reason="$1"
+  local reason_json
+  reason_json=$(printf '%s' "$reason" | jq -Rs .)
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' \
+    "$reason_json"
+}
+
+if [ "$JQ_EXIT" -ne 0 ]; then
+  emit_deny "Blocked: could not parse tool-input JSON."
+  exit 0
+fi
+```
+
+Exit code is always `0`; the hook signals via stdout JSON, not via exit code.
+
+Two non-obvious constraints for new gates:
+- `"permissionDecision"` must be exactly `"deny"` (lowercase) — the runtime is case-sensitive; `"Deny"`, `"block"`, or any variant silently allows.
+- `jq -r '... // empty'` exits **0** on missing fields (empty string, not a non-zero exit). `JQ_EXIT` guards against JSON parse failures only. For allow-list-style gates (deny anything outside a known set), also guard on `[ -z "$COMMAND" ]`. For deny-list-style gates (deny specific operations, allow all else), empty `COMMAND` correctly falls through.
+
+## 3. Fail-open vs fail-closed posture
+
+**Fail-closed** when the gate prevents a leak: parse failure → deny (a hook that can't read its input can't verify the operation is safe). Example: `deny-private-project-refs.sh:101–104`.
+
+**Fail-open** when the gate is advisory and absence of input is normal: if `~/.claude/private-projects.md` is missing, allow normally (`deny-private-project-refs.sh:259–260`).
+
+State the chosen posture in the script header. Reviewers shouldn't have to re-derive it from the code.
+
+## 4. Dispatch design and drift risk
+
+`settings.json` carries `if`-patterns for zero-cost early dispatch (e.g., `Bash(git commit *)`, `Bash(gh pr create *)`, `Bash(gh pr edit *)`). The script's internal regex is the authoritative gate. When both surfaces cover the same operation, they must stay in sync — document the pairing explicitly in the script header (`deny-private-project-refs.sh:9–14` is the model). A drift between `if`-pattern and internal regex creates silent coverage gaps.
+
+## 5. Escape hatches and allowlists
+
+Two distinct extension surfaces — don't conflate them:
+
+- **`OSS_ALLOWLIST` in the committed script** (`deny-private-project-refs.sh:151`): open-source and standards-body references only. Adding a private identifier here commits it to a public repo — exactly the leak the hook prevents.
+- **`~/.claude/private-projects.md`**: private identifiers, user-local, never committed. Users who need to blocklist private project names use this path.
+
+Prefer named variables over magic strings buried in a regex; future contributors need a clear place to extend and a clear signal about which surface is appropriate.
+
+## 6. Performance budget
+
+Hooks fire on every matching tool call. Budget <100ms per fire. Subprocess spawns (`jq`, `grep`) add up — avoid loops over them. No network calls. No unbounded file I/O. If the hook reads user-controlled input, cap the read before scanning.
+
+## 7. Test patterns
+
+`claude/.claude/hooks/tests/test_hooks.py` is the model. Each test feeds tool-input JSON on stdin and reads `permissionDecision` from stdout. Cover boundary cases: malformed JSON input, unreadable file paths, pseudo-file paths (`/dev/stdin`, `/dev/fd/*`). When a test needs synthetic project-shaped tokens, follow the file's existing precedent for invented prefixes — do **not** invent prefixes that resemble real private projects.
+
+## 8. Review checklist
+
+Flag these on a hook PR:
+
+- Header documents purpose, scope, dispatch surfaces, known gaps, and fail posture.
+- `if`-dispatch in `settings.json` matches the internal regex (no drift between the two).
+- `set -uo pipefail` present for gates with non-trivial parsing; if absent, justified.
+- JSON input parsed with `jq`; fail-closed on parse error.
+- `emit_deny` JSON shape: `hookSpecificOutput.permissionDecision` is exactly `"deny"` (lowercase, case-sensitive — `"Deny"` or `"block"` silently allows), `permissionDecisionReason` set.
+- Matcher (`Bash` vs `Edit|Write|MultiEdit`) matches the operation surface being gated.
+- Scope is narrow enough to avoid false positives: matcher + internal filter + repo-url guard exclude operations outside the stated purpose; header documents what the hook deliberately does NOT gate.
+- Tests cover new code paths; synthetic prefixes only, no real project names.
+- No unbounded loops, no network calls, no unbounded file I/O.
+- Header lists known gaps the hook does not close.


### PR DESCRIPTION
## Summary

Extracts item 36 (Hook correctness) from \`code-review\` into a new dedicated \`claude-hook-review\` skill, mirroring the \`skill-review\` extraction in #70.

- **New skill** at \`claude/.claude/skills/claude-hook-review/SKILL.md\` (107 lines) — owns the full hook-review surface: event/matcher selection, script skeleton idioms (with \`emit_deny\` quoted directly from the hooks), fail-open vs fail-closed posture, \`if\`-dispatch drift risk, the OSS_ALLOWLIST vs \`~/.claude/private-projects.md\` distinction, performance budget, test patterns, and a review checklist.
- **\`code-review\` updated**: item 36 replaced with a pointer; ownership-table row updated to reference the \`claude-hook-review\` skill while preserving \`staff-platform-engineer\` + \`ciso-reviewer\` as routing targets.

The \`claude-\` prefix was added after PR review — "hook" alone is ambiguous with git hooks, husky, and lefthook; the DO NOT TRIGGER section already called these out.

## What's in the skill body (not in the original item 36 one-liner)

The new skill adds actionable detail that the single item 36 line couldn't carry:

- The \`emit_deny\` helper quoted verbatim so reviewers recognize the shape on sight.
- \`"permissionDecision"\` must be exactly \`"deny"\` (lowercase) — case-sensitive; any variant silently allows.
- \`jq -r '... // empty'\` exits 0 on missing fields (not non-zero) — the \`JQ_EXIT\` guard only catches parse failures; allow-list-style gates need a separate \`[ -z "\$COMMAND" ]\` guard.
- Two distinct extension surfaces: \`OSS_ALLOWLIST\` in the committed script (open-source refs only — adding a private name here publishes it) vs \`~/.claude/private-projects.md\` (private identifiers, user-local, never committed).
- False-positive risk checklist item: matcher + internal filter + repo-url guard should be narrow enough to exclude operations outside the gate's stated purpose.

## What stays in \`code-review\`

Item 35 (Permission scope → \`/review-permissions\`) is unchanged. The ownership-table row for item 36 is retained with a note pointing to the \`claude-hook-review\` skill, so \`staff-platform-engineer\` and \`ciso-reviewer\` remain in the dispatch path for hook changes.

## Test plan

- [x] \`pytest claude/.claude/hooks/tests/test_hooks.py\` — 261 passed
- [x] \`/code-review\` run on staged diff (specialists \`staff-platform-engineer\` + \`ciso-reviewer\` consulted per ripple-triage ownership-table rule; all findings addressed before commit)
- [x] \`code-review\` Domain: Claude Code config section reads coherently: skill-review pointer → item 35 → claude-hook-review pointer
- [x] Ownership table has row for item 36 → \`claude-hook-review\` skill, with correct owners

🤖 Generated with [Claude Code](https://claude.com/claude-code)