### PR TITLE
Document plan-mode inheritance in Agent Briefing

### DIFF
--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -34,6 +34,7 @@
 ## Agent Briefing
 
 - When spawning sub-agents with `isolation: "worktree"`, do NOT include an explicit `Working directory: /path/to/repo` line. The harness sets the agent's CWD to the isolated worktree automatically; naming the main repo path causes the agent to use `git -C <main-path>` operations that bypass isolation and mutate the main working tree directly.
+- Before delegating execution to a sub-agent from a session that has been in plan mode, call `ExitPlanMode` in the parent first. Sub-agents inherit harness-enforced plan-mode state and will refuse to execute — returning a plan file even when the prompt says "execute, do not plan" — until the parent exits plan mode. Symptom: the sub-agent cites a "plan-mode system-reminder" as harness-enforced and asks the user to exit plan mode.
 
 ## Safety
 


### PR DESCRIPTION
## Summary

When a parent session has been in plan mode and then delegates execution to a sub-agent, the sub-agent inherits the harness-enforced plan-mode system-reminder and refuses to execute — returning a plan file even when its prompt explicitly says "execute, do not plan." The symptom is the sub-agent citing the plan-mode system-reminder as harness-enforced and asking the user to exit plan mode before it will act.

**Verification:** Confirmed in a live session. After the parent called `ExitPlanMode`, a Sonnet sub-agent was spawned and observed no plan-mode reminder in its initial context — it proceeded to execution normally (hypothesis 1: mode-scoped, not session-sticky). `ExitPlanMode` in the parent is sufficient to clear the state.

**Why CLAUDE.md, not auto-memory:** This is a behavioral rule that applies to all contributors and sessions that use this config, not a personal preference. The `ai-instruction-and-memory-files` skill §5 routing table puts "rules any contributor should follow" in CLAUDE.md. Global CLAUDE.md is the right home — same shelf as the existing worktree-CWD bullet in the Agent Briefing section.

## Change

One bullet appended to the `Agent Briefing` section of `claude/.claude/CLAUDE.md`:

> Before delegating execution to a sub-agent from a session that has been in plan mode, call `ExitPlanMode` in the parent first. Sub-agents inherit harness-enforced plan-mode state and will refuse to execute — returning a plan file even when the prompt says "execute, do not plan" — until the parent exits plan mode. Symptom: the sub-agent cites a "plan-mode system-reminder" as harness-enforced and asks the user to exit plan mode.

## Test plan

- [ ] Read `~/.claude/CLAUDE.md` and confirm the new bullet appears under Agent Briefing
- [ ] Confirm line count remains under 200 (`wc -l`)
- [ ] In a fresh session that uses plan mode, approve a plan, call `ExitPlanMode`, then spawn a sub-agent — confirm it executes without citing a plan-mode reminder