### PR TITLE
Hook: corrective note when git -C is used from main working tree

### DIFF
--- a/claude/.claude/hooks/require-worktree-for-git-writes.sh
+++ b/claude/.claude/hooks/require-worktree-for-git-writes.sh
@@ -48,6 +48,54 @@ cwd_anchor_note_if_chained() {
   fi
 }
 
+# When the command uses `git -C <path> <write-op>` from the main tree,
+# the agent likely expected the -C path to be treated as the working
+# tree. The hook checks the session-persisted CWD (from the tool input
+# JSON) — not the -C path — so the op is blocked even when -C points at
+# a linked worktree. Returns a self-correction note for the agent when
+# this pattern is detected; empty otherwise.
+#
+# Detection is scoped to `-C` in the GLOBAL flag position only —
+# subcommand-level uses (`git commit -C HEAD`, `git diff -C`, etc.)
+# do not trigger the note, since the hint would not apply there.
+# Mirrors the flag-skip table in extract_git_subcmd so both parsers
+# stay consistent. Globbing is disabled around the loop so that an
+# input like "git * -C foo" can't glob against cwd contents.
+git_C_note_if_present() {
+  local command="$1"
+  fragment_invokes_git "$command" || return
+  local after_git="${command#*git}"
+  local saved_opts=$-
+  set -f
+  local skip_next=false found=false
+  for word in $after_git; do
+    if $skip_next; then
+      skip_next=false
+      continue
+    fi
+    case "$word" in
+      -C)
+        found=true
+        break ;;
+      -c|--git-dir|--work-tree|--namespace|--super-prefix|--config-env)
+        skip_next=true ;;
+      -*)
+        ;;
+      *)
+        break ;;  # subcommand reached; any -C past here is subcommand-scoped
+    esac
+  done
+  # Note: detects -C in the first git invocation only. A command like
+  # `git status && git -C ...` won't trigger — the loop stops at the
+  # first git's subcommand and never reaches the second git's flags.
+  if [[ "$saved_opts" != *f* ]]; then
+    set +f
+  fi
+  if $found; then
+    printf '%s' " If you used 'git -C <path>' expecting the -C path to be treated as the working tree: this hook reads cwd from Claude Code's session-persisted bash state (set by prior Bash calls), not from the -C path, because -C only retargets git's own working directory and doesn't change the session cwd. Anchor cwd by running 'cd /path/to/worktree' as its own Bash call first, then retry the git op in a follow-up call."
+  fi
+}
+
 # Fail-closed on malformed input: if jq couldn't parse the stdin JSON, we
 # can't tell what Claude is about to run, so deny rather than silently allow.
 if [ "$JQ_EXIT" -ne 0 ]; then
@@ -195,12 +243,12 @@ while IFS= read -r fragment; do
 
   subcmd=$(extract_git_subcmd "$fragment")
   if [ -z "$subcmd" ]; then
-    emit_deny "Blocked by worktree-enforcement hook: could not determine the git subcommand in '$fragment'. This repo has opted into worktree discipline (.claude/worktree-required is committed). Run git write operations from inside a linked worktree — either change the session cwd into an existing worktree under .claude/worktrees/, use the EnterWorktree tool, or spawn an agent with isolation: worktree.$(cwd_anchor_note_if_chained "$COMMAND")"
+    emit_deny "Blocked by worktree-enforcement hook: could not determine the git subcommand in '$fragment'. This repo has opted into worktree discipline (.claude/worktree-required is committed). Run git write operations from inside a linked worktree — either change the session cwd into an existing worktree under .claude/worktrees/, use the EnterWorktree tool, or spawn an agent with isolation: worktree.$(cwd_anchor_note_if_chained "$COMMAND")$(git_C_note_if_present "$COMMAND")"
     exit 0
   fi
 
   if ! [[ "$subcmd" =~ ^($ALLOWED_RE)$ ]]; then
-    emit_deny "Blocked by worktree-enforcement hook: 'git $subcmd' is not on the read-only allowlist, and this session is running in the main working tree of a repo that has opted into worktree discipline (.claude/worktree-required is committed). Run git write operations from inside a linked worktree — cd into an existing worktree under .claude/worktrees/, create one with 'git worktree add .claude/worktrees/<branch> -b <branch>' (that specific command is allowed on the main tree), or spawn an agent with isolation: worktree. See claude-config README 'Worktree enforcement' for details.$(cwd_anchor_note_if_chained "$COMMAND")"
+    emit_deny "Blocked by worktree-enforcement hook: 'git $subcmd' is not on the read-only allowlist, and this session is running in the main working tree of a repo that has opted into worktree discipline (.claude/worktree-required is committed). Run git write operations from inside a linked worktree — cd into an existing worktree under .claude/worktrees/, create one with 'git worktree add .claude/worktrees/<branch> -b <branch>' (that specific command is allowed on the main tree), or spawn an agent with isolation: worktree. See claude-config README 'Worktree enforcement' for details.$(cwd_anchor_note_if_chained "$COMMAND")$(git_C_note_if_present "$COMMAND")"
     exit 0
   fi
 done <<< "$FRAGMENTS"

--- a/claude/.claude/hooks/tests/test_hooks.py
+++ b/claude/.claude/hooks/tests/test_hooks.py
@@ -3163,6 +3163,67 @@ class TestRequireWorktreeForGitWrites:
         assert reason is not None
         assert "session-persisted" not in reason
 
+    # Tests for git_C_note_if_present: the corrective note appended when
+    # the agent used `git -C <path> <write-op>` from the main tree and
+    # expected the -C path to be treated as the working directory.
+    # Assertion phrases:
+    #   chained-cd note (existing) → unique substring: "chained 'cd"
+    #   -C note (new)              → unique substring: "-C path"
+
+    def test_git_dash_C_write_appends_C_note(self, opted_in_repo):
+        """`git -C /tmp commit` → denied; -C note appended."""
+        reason = run_hook_reason(
+            WORKTREE_HOOK,
+            bash_input("git -C /tmp commit -m foo"),
+            cwd=opted_in_repo,
+        )
+        assert reason is not None
+        assert "-C path" in reason
+
+    def test_git_dash_C_readonly_no_C_note(self, opted_in_repo):
+        """`git -C /tmp log` is read-only → allowed; no deny reason."""
+        assert (
+            run_hook(
+                WORKTREE_HOOK,
+                bash_input("git -C /tmp log"),
+                cwd=opted_in_repo,
+            )
+            == "allow"
+        )
+
+    def test_plain_git_no_C_note(self, opted_in_repo):
+        """Plain `git commit` without -C → denied; -C note NOT appended."""
+        reason = run_hook_reason(
+            WORKTREE_HOOK,
+            bash_input("git commit -m foo"),
+            cwd=opted_in_repo,
+        )
+        assert reason is not None
+        assert "-C path" not in reason
+
+    def test_subcommand_dash_C_no_C_note(self, opted_in_repo):
+        """`git commit -C HEAD` uses -C as commit's reuse-message flag,
+        not as the global working-dir flag. The note must NOT fire —
+        the hint about working directories doesn't apply here."""
+        reason = run_hook_reason(
+            WORKTREE_HOOK,
+            bash_input("git commit -C HEAD"),
+            cwd=opted_in_repo,
+        )
+        assert reason is not None
+        assert "-C path" not in reason
+
+    def test_chained_cd_and_git_C_appends_both_notes(self, opted_in_repo):
+        """Command with both patterns → both notes appended independently."""
+        reason = run_hook_reason(
+            WORKTREE_HOOK,
+            bash_input("cd /tmp && git -C /tmp commit -m foo"),
+            cwd=opted_in_repo,
+        )
+        assert reason is not None
+        assert "chained 'cd" in reason   # chained-cd note
+        assert "-C path" in reason        # -C note
+
 
 # --- require-stow-reminder.sh ----------------------------------------
 #


### PR DESCRIPTION
## Summary

When an agent runs `git -C <path> <write-op>` from the main working tree, the worktree-enforcement hook correctly denies the write — but the deny message gives no hint that `-C` is the problem. The hook checks the session-persisted CWD from the tool-input JSON, not the `-C` path, so the op is blocked even when `-C` points at a linked worktree.

The chained `cd && git` mistake already has a tailored note (`cwd_anchor_note_if_chained`). This PR adds a parallel note for the `git -C` case, making the hook's feedback symmetric for both common "I'm pointing at the worktree but it's blocked" patterns.

## What changed

- Added `git_C_note_if_present` function in `require-worktree-for-git-writes.sh`, mirroring `cwd_anchor_note_if_chained`
- Detection is scoped to the **global** `-C` flag position only — subcommand-level uses (`git commit -C HEAD`, `git diff -C`, etc.) do not trigger the note (the loop stops at the first non-flag word/subcommand)
- Wired into both `emit_deny` call sites (parse-failure and allowlist-miss)
- Note is appended after the existing chained-cd note; both can coexist

## Tests

Five new tests in `TestRequireWorktreeForGitWrites`:

| Test | Input | Expected |
|------|-------|----------|
| `test_git_dash_C_write_appends_C_note` | `git -C /tmp commit -m foo` | deny; `-C path` in reason |
| `test_git_dash_C_readonly_no_C_note` | `git -C /tmp log` | allow |
| `test_plain_git_no_C_note` | `git commit -m foo` | deny; `-C path` NOT in reason |
| `test_subcommand_dash_C_no_C_note` | `git commit -C HEAD` | deny; `-C path` NOT in reason (false-positive guard) |
| `test_chained_cd_and_git_C_appends_both_notes` | `cd /tmp && git -C /tmp commit -m foo` | deny; both `chained 'cd` and `-C path` in reason |

All 59 existing `TestRequireWorktreeForGitWrites` tests continue to pass.