### PR TITLE
Improve CLAUDE.md coverage and add output-preferences mechanism

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,18 @@ This repository is **public** — every commit, skill body, commit message,
 and PR description ships to anyone with the URL. The guardrails below
 govern any contribution (human or agent).
 
+## Commands
+
+```bash
+./install.sh                        # first-time setup (stow + plugin registration)
+pytest claude/.claude/hooks/tests/  # hook test suite
+```
+
 ## Working in this repo
+
+**Repo layout:** `claude/` is the stow package — `claude/.claude/` maps 1:1 to `~/.claude/`. Skills, hooks, and reviewer agents live under `claude/.claude/skills/`, `claude/.claude/hooks/`, and `claude/.claude/agents/` respectively.
+
+**Two CLAUDE.md files:** This file (repo root) governs contributor workflow. `claude/.claude/CLAUDE.md` contains the global engineering instructions (judgment heuristics, working style, safety rules) — it is stowed to `~/.claude/CLAUDE.md` and applies to all Claude Code sessions on this machine.
 
 Worktree enforcement is active. `.claude/worktree-required` is committed, so
 non-read-only git operations must run inside a linked worktree

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ To customize response tone, formatting, and communication style, create `~/.clau
 ```markdown
 # Output preferences
 
+- Tone: direct and confident; skip hedging phrases like "it seems" or "you might want to consider".
 - Avoid emoji unless explicitly asked.
 - Prefer plain prose over bullet lists when the answer is a single concept.
-- Use British English spelling.
 ```

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This symlinks `claude/.claude/` into `$HOME/.claude/`.
 - **`deny-private-project-refs.sh`** — blocks `git commit`, `gh pr create`, and `gh pr edit` when the staged diff, commit message, or PR title/body/body-source-file contains either (a) tracker-ID tokens (`[A-Z]{2,}-\d+`) outside an OSS-prefix allowlist (`CVE-`, `RFC-`, `GH-`, and similar — see the script for the full list), or (b) a literal substring match against entries in the user's opt-in `~/.claude/private-projects.md` blocklist. Enforces the mechanical categories of the repo-root `CLAUDE.md` redaction rule; structural fingerprints still require review discipline. See [Private-project redaction](#private-project-redaction) below.
 - **`require-stow-reminder.sh`** — scoped to the claude-config repo. Blocks `gh pr create` and `gh pr edit` (when the edit changes the body) if the PR adds a new immediate child of `claude/.claude/` (file or directory) and neither the inline command, a referenced `--body-file`/`--template`, nor any `--fill`-sourced commit message mentions `install.sh` or `stow` (case-insensitive). Reason: GNU Stow links each top-level child of `claude/.claude/` individually, so a brand-new child only appears in `~/.claude/` after re-running `install.sh` — `git pull` alone won't materialize the symlink. The reminder lands in the PR body so the post-merge stow step doesn't get forgotten at merge time.
 - **`require-respond-pr.sh`** — blocks PR comment reads and posts (`gh api .../pulls|issues/N/{comments,reviews}`, `gh pr comment`, `gh pr review`) and redirects to `/respond-pr`, so all three comment types get fetched and replies carry the `[Claude Code]` attribution prefix. Honors a per-session bypass marker at `~/.claude/.respond-pr-active.d/<session_id>` that the skill sets on entry and removes on exit; the hook refreshes the marker's mtime on each bypass so long skill runs don't hit the 60-minute staleness cutoff. Per-session keying (rather than a singleton path) keeps parallel Claude sessions from thrashing on cleanup or leaking bypass to unrelated sessions.
+- **`require-ready-for-review.sh`** — gates `git push` and `gh pr ready` on branches with an open PR. Requires `/ready-for-review` to have run and passed since the last commit. Verified via a per-session marker keyed by HEAD SHA — a new commit invalidates the marker automatically and forces a re-run. An active-skill bypass marker (`~/.claude/.ready-for-review-active.d/<session_id>`) prevents the skill's own iteration pushes (fix → push → loop) from self-denying.
 - **`capture-session-id.sh`** (SessionStart) — at session start, writes the session's `session_id` to `~/.claude/sessions/<claude-pid>` so skills running as Bash tool calls (which don't see the hook payload) can look up their own session id via the bash tool's `$PPID`. Used by both `/respond-pr` and `/code-review` to compute per-session marker filenames.
 - **`ask-review-permissions.sh`** — asks before `Edit`/`Write`/`MultiEdit` to `.claude/settings*.json`, nudging toward `/review-permissions` when the edit touches `permissions.allow`.
 - **`require-worktree-for-git-writes.sh`** — opt-in per repo. When active, denies non-read-only git operations unless the session runs in a linked git worktree. Prevents concurrent Claude Code sessions from racing on the same working tree. See [Worktree enforcement](#worktree-enforcement) below for opt-in instructions.
@@ -225,3 +226,19 @@ If a project's review pattern consistently surfaces gaps in these areas — and 
 ## Machine-specific overrides
 
 Machine-local Claude Code permissions belong in `~/.claude/settings.local.json` (not tracked).
+
+## Output preferences
+
+To customize response tone, formatting, and communication style, create `~/.claude/output-preferences.md`. This file is user-local and never committed to this repo. It is loaded via an instruction in `claude/.claude/CLAUDE.md`'s "Output Preferences" section.
+
+**Cap:** keep it under 50 lines — content beyond that competes with project context for the 200-line CLAUDE.md budget. Avoid duplicating rules already in the global CLAUDE.md — they apply regardless, and duplicate entries waste context budget.
+
+**Template:**
+
+```markdown
+# Output preferences
+
+- Avoid emoji unless explicitly asked.
+- Prefer plain prose over bullet lists when the answer is a single concept.
+- Use British English spelling.
+```

--- a/README.md
+++ b/README.md
@@ -238,7 +238,8 @@ To customize response tone, formatting, and communication style, create `~/.clau
 ```markdown
 # Output preferences
 
-- Tone: direct and confident; skip hedging phrases like "it seems" or "you might want to consider".
+- Tone: direct and calibrated — state things plainly; match certainty to evidence (no overclaiming, no hedging filler).
+- Length: concise. Include the why when non-obvious; skip narration of internal process.
 - Avoid emoji unless explicitly asked.
 - Prefer plain prose over bullet lists when the answer is a single concept.
 ```

--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -41,3 +41,7 @@
 - Never run sudo commands directly.
 - Never commit secrets, credentials, API keys, or large binary assets to repositories.
 - Never use the Read tool on files likely to contain secrets (`.env`, `.claude.json`, `credentials.json`, similar). Reading pulls the secret into the conversation context. When you need to inspect such a file, give the user a shell command (`cat`, `grep`, `jq`) to run via `!` instead.
+
+## Output Preferences
+
+If `~/.claude/output-preferences.md` exists, read it at session start and apply those preferences for response tone and formatting. Cap at 50 lines.


### PR DESCRIPTION
## Summary

- **Project CLAUDE.md**: adds `## Commands` section (install + test commands), repo layout note explaining the stow mapping and directory purposes, and a two-CLAUDE.md clarification so agents know which file governs contributor workflow vs. global engineering behavior
- **Global `claude/.claude/CLAUDE.md`**: adds `## Output Preferences` section — if `~/.claude/output-preferences.md` exists, Claude reads and applies it for tone/formatting; file is user-local and never committed to this repo
- **README**: documents the previously undocumented `require-ready-for-review.sh` hook, adds an "Output preferences" section with template and a duplication warning (don't re-state rules already in the global CLAUDE.md)

## Notes

- `@output-preferences.md` import syntax was considered but not used — missing-file behavior is unverified; prose instruction is safer until tested
- `dotfiles/` (untracked, legacy directory from the pre-split repo name) was deleted from the main working tree separately — not part of this commit since it was never tracked
- Main working tree `claude/.claude/settings.json` was found corrupted by a prior session (most hooks stripped); restored to HEAD separately before this PR

## Test plan

- [x] Verify `./install.sh` and `pytest claude/.claude/hooks/tests/` commands in the Commands section are accurate
- [x] Create `~/.claude/output-preferences.md` with a few lines and confirm Claude applies them in a new session
- [x] Confirm README hook list now matches the actual scripts in `claude/.claude/hooks/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)