### PR TITLE
Fix two bugs in /cleanup-merged-branch skill

### DIFF
--- a/claude/.claude/skills/cleanup-merged-branch/SKILL.md
+++ b/claude/.claude/skills/cleanup-merged-branch/SKILL.md
@@ -26,12 +26,26 @@ constraints shape every step:
   reads the session's prior CWD, not the inline `cd`. Run `cd` as its
   own Bash call, then the git op in a follow-up call.
 
+## Before you begin — anchor CWD
+
+Run this as the very first Bash call, using the absolute repo root path
+you know from context. CWD may point to a deleted worktree directory
+left over from earlier in the session; any git command will fail with
+`getcwd: cannot access parent directories` until you re-anchor:
+
+```bash
+cd <ABSOLUTE_REPO_ROOT>
+```
+
+If the path isn't obvious, check recent tool output — a `git worktree list`
+result, a file path the model wrote, or the skill invocation directory.
+
 ## 0. Resolve branch name
 
 Use the argument if provided. Otherwise detect the most recently merged PR:
 
 ```bash
-gh pr list --state merged --limit 1 --json headRefName --jq .headRefName
+gh pr list --state merged --limit 1 --json headRefName --jq '.[0].headRefName'
 ```
 
 Confirm with the user if unsure which branch to clean up.


### PR DESCRIPTION
## Summary

Two bugs caught on first real run of the skill:

- **CWD may be invalid at skill start** — if the session was previously operating inside the branch's worktree, CWD points to a deleted directory when cleanup runs. Any git command fails with `getcwd: cannot access parent directories`. Added a "Before you begin" preamble step instructing an explicit `cd <ABSOLUTE_REPO_ROOT>` as the first Bash call.
- **`--jq .headRefName` fails on array output** — `gh pr list` returns an array even with `--limit 1`, so `.headRefName` errors with "expected an object but got array". Fixed to `.[0].headRefName`.

## Test plan

- [ ] Run `/cleanup-merged-branch` after merging this PR and verify both steps (step 0 branch detection and the preamble CWD anchor) work cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)