### PR TITLE
CLAUDE.md: restructure redaction tiers, promote conventions, add ruff linter

### DIFF
--- a/.github/workflows/hooks.yml
+++ b/.github/workflows/hooks.yml
@@ -50,7 +50,7 @@ jobs:
             exit 0
           fi
 
-          if git diff --name-only "$BASE" "$HEAD" | grep -qE '^(claude/\.claude/hooks/|\.github/workflows/hooks\.yml)'; then
+          if git diff --name-only "$BASE" "$HEAD" | grep -qE '^(claude/\.claude/hooks/|\.github/workflows/hooks\.yml|pyproject\.toml)'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -65,10 +65,14 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install pytest
+      - name: Install dependencies
         if: steps.detect.outputs.changed == 'true'
-        run: pip install 'pytest==8.*'
+        run: pip install 'pytest==8.*' 'ruff==0.6.*'
 
       - name: Run hook tests
         if: steps.detect.outputs.changed == 'true'
         run: pytest claude/.claude/hooks/tests/ -v
+
+      - name: Lint
+        if: steps.detect.outputs.changed == 'true'
+        run: ruff check claude/.claude/hooks/tests/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,8 +91,8 @@ examples that would reveal the project via shape alone.
 
 Not a redaction concern — a do-not-commit-ever concern. API keys,
 OAuth tokens, service-role keys, `.env` contents, database URLs with
-credentials, private-key material. If one ever lands, rotate it *then*
-rewrite history.
+credentials, private-key material. If one ever lands, ask the owner to
+rotate it *then* rewrite history.
 
 ### When a skill is surfaced by real-world work, abstract first
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,8 +7,10 @@ govern any contribution (human or agent).
 ## Commands
 
 ```bash
-./install.sh                        # first-time setup (stow + plugin registration)
-pytest claude/.claude/hooks/tests/  # hook test suite
+./install.sh                            # first-time setup (stow + plugin registration)
+pip install 'ruff==0.6.*'              # one-time linter install
+pytest claude/.claude/hooks/tests/     # hook test suite
+ruff check claude/.claude/hooks/tests/ # lint
 ```
 
 ## Working in this repo
@@ -31,6 +33,15 @@ tracked files in this repo — appending via `>>` writes through the
 symlink and silently stages changes to the public repo. Edit the
 committed file directly via PR.
 
+**Terminology:** Use "project" / "private project", not "client", in
+claude-config prose. The redaction hook is `deny-private-project-refs`.
+
+**Hook defense-in-depth:** Hooks must filter their own input by tool
+name and matcher; do not rely solely on settings.json `if` conditions.
+
+**Plugin config:** `enabledPlugins` only takes effect in
+`settings.json`, not `settings.local.json`.
+
 ## AI agents: don't merge your own PRs
 
 In this repo, an AI agent that opens a PR does not also merge it.
@@ -43,72 +54,57 @@ the PR, not landing it.
 
 A skill's body states the rules it enforces; an edit can violate
 those rules unless you re-read the body with the diff in mind. Before
-committing a skill change, load the skill into context and check the
-diff against its sections — e.g. an edit adding prose to a skill that
-argues for brevity is the kind of thing the skill would flag against
-itself.
+committing a skill change, invoke the skill via the `Skill` tool and
+check the diff against its output — e.g. an edit adding prose to a
+skill that argues for brevity is the kind of thing the skill would
+flag against itself.
 
 ## Redact private-project-identifying content
 
-Never commit anything that ties a skill, rule, or example back to a
-specific private project, engagement, or private codebase. Categories:
+Never commit anything that identifies a specific private project,
+engagement, or codebase. Three enforcement tiers apply:
 
-- **Project or organization names** (including the repo owner's own
-  private projects).
-- **Project codenames** unique to a private codebase.
-- **Internal tool or product names** (bespoke CLIs, in-house services)
-  beyond those generally known in open source.
-- **Issue or ticket IDs from private trackers** — anything matching
-  `[A-Z]{2,}-\d+` that is *not* on this allowlist of standard
-  open-source references: `CVE-`, `RFC-`, `PEP-`, `ISO-`, `GH-`,
-  `BUG-` / bugzilla-style, and clearly-public project prefixes.
-  Default: if in doubt, strip it. When an example or commit message
-  needs a tracker-ID-shaped placeholder, use `PROJ-<digits>` or
-  `TICKET-<digits>` — both prefixes are reserved as placeholders
-  and pass the allowlist with any digit suffix.
-- **Internal URLs, hostnames, Slack channels, project domains**.
-- **Absolute filesystem paths** that embed project names
-  (`~/Code/acme-platform/...`, `/home/foo/WorkForProject/...`).
-- **Environment variable names** that encode a project (`ACME_API_URL`,
-  `PROD_FOOCO_DB_URL`).
-- **Commit SHAs or PR numbers from private repos** — pastes like
-  `see abc1234 in the main repo` are useless publicly and correlatable.
-- **Person names** other than the repo owner's own commit-author
-  identity.
+**Always caught by hook:** tracker IDs matching `[A-Z]{2,}-\d+` not on
+the OSS allowlist (`CVE-`, `RFC-`, `GH-`, and similar). For
+tracker-ID-shaped placeholders in examples, use `PROJ-<digits>` or
+`TICKET-<digits>` — both pass the allowlist.
+
+**Caught by hook when `~/.claude/private-projects.md` is populated:**
+project/org names (including the owner's own private projects),
+codenames, internal URLs/hostnames/Slack channels/project domains,
+filesystem paths embedding project names, env var names encoding a
+project, and person names other than the repo owner's commit-author
+identity. Default: if in doubt, strip it.
+
+**Reviewer discipline only — hook doesn't catch these:** internal
+tool/product names not generally known in open source; commit SHAs or
+PR numbers from private repos; structural fingerprints (see below).
 
 ### Also redact structural fingerprints
 
 Identifiers aren't the only leak. Structural shapes can identify a
-project even without names — a verbatim RLS policy copied from a
-private codebase, a rare column-naming pattern, an unusual error-code
-namespace. When an example would reveal the project via shape alone,
-generalize the example.
+project even without names — a verbatim RLS policy, a rare
+column-naming pattern, an unusual error-code namespace. Generalize
+examples that would reveal the project via shape alone.
 
 ### Secrets, tokens, credentials
 
 Not a redaction concern — a do-not-commit-ever concern. API keys,
 OAuth tokens, service-role keys, `.env` contents, database URLs with
-credentials, private-key material. The repo has no legitimate use for
-any of these. If one ever lands, rotate it *then* rewrite history.
+credentials, private-key material. If one ever lands, rotate it *then*
+rewrite history.
 
 ### When a skill is surfaced by real-world work, abstract first
 
-Skills are often motivated by a concrete incident. The insight belongs
-in this repo; the incident specifics do not.
-
-**Rule:** keep the failure mode and the fix; drop the trigger's identity.
+Keep the failure mode and the fix; drop the trigger's identity.
 
 - ✅ "Surfaced during a production incident where a mid-merge index was
   silently corrupted by a diagnostic `git checkout`."
-- ❌ "Surfaced during the ExampleCo WIDGET-123 review, where the mid-merge
-  index was silently corrupted..."
+- ❌ "Surfaced during the ExampleCo PROJ-123 review, where the
+  mid-merge index was silently corrupted..."
 
 ### Enforcement
 
-The mechanical categories above — tracker IDs always, named projects
-when the user opts in via `~/.claude/private-projects.md` — are
-enforced by the `deny-private-project-refs.sh` PreToolUse hook on
-`git commit`, `gh pr create`, and `gh pr edit`. Other categories
-(internal tool names, structural fingerprints) still require review
-discipline. See README "Private-project redaction" for full hook
-behavior, opt-in instructions, and test location.
+`deny-private-project-refs.sh` fires on `git commit`, `gh pr create`,
+and `gh pr edit`. See README "Private-project redaction" for blocklist
+setup, opt-in instructions, and test location.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Portable [Claude Code](https://claude.ai/claude-code) global configuration: custom skills, PreToolUse hooks that gate `git commit` and PR-comment flows, and a custom statusline. Runs on any Unix-like system (Linux, macOS, WSL). Managed with [GNU Stow](https://www.gnu.org/software/stow/).
 
+Maintained by [Cordova Strategy](https://cordovastrategy.com).
+
 ## Requirements
 
 - **Operating system:** Linux, macOS, or WSL2. Native Windows (PowerShell / cmd.exe) is not supported — every hook is a bash script and `install.sh` uses GNU `stow` with symlinks. If you're on Windows, install inside [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) instead.

--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -1,10 +1,3 @@
-<!--
-  Global Claude Code instructions for Cordova Strategy.
-  These encode engineering judgment heuristics developed through
-  real-world fractional CTO engagements.
-  https://cordovastrategy.com
--->
-
 # Global Instructions
 
 ## Engineering Judgment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.ruff]
+line-length = 130
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "B", "I", "UP", "SIM"]


### PR DESCRIPTION
## Summary

- **Project CLAUDE.md**: restructure the 64-line redaction section into three enforcement tiers (always-mechanical / opt-in-mechanical / reviewer-discipline-only), cutting ~25 lines; clarify the skill-on-own-diff rule to specify the `Skill` tool as the mechanism; add ruff commands to the Commands block; promote three contributor conventions from auto-memory (terminology, hook defense-in-depth, `enabledPlugins` location); clarify that credential rotation requires the owner's action (not Claude's)
- **Global CLAUDE.md** (`claude/.claude/CLAUDE.md`): drop the HTML attribution comment (6 lines of tokens loaded into every session; attribution belongs in README)
- **README**: add "Maintained by Cordova Strategy" — was absent from the repo despite being the only attribution point
- **CI** (`.github/workflows/hooks.yml`): add `ruff==0.6.*` to the install step and a `Lint` step after tests; extend change-detection to trigger on `pyproject.toml` changes
- **pyproject.toml**: new file — ruff config (`line-length=130`, `E/F/B/I/UP/SIM`, `target-version=py312`)

## Notes

- `line-length=130` rather than 100 to accommodate pre-existing test assertions (max line is 124 chars); no reformatting of the 3984-line test file in this PR
- The ❌ placeholder example in the "abstract first" section used a tracker-ID prefix that isn't on the OSS allowlist; replaced with `PROJ-123`, which is the designated allowlisted placeholder per the redaction rule

## Test plan

- [ ] CI `hook-tests` job passes (pytest 332 tests + ruff check clean)
- [ ] `ruff check claude/.claude/hooks/tests/` runs clean locally
- [ ] `head -3 claude/.claude/CLAUDE.md` shows `# Global Instructions` with no leading comment
- [ ] `grep -ri 'cordovastrategy' .` returns only `README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)