### PR TITLE
respond-pr: document marker lifecycle to prevent mid-session cleanup

### DIFF
--- a/claude/.claude/skills/respond-pr/SKILL.md
+++ b/claude/.claude/skills/respond-pr/SKILL.md
@@ -16,6 +16,8 @@ Fetch all review comments on the current branch's open pull request and address 
    SESSION_ID=$(cat "$HOME/.claude/sessions/$PPID") && [ -n "$SESSION_ID" ] && mkdir -p "$HOME/.claude/.respond-pr-active.d" && touch "$HOME/.claude/.respond-pr-active.d/$SESSION_ID"
    ```
    The `require-respond-pr.sh` PreToolUse hook bypasses while THIS session's marker is fresh (<60 min) and refreshes its mtime on each bypass so long runs don't hit the staleness cutoff. Per-session keying prevents parallel respond-pr sessions from thrashing on cleanup or leaking bypass to unrelated sessions. If the chain fails (empty `SESSION_ID`, etc.), the `capture-session-id.sh` SessionStart hook didn't run — abort and report; do not proceed without the marker, since every gated `gh` call below will be blocked.
+
+   **Marker lifecycle:** this marker must stay active for the entire skill session — step 6 is the only step that removes it. If you run other skills as intermediate steps (e.g., `/ready-for-review` before pushing in step 5), their cleanup must not touch this marker. If the marker is accidentally removed mid-session, restore it in a standalone Bash call before any subsequent `gh` command — the hook fires before the shell executes, so you cannot create the marker and use it atomically in the same call.
 1. Identify the PR number for the current branch: `gh pr view --json number -q '.number'`
 2. Fetch **all three** types of comments. Two failure modes Claude commonly hits: (a) fetching only the first type and missing the other two; (b) fetching without `--paginate` and silently truncating at 30 results per type. Both produce reviews that look complete but miss real feedback.
    - **Inline file comments:** `gh api repos/{owner}/{repo}/pulls/{number}/comments --paginate`


### PR DESCRIPTION
## Summary

- Adds a **Marker lifecycle** paragraph to step 0 of the respond-pr skill
- Documents two failure modes that caused real token burn in a session:
  1. Another skill's cleanup step (e.g., `/ready-for-review`) removing the respond-pr bypass marker before all `gh` API calls complete — subsequent calls are blocked by the gate
  2. Attempting `touch marker && gh api ...` as one compound Bash call fails because the PreToolUse hook fires before the shell executes the compound — the marker doesn't exist at hook-check time

## Test plan

- [ ] Read the updated step 0 — confirm the lifecycle paragraph follows the existing explanation without breaking the `HOOK_TEST_FIXTURE` comment sentinel structure
- [ ] Verify the enable-bypass fenced block is still the only block with the `enable-bypass` fixture tag (the paragraph is prose, not a code block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)