### PR TITLE
agents: add model: sonnet frontmatter to all 8 specialist reviewer agents

### DIFF
--- a/claude/.claude/agents/ciso-reviewer.md
+++ b/claude/.claude/agents/ciso-reviewer.md
@@ -1,4 +1,5 @@
 ---
+model: sonnet
 name: ciso-reviewer
 description: CISO-perspective security review of a diff or plan. Focus on threat modeling, auth boundaries, privilege escalation, data exposure, defense in depth. TRIGGER when changes touch authentication or authorization (auth, authN, authZ), secrets, tokens, access-control policies (RLS / RBAC / ACL), privileged functions, input validation at trust boundaries, logging of sensitive data, or third-party data sharing, including in docs that prescribe security-relevant behavior. DO NOT TRIGGER for cosmetic-only edits (typo fixes, formatting, copy polish) with no privilege delta.
 tools: Read, Grep, Glob, Bash

--- a/claude/.claude/agents/staff-analytics-engineer.md
+++ b/claude/.claude/agents/staff-analytics-engineer.md
@@ -1,4 +1,5 @@
 ---
+model: sonnet
 name: staff-analytics-engineer
 description: Staff analytics engineer review of a diff or plan. Focus on warehouse-side modeling (fact/dim, SCD, partitioning, materialization), transformation correctness, and data-contract review of source schemas for ELT-readiness. TRIGGER when changes touch any application schema or NoSQL document shape (the change may eventually feed a warehouse — review proactively, not contingently), warehouse models or transformation files, schema definitions consumed by warehouse pipelines, scheduled queries, or semantic-layer files, including in docs that prescribe analytical data behavior. DO NOT TRIGGER for cosmetic-only edits (typo / formatting), pure frontend / pure infra-config diffs with no schema impact, or pure application logic that doesn't touch any data-store schema.
 tools: Read, Grep, Glob, Bash

--- a/claude/.claude/agents/staff-backend-engineer.md
+++ b/claude/.claude/agents/staff-backend-engineer.md
@@ -1,4 +1,5 @@
 ---
+model: sonnet
 name: staff-backend-engineer
 description: Staff backend engineer review of a diff or plan. Focus on API contracts, error handling, idempotency, retry semantics, service boundaries, SDK behavior, and application data-store schema design (relational and NoSQL). TRIGGER when changes touch server-side code — HTTP endpoints, RPCs, edge functions, background jobs, queue consumers, SDK integrations, shared server utilities, server-side event emission — OR when changes touch application data-store schema (relational tables / migrations / indexes for app queries; NoSQL document or item shape, partition keys, GSI/LSI), including in docs that prescribe server-side behavior or schema. DO NOT TRIGGER for cosmetic-only edits (typo fixes, formatting) or for warehouse-side modeling (analytics-engineer's turf).
 tools: Read, Grep, Glob, Bash

--- a/claude/.claude/agents/staff-data-engineer.md
+++ b/claude/.claude/agents/staff-data-engineer.md
@@ -1,4 +1,5 @@
 ---
+model: sonnet
 name: staff-data-engineer
 description: Staff data engineer review of a diff or plan. Focus on operational data infrastructure across all stores: migration safety (pipeline impact), pipeline transport (CDC, change streams, ETL/ELT), schema-drift detection, warehouse ingestion mechanics, observability, and data catalog / lineage tracking. TRIGGER when changes touch database migrations, schema DDL, RLS / row-security policies, CDC or change-stream config, ETL/ELT pipeline code, warehouse ingestion connectors (Fivetran / Airbyte / custom), raw landing schemas, schema-drift handling, or files whose changes break downstream lineage, including in docs that prescribe data-infrastructure behavior. DO NOT TRIGGER for warehouse-side modeling (analytics-engineer's turf), application schema design or access patterns (backend's turf), pure application logic with no data-infrastructure impact, or cosmetic-only doc edits (typo / formatting).
 tools: Read, Grep, Glob, Bash

--- a/claude/.claude/agents/staff-frontend-engineer.md
+++ b/claude/.claude/agents/staff-frontend-engineer.md
@@ -1,4 +1,5 @@
 ---
+model: sonnet
 name: staff-frontend-engineer
 description: Staff frontend engineer review of a diff or plan. Focus on component patterns, state management, data fetching and cache consistency, routing, forms, accessibility, Web Vitals, internationalization, and client-side analytics emission. TRIGGER when changes touch client-side code — components, hooks, client state, routing, forms, data fetching, optimistic mutations, bundle composition, SSR — OR when server-side changes alter an API contract that the frontend consumes (response shape, status codes, headers, error taxonomy), including in docs that prescribe client-side behavior or UX. DO NOT TRIGGER for pure server-side changes that don't affect a frontend-consumed contract, or for cosmetic-only edits (typo fixes, formatting) with no behavioral delta.
 tools: Read, Grep, Glob, Bash

--- a/claude/.claude/agents/staff-platform-engineer.md
+++ b/claude/.claude/agents/staff-platform-engineer.md
@@ -1,4 +1,5 @@
 ---
+model: sonnet
 name: staff-platform-engineer
 description: Staff platform engineer review of a diff or plan. Covers CI/CD, IaC, shell discipline, deployment ordering, secret provisioning AND observability coverage, alerting, SLO impact, runbook linkage, load characteristics, and cost/operational footprint. TRIGGER when changes touch GitHub Actions/other CI config, Terraform/Pulumi/CloudFormation, Dockerfiles/K8s manifests, deployment scripts, bash/shell, environment config, OR when application changes introduce new hot paths, new cron jobs, new external dependencies with cost/latency implications, or new failure modes requiring alerting, including in docs that prescribe operational, deployment, observability, or alerting behavior. DO NOT TRIGGER for pure application logic with no operational surface delta, or for cosmetic-only edits.
 tools: Read, Grep, Glob, Bash

--- a/claude/.claude/agents/staff-product-engineer.md
+++ b/claude/.claude/agents/staff-product-engineer.md
@@ -1,4 +1,5 @@
 ---
+model: sonnet
 name: staff-product-engineer
 description: Staff product engineer review of a diff or plan. You are the reviewer who reads the spec — and reads it critically, separating requirements from implementation details. Focus on spec-to-user-problem fidelity, adjacent-behavior regression, backward compatibility for existing users, migration UX, and telemetry event semantics. TRIGGER when the change affects user-visible behavior (UI, API responses surfaced to client, flows, billing/entitlement, notifications, emails, analytics events) or when a plan claims to close a product ticket, including in docs that prescribe user-facing behavior, copy accuracy, or feature semantics. DO NOT TRIGGER for purely internal refactors with no user-perceivable delta, or for cosmetic-only edits with no behavioral or semantic change.
 tools: Read, Grep, Glob, Bash

--- a/claude/.claude/agents/staff-sdet.md
+++ b/claude/.claude/agents/staff-sdet.md
@@ -1,4 +1,5 @@
 ---
+model: sonnet
 name: staff-sdet
 description: Staff SDET review of a diff or plan. Focus on testability of the design, test-pyramid shape, edge cases the plan omits, mock design, fixture realism, and security invariant coverage. TRIGGER when the change adds / modifies test code, changes a module's testability (new side effects, new dependencies, new mocking surface), proposes test strategy in a plan, OR adds production code with non-trivial logic (business logic, error paths, security boundaries, state machines) that lacks corresponding test coverage, including in docs that prescribe testing behavior. DO NOT TRIGGER for cosmetic-only edits (typo fixes, formatting, copy polish, CSS color or font tweaks with no behavioral or interactive change).
 tools: Read, Grep, Glob, Bash


### PR DESCRIPTION
## Summary

- Adds `model: sonnet` as the first frontmatter key in each of the 8 specialist reviewer agent files
- Enforces the Model Routing policy documented in CLAUDE.md: Sonnet for all code-reading and specialist reviewer agents
- No behavior change to trigger logic, scope, or ownership — config addition only

## Test plan

- [ ] Verify each file opens with `---\nmodel: sonnet\n` as the first two lines of the frontmatter block
- [ ] Confirm no trigger descriptions, tool lists, or body content were modified
- [ ] Spot-check that a code-review spawn picks up the model key correctly

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)