### PR TITLE
CLAUDE.md: add plan-review repo-scope rule for stow-distributed audience

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,10 @@ name and matcher; do not rely solely on settings.json `if` conditions.
 **Plugin config:** `enabledPlugins` only takes effect in
 `settings.json`, not `settings.local.json`.
 
+## Plans in this repo affect all stow users
+
+`claude/` is stowed into `$HOME` — changes ship to every user who clones and stows this repo, not only to the session owner. When reviewing a plan for claude-config, evaluate with that audience in mind. Files under `claude/` are not personal config; they are distributed to all stow users on `git pull`. Surface this when declaring the user surface in Step 2 of plan-review, and weight finding severity accordingly.
+
 ## AI agents: don't merge your own PRs
 
 In this repo, an AI agent that opens a PR does not also merge it.


### PR DESCRIPTION
## Summary

- Moves the \"claude-config is stow-distributed; review plans with that audience in mind\" rule from auto-memory into the repo `CLAUDE.md` where it travels with the code and applies to all contributors
- Adds a new `## Plans in this repo affect all stow users` section in the Working in this repo cluster
- Updates the auto-memory pointer to reference the canonical location in `CLAUDE.md`

## Files changed

- `CLAUDE.md` — new section added before "AI agents: don't merge your own PRs"
- Auto-memory `feedback_plan_review_user_surface.md` — updated to pointer (local-only, not in this commit)

## Test plan

- [ ] Read the new section in `CLAUDE.md` and verify it is generic/portable (no private-project phrasing)
- [ ] Confirm the auto-memory file now reads as a pointer, not a rule
- [ ] Confirm `claude/.claude/skills/plan-review/SKILL.md` is unchanged (rule was never there)

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)