### PR TITLE
CLAUDE.md: add session-length handoff guardrail

### DIFF
--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -15,6 +15,7 @@
 - Always prefer minimal, targeted changes. Do not refactor entire files or expand scope beyond what was asked. If you see an opportunity for a broader improvement, mention it separately — do not bundle it in.
 - Before assuming anything about the environment, stack, or project conventions, check first. Read the actual config files rather than guessing defaults.
 - Use descriptive variable and function names. No generic names.
+- When a session crosses ~300K output tokens or ~3 hours of wallclock time, proactively suggest a handoff. Write `/tmp/<task>-handoff.md` summarizing current state and what's next, then start a fresh session that reads it.
 
 ## Code Review
 


### PR DESCRIPTION
## Summary

- Adds a new bullet to the **Working Style** section of `claude/.claude/CLAUDE.md` (stowed to `~/.claude/CLAUDE.md`)
- Formalizes the handoff pattern already used informally: when a session crosses ~300K output tokens or ~3 hours wallclock, proactively suggest writing a `/tmp/<task>-handoff.md` state summary and starting a fresh session
- Motivated by 9 sessions (2.2% of corpus) consuming 27% of total output tokens

## Test plan

- [ ] Verify `claude/.claude/CLAUDE.md` renders correctly in the stow target (`~/.claude/CLAUDE.md`)
- [ ] Read the file and confirm bullet is coherent in context of the Working Style section

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)