### PR TITLE
skill trim: reduce three over-200-line skills to ≤200 lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This symlinks `claude/.claude/` into `$HOME/.claude/`.
 - **`/read-docx-comments`** — extract comments from `.docx` files with anchored text context.
 - **`/cleanup-merged-branch`** — removes the local worktree and branch, prunes remote tracking refs, and fast-forwards the default branch after a PR is merged. Handles squash-merge branch detection and CWD anchoring for worktree-enforced repos.
 
-Each skill lives in `claude/.claude/skills/<skill-name>/SKILL.md`. A skill directory may also contain a `SOURCES.md` — canonical references (URLs, key quotes, framework notes) that informed the skill's rules. `SOURCES.md` is not loaded during skill execution; consult it when editing a skill to verify a rule still holds or to add new guidance.
+Each skill lives in `claude/.claude/skills/<skill-name>/SKILL.md`. A skill directory may also contain a `REFERENCES.md` — canonical references (URLs, key quotes, framework notes) that informed the skill's rules. `REFERENCES.md` is not loaded during skill execution; consult it when editing a skill to verify a rule still holds or to add new guidance.
 
 ### Reviewer subagents
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ This symlinks `claude/.claude/` into `$HOME/.claude/`.
 - **`/read-docx-comments`** — extract comments from `.docx` files with anchored text context.
 - **`/cleanup-merged-branch`** — removes the local worktree and branch, prunes remote tracking refs, and fast-forwards the default branch after a PR is merged. Handles squash-merge branch detection and CWD anchoring for worktree-enforced repos.
 
+Each skill lives in `claude/.claude/skills/<skill-name>/SKILL.md`. A skill directory may also contain a `SOURCES.md` — canonical references (URLs, key quotes, framework notes) that informed the skill's rules. `SOURCES.md` is not loaded during skill execution; consult it when editing a skill to verify a rule still holds or to add new guidance.
+
 ### Reviewer subagents
 
 Eight stack-agnostic reviewer personas in `claude/.claude/agents/`, spawned by `/plan-review` and `/code-review` based on the **Item ownership** tables in those skills. Each runs in its own context with read-only tools (`Read`, `Grep`, `Glob`, `Bash`).

--- a/claude/.claude/skills/config-environments/REFERENCES.md
+++ b/claude/.claude/skills/config-environments/REFERENCES.md
@@ -1,4 +1,4 @@
-# Sources — config-environments
+# References — config-environments
 
 Reference material that informed this skill. Not loaded during skill execution — consult when editing the skill to verify a rule still holds or to add new guidance.
 

--- a/claude/.claude/skills/config-environments/SKILL.md
+++ b/claude/.claude/skills/config-environments/SKILL.md
@@ -84,7 +84,7 @@ function getStripeKey() {
 }
 ```
 
-✅ **Recommended pattern:** the prod deploy populates `STRIPE_SECRET_KEY` with the live key; the dev `.env` populates it with the test key. Stripe's `sk_live_…` vs `sk_test_…` value prefix encodes the mode inside the *value* — no code branch needed.
+**Recommended pattern:** the prod deploy populates `STRIPE_SECRET_KEY` with the live key; the dev `.env` populates it with the test key. Stripe's `sk_live_…` vs `sk_test_…` value prefix encodes the mode inside the *value* — no code branch needed.
 
 ### 3. Sentinel-value defaults that silently leak production-shaped state
 

--- a/claude/.claude/skills/config-environments/SKILL.md
+++ b/claude/.claude/skills/config-environments/SKILL.md
@@ -54,18 +54,10 @@ Don't mix idioms across modules in the same runtime — it makes scattered reads
 
 ## Why
 
-- **12-Factor §III Config** (<https://12factor.net/config>) explicitly rejects environment-named variables: *"env vars are granular controls, each fully orthogonal to other env vars. They are never grouped together as 'environments', but instead are independently managed for each deploy."*
-- **Mainstream frameworks resolve per-env config by file/store selection, not renaming:**
-  - Next.js — lookup order `process.env` → `.env.$(NODE_ENV).local` → `.env.local` → `.env.$(NODE_ENV)` → `.env` (`.env.local` is skipped when `NODE_ENV=test`). Platform env stores (Vercel, Railway, etc.) populate `process.env` and win over file-based config.
-  - Rails — `config/credentials/#{Rails.env}.yml.enc` per-env encrypted file with fallback to `config/credentials.yml.enc`.
-  - Kubernetes — ConfigMap / Secret with Kustomize overlays or Helm values per env.
-  - Docker Compose — supports different `.env` files per env (passed with `--env-file`) rather than renaming variables.
-  - Supabase Edge Functions — local `supabase/functions/.env` vs `supabase secrets set FOO=…` in prod, same key name.
-- **Suffix patterns duplicate logic.** The "which environment am I?" decision is already encoded in which config source loaded. Adding `_DEV` / `_PROD` to variable names fans that decision out to runtime code that branches on `NODE_ENV`/`ENVIRONMENT`, which:
-  - Requires both values to be present where only one is ever read, forcing every config source to populate every suffix.
-  - Leaks the env selector into every consumer.
-  - Leaves unused-in-this-env variables sitting as placeholders in each config source, where a stale or missing value silently becomes live when the branch flips.
-- **Rotation is cheaper with canonical names.** Rotating `STRIPE_SECRET_KEY` means updating one name in the prod store; rotating `STRIPE_SECRET_KEY_PROD` requires remembering which suffix prod actually reads, and leaves a `_DEV` variant that's easy to update by mistake. Secrets hygiene practices (scheduled rotation, breach response) work best when the variable name is stable and only the value churns.
+- **12-Factor §III Config** (<https://12factor.net/config>) explicitly rejects environment-named variables: *"env vars are granular controls, each fully orthogonal to other env vars. They are never grouped together as 'environments'."*
+- **Suffix patterns duplicate logic.** The "which environment am I?" decision is already encoded in which config source loaded. Adding `_DEV` / `_PROD` to variable names fans that decision out to runtime code that branches on `NODE_ENV`, requiring both values to be present where only one is ever read, leaking the env selector into every consumer.
+- **Rotation is cheaper with canonical names.** Rotating `STRIPE_SECRET_KEY` means updating one name in the prod store; rotating `STRIPE_SECRET_KEY_PROD` requires remembering which suffix prod reads and leaves a `_DEV` variant easy to update by mistake.
+- **Mainstream frameworks resolve per-env config by file/store selection, not renaming:** Next.js lookup order, Rails per-env credentials, Kubernetes Kustomize overlays, Docker Compose `--env-file` — all load different sources for the same variable name.
 
 ## Anti-patterns to flag
 
@@ -76,14 +68,10 @@ Don't mix idioms across modules in the same runtime — it makes scattered reads
 const clientId = process.env.NODE_ENV === 'production'
   ? process.env.OAUTH_CLIENT_ID_PROD
   : process.env.OAUTH_CLIENT_ID_DEV;
-```
 
-```ts
 // Good
 const clientId = process.env.OAUTH_CLIENT_ID;
 ```
-
-The "bad" version requires both `_PROD` and `_DEV` to exist in *every* environment's config source even though only one is ever read — the other sits as a placeholder. Deploy-time config gets duplicated, and the env-branching logic is dead weight.
 
 ### 2. Environment-branching for credential selection
 
@@ -96,65 +84,47 @@ function getStripeKey() {
 }
 ```
 
-Same anti-pattern: pushes environment awareness into credential lookup. Instead, the prod deploy populates `STRIPE_SECRET_KEY` with the live key; the dev `.env` populates `STRIPE_SECRET_KEY` with the test key. No code branch.
-
-Stripe's own convention (`sk_live_…` vs `sk_test_…` prefix inside the *value*) is the cleanest version of this: the code just reads `STRIPE_SECRET_KEY` and the value itself encodes which mode it's in.
+The prod deploy populates `STRIPE_SECRET_KEY` with the live key; the dev `.env` populates it with the test key. Stripe's `sk_live_…` vs `sk_test_…` value prefix encodes the mode inside the *value* — no code branch needed.
 
 ### 3. Sentinel-value defaults that silently leak production-shaped state
 
 ```ts
 // Bad — silently falls back to a prod-ish default
 const bucket = process.env.STORAGE_BUCKET ?? 'prod-uploads';
-```
 
-Missing **stateful** config should **fail fast**, not substitute a default that might be production-shaped. A dev environment with missing `STORAGE_BUCKET` writing to `prod-uploads` is the classic data-leak path.
-
-```ts
 // Good — missing config fails boot, not first write
 const bucket = process.env.STORAGE_BUCKET;
 if (!bucket) throw new Error('STORAGE_BUCKET missing');
 ```
 
-**Convention defaults are fine** for non-sensitive ergonomics: `PORT ?? 3000`, `LOG_LEVEL ?? 'info'`, `MAX_RETRIES ?? 3`, `CACHE_TTL_SECONDS ?? 60`. The distinction:
-
-- **Can the default point at live production state if it's read in the wrong env?** → No default. Fail fast. (`STORAGE_BUCKET`, `DATABASE_URL`, `STRIPE_SECRET_KEY`, `OAUTH_CLIENT_ID`.)
-- **Is the default a neutral convention that works anywhere?** → Default is fine. (`PORT`, log levels, timeouts, retry counts.)
+**Convention defaults are fine** for non-sensitive ergonomics: `PORT ?? 3000`, `LOG_LEVEL ?? 'info'`, `MAX_RETRIES ?? 3`. The rule: if the default can point at live production state in the wrong env, fail fast (`STORAGE_BUCKET`, `DATABASE_URL`, `STRIPE_SECRET_KEY`). Otherwise a default is fine.
 
 ### 4. Assuming client-side frameworks "know" the environment
 
-Client bundles (Vite, Next.js, React Native) bake env vars in at build time — the bundle that ships is **frozen** with the values present when `next build` / `vite build` ran. A value set in the production deploy's runtime env does **not** reach the prod bundle retroactively. Only specifically-prefixed vars are inlined (`VITE_*`, `NEXT_PUBLIC_*`, similar), and they're inlined at build time. If the CI pipeline builds the prod bundle under staging's env (or a missing env var falls back to a dev default), the shipped prod bundle carries the wrong values and no runtime config change will fix it. This is the single most common cause of "prod points at staging" incidents.
+Client bundles (Vite, Next.js) bake env vars in at build time — the bundle is **frozen** with the values present when `next build` / `vite build` ran. Only `VITE_*` / `NEXT_PUBLIC_*` vars are inlined, at build time only. If CI builds the prod bundle under staging's env, the shipped prod bundle carries the wrong values permanently.
 
 ## Environment-aware *behavior* vs environment-aware *credentials*
 
-Not all env-branching is an anti-pattern. The distinction is what the branch is *selecting:*
-
-- **Credential selection branching is the anti-pattern.** Reading `X_DEV` vs `X_PROD` based on `NODE_ENV` is duplicated logic (see above).
-- **Behavior branching can be legitimate.** If the *same canonical variable* drives the decision (e.g. `ENVIRONMENT` controls which origin allowlist applies, not which secret is read), the env check lives in one place and only affects behavior. The credentials are still a single-name read.
-
-Example of a legitimate behavior branch:
+- **Credential selection branching is the anti-pattern.** Reading `X_DEV` vs `X_PROD` based on `NODE_ENV` is duplicated logic.
+- **Behavior branching can be legitimate.** If the *same canonical variable* drives the decision, the env check lives in one place and only affects behavior.
 
 ```ts
-// The allowlist itself differs per env (localhost only in dev).
-// But credentials are a single-name read — no _DEV / _PROD suffixes.
-const origins = currentEnv() === 'production'
-  ? PRODUCTION_ORIGINS
-  : DEV_ORIGINS;
+// Legitimate: behavior differs, credentials are a single-name read
+const origins = currentEnv() === 'production' ? PRODUCTION_ORIGINS : DEV_ORIGINS;
 const clientId = process.env.OAUTH_CLIENT_ID; // same name in every env
 ```
 
 ## When suffix patterns ARE legitimate
 
-Narrow cases where both values must exist in the same process at the same time:
+- **Co-located simultaneous values** — a migration script reading `OLD_DATABASE_URL` and `NEW_DATABASE_URL` in one process.
+- **Test harness stubs** — `TEST_STRIPE_KEY` next to `STRIPE_SECRET_KEY` so a test hits test mode deliberately.
+- **Feature flags orthogonal to environment** — `ENABLE_NEW_BILLING` is a rollout control, not an environment name.
 
-- **Co-located simultaneous values.** A migration script reading `OLD_DATABASE_URL` and `NEW_DATABASE_URL` in one process.
-- **Test harness stubs alongside real values.** `TEST_STRIPE_KEY` held next to `STRIPE_SECRET_KEY` so a test file can hit the test mode deliberately without swapping files.
-- **Feature flags genuinely orthogonal to environment.** `ENABLE_NEW_BILLING` is flipped per-deploy but the variable isn't an environment — it's a rollout control.
-
-If a single invocation of the code needs both suffixed values at the same time, the suffix is fine. If it's just "I'm in dev vs I'm in prod," it's the anti-pattern.
+If a single invocation needs both suffixed values at the same time, the suffix is fine. If it's just "I'm in dev vs prod," it's the anti-pattern.
 
 ## Centralize config at startup (`config.ts` pattern)
 
-Read every env var **once**, in a single module, validate at process boot, freeze, and export a typed object. Every consumer imports the config module — no `process.env` / `Deno.env.get` at call sites.
+Read every env var **once**, in a single module, validate at process boot, freeze, and export a typed object.
 
 ```ts
 // config.ts — the one place env vars are read.
@@ -164,96 +134,46 @@ const schema = z.object({
   DATABASE_URL: z.string().url(),
   STRIPE_SECRET_KEY: z.string().startsWith('sk_'),
   OAUTH_CLIENT_ID: z.string().min(1),
-  OAUTH_CLIENT_SECRET: z.string().min(1),
   PORT: z.coerce.number().int().positive().default(3000),
   LOG_LEVEL: z.enum(['debug', 'info', 'warn', 'error']).default('info'),
 });
 
-// Throws on boot with a clear validation message if anything is missing
-// or malformed. The process never starts with bad config.
 export const config = Object.freeze(schema.parse(process.env));
-export type Config = typeof config;
 ```
 
-```ts
-// elsewhere.ts
-import { config } from './config';
-
-const stripe = new Stripe(config.STRIPE_SECRET_KEY); // typed: string, validated: sk_ prefix
-app.listen(config.PORT);                             // typed: number
-```
-
-**Why this matters:**
-
-- **Fail-fast.** Missing / malformed config crashes at boot with a clear error, not at 3am on the first checkout attempt.
-- **Type safety.** `process.env.X` is `string | undefined`; `config.X` is whatever the schema said (validated `string`, `number`, enum, URL, etc.).
-- **Central audit surface.** One grep of `process.env.` in your repo should return exactly one file. New env var = one place to add it.
-- **Testability.** Tests mock the `./config` module (`vi.mock('./config', () => ({ config: { ... } }))`) rather than stubbing `process.env` — cleaner, safer, and doesn't leak across test isolation.
-- **ORM / client init plays along.** Instead of Prisma/Drizzle/Stripe reading `process.env` directly at import time, construct them from `config`:
-  ```ts
-  // db.ts
-  import { config } from './config';
-  export const db = drizzle({ connectionString: config.DATABASE_URL });
-  ```
-
-Zod is shown above; `valibot`, `envalid`, `@t3-oss/env-core`, or hand-rolled validation all work. The point is a single validated module, not the library.
-
-### Language equivalents
-
-The examples above are TypeScript / Node because it's the most common backend in many stacks. The `config.ts` *pattern* — one module that reads env, validates, freezes, exports typed config — translates directly:
+Benefits: fail-fast (missing config crashes at boot), type safety, central audit surface (one grep of `process.env.`), testability (`vi.mock('./config', () => ({ config: { ... } }))`).
 
 | Language / stack | Config module | Common libraries |
 |---|---|---|
 | TypeScript / Node / Bun | `src/config.ts` or `src/env.ts` | Zod, valibot, envalid, `@t3-oss/env-core` |
-| Python | `config.py` or `settings.py` | `pydantic-settings`, `dynaconf`; `django-environ` for Django |
-| Go | `internal/config/config.go` or `config/config.go` | Parsing: `caarlos0/env`, `spf13/viper`, `knadh/koanf` (note: `kelseyhightower/envconfig` is widely used but largely unmaintained). Field validation: `go-playground/validator`. |
-| Ruby / Rails | `config/application.rb` + `config/environments/*.rb` + `config/credentials/<env>.yml.enc` | Built-in `Rails.application.credentials`; `anyway_config`, `dotenv-rails` |
-| Java / Kotlin / Spring Boot | `@ConfigurationProperties` class | Jakarta Bean Validation (Hibernate Validator via `spring-boot-starter-validation`) |
-| Rust | `src/config.rs` | Parsing: `config`, `figment`, or `envy` with `serde` `#[derive(Deserialize)]`. Field validation: `validator` or `garde`. `.env` loading: `dotenvy`. |
-
-A note on the TS/Python rows vs Go/Rust rows: in TypeScript and Python, one library usually handles both parsing and validation (Zod, pydantic-settings). In Go and Rust, they're separate concerns — a config library maps env vars into a struct, and a validator library enforces field constraints. Either way the `config.ts`-style pattern applies: one module reads + validates + freezes at boot. Plain Ruby (Sinatra, scripts) typically uses `ENV.fetch` with manual validation in a `config.rb`.
-
-Runtime env-access syntax is in the table at the top of this skill. The principles (read once at boot, validate, freeze, export typed, mock-the-module in tests) are the same everywhere — only the library names change.
+| Python | `config.py` or `settings.py` | `pydantic-settings`, `dynaconf` |
+| Go | `internal/config/config.go` | `caarlos0/env`, `spf13/viper`; validate with `go-playground/validator` |
+| Ruby / Rails | `config/environments/*.rb` + credentials | Built-in `Rails.application.credentials` |
+| Java / Kotlin / Spring Boot | `@ConfigurationProperties` class | Jakarta Bean Validation |
+| Rust | `src/config.rs` | `config`/`figment` + `serde`; validate with `validator`; `.env` via `dotenvy` |
 
 ## Isolation patterns that actually work
 
-If the goal is **credential isolation across environments** (so a dev leak can't compromise prod), enforce it at **provisioning time**, not in code:
+Enforce **credential isolation** at provisioning time, not in code:
 
 - Register separate upstream credentials per env (OAuth clients, API keys, service accounts).
-- Each env's config source (Vercel env, Railway env, managed secret store, `.env.local`) holds only its own credential.
-- Code reads a single canonical name (`OAUTH_CLIENT_ID`, `STRIPE_SECRET_KEY`) and trusts the source to have populated the right value.
-- The two sources never share state — prod values live only in the prod secret store, never on developer machines — so a dev-machine compromise physically cannot mint prod tokens.
-
-Auth.js explicitly recommends this: *"we recommend using a different OAuth app for development/production so that you don't mix your test and production user base"* ([Auth.js deployment](https://authjs.dev/getting-started/deployment)). Clerk bakes the pattern in with `pk_test_` / `pk_live_` instance prefixes. Managed secret stores (AWS Secrets Manager, Doppler, HashiCorp Vault) don't prescribe naming conventions directly — they provide per-environment namespacing so the consumer's code can keep reading a single canonical name.
+- Each env's config source holds only its own credential — prod values live only in the prod secret store.
+- Code reads a single canonical name and trusts the source to have populated the right value.
 
 ## CI/CD and build-time config
 
-A subtlety that surfaces often in 2026 stacks:
-
-- **GitHub Actions `secrets.*` vs `vars.*`.** `secrets.*` is masked in logs and appropriate for credentials; `vars.*` is plaintext-logged and appropriate only for non-sensitive config. Never put a secret in `vars.*` just to "see the value" for debugging — log-scraped `vars.*` values are the same exposure class as committed `.env` files.
-- **Build-time vs runtime env.** A Docker image built with `ENV FOO=bar` bakes `FOO` into every running container. Runtime env (`docker run -e FOO=...`, Kubernetes `envFrom`) overrides per-container. For bundled frontend code (Next.js / Vite / etc.), build-time is the only injection point for `NEXT_PUBLIC_*` / `VITE_*` — see anti-pattern #4 above. Mixing the two silently (e.g. building the image with dev env, injecting prod env at runtime, but having `NEXT_PUBLIC_*` baked from the dev build) produces wrong-env client bundles.
-- **Fail-fast at process startup.** Validate required env vars on boot, not at first use. A late failure (missing `STRIPE_SECRET_KEY` on first checkout attempt at 3am) is much harder to diagnose than a refused startup.
+- **GitHub Actions `secrets.*` vs `vars.*`.** `secrets.*` is masked in logs; `vars.*` is plaintext-logged — never put a secret in `vars.*`.
+- **Build-time vs runtime env.** A Docker image built with `ENV FOO=bar` bakes `FOO` into every container. For `NEXT_PUBLIC_*` / `VITE_*`, build-time is the *only* injection point — see anti-pattern #4.
 
 ## Review checklist
 
-When reviewing code or plans that touch multi-env config:
-
 1. **Are there variables whose names contain `_DEV`, `_PROD`, `_STAGING`, `_TEST`?** Flag unless the "simultaneous values in one process" criterion applies.
-2. **Does the code branch on `NODE_ENV` / `ENVIRONMENT` / equivalent to pick a credential?** Collapse to a single env var read. (Behavior branching on the same env check is fine — see the behavior/credentials section.)
-3. **Are missing stateful env vars handled with a production-shaped sentinel default rather than fail-fast?** Fail loudly for credentials, URLs, bucket names. Convention defaults (`PORT`, `LOG_LEVEL`, retry counts) are fine.
-4. **Does the client bundle resolve env vars at build time?** Verify the prod bundle was built with prod env vars, not dev defaults.
-5. **Is "environment" conflated with "tenant" or "feature flag"?** Those are different axes; don't encode them in the same variable.
-6. **Are `process.env` / `Deno.env.get(...)` reads scattered across many files?** Consolidate into one `config.ts` module that reads + validates + freezes + exports once at boot.
-7. **Are env vars read inside functions/handlers instead of at module scope?** Request-path env reads re-parse strings on every call and hide missing-config failures from boot-time validation.
-8. **Is there boot-time validation of required env vars?** Zod / valibot / envalid schema parsed on startup — not "check on first use."
-9. **Do tests stub `process.env` directly instead of mocking the config module?** `vi.mock('./config', () => …)` keeps test isolation clean and gives typed overrides.
-10. **Are env var reads flowing into callers untyped (`string | undefined`)?** Either narrow via validation (preferred) or assert non-null at boot — don't let the union leak.
-
-## Sources
-
-- [12-Factor App §III Config](https://12factor.net/config)
-- [Next.js Environment Variables](https://nextjs.org/docs/app/guides/environment-variables)
-- [Rails Configuration](https://guides.rubyonrails.org/configuring.html)
-- [Kubernetes ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/)
-- [Docker Compose env-var best practices](https://docs.docker.com/compose/how-tos/environment-variables/best-practices/)
-- [Supabase Functions Secrets](https://supabase.com/docs/guides/functions/secrets)
+2. **Does the code branch on `NODE_ENV` / `ENVIRONMENT` to pick a credential?** Collapse to a single env var read.
+3. **Are missing stateful env vars handled with a production-shaped sentinel default?** Fail loudly for credentials, URLs, bucket names.
+4. **Does the client bundle resolve env vars at build time?** Verify the prod bundle was built with prod env vars.
+5. **Is "environment" conflated with "tenant" or "feature flag"?** Those are different axes.
+6. **Are `process.env` / `Deno.env.get(...)` reads scattered across many files?** Consolidate into `config.ts`.
+7. **Are env vars read inside functions/handlers instead of at module scope?** Request-path reads hide missing-config failures from boot-time validation.
+8. **Is there boot-time validation of required env vars?** Schema parsed on startup, not on first use.
+9. **Do tests stub `process.env` directly instead of mocking the config module?** `vi.mock('./config', () => …)` is cleaner.
+10. **Are env var reads flowing into callers untyped (`string | undefined`)?** Narrow via validation or assert non-null at boot.

--- a/claude/.claude/skills/config-environments/SKILL.md
+++ b/claude/.claude/skills/config-environments/SKILL.md
@@ -54,7 +54,7 @@ Don't mix idioms across modules in the same runtime — it makes scattered reads
 
 ## Why
 
-- **12-Factor §III Config** (<https://12factor.net/config>) explicitly rejects environment-named variables: *"env vars are granular controls, each fully orthogonal to other env vars. They are never grouped together as 'environments'."*
+- **12-Factor §III Config** explicitly rejects environment-named variables: *"env vars are granular controls, each fully orthogonal to other env vars. They are never grouped together as 'environments'."*
 - **Suffix patterns duplicate logic.** The "which environment am I?" decision is already encoded in which config source loaded. Adding `_DEV` / `_PROD` to variable names fans that decision out to runtime code that branches on `NODE_ENV`, requiring both values to be present where only one is ever read, leaking the env selector into every consumer.
 - **Rotation is cheaper with canonical names.** Rotating `STRIPE_SECRET_KEY` means updating one name in the prod store; rotating `STRIPE_SECRET_KEY_PROD` requires remembering which suffix prod reads and leaves a `_DEV` variant easy to update by mistake.
 - **Mainstream frameworks resolve per-env config by file/store selection, not renaming:** Next.js lookup order, Rails per-env credentials, Kubernetes Kustomize overlays, Docker Compose `--env-file` — all load different sources for the same variable name.
@@ -84,7 +84,7 @@ function getStripeKey() {
 }
 ```
 
-The prod deploy populates `STRIPE_SECRET_KEY` with the live key; the dev `.env` populates it with the test key. Stripe's `sk_live_…` vs `sk_test_…` value prefix encodes the mode inside the *value* — no code branch needed.
+✅ **Recommended pattern:** the prod deploy populates `STRIPE_SECRET_KEY` with the live key; the dev `.env` populates it with the test key. Stripe's `sk_live_…` vs `sk_test_…` value prefix encodes the mode inside the *value* — no code branch needed.
 
 ### 3. Sentinel-value defaults that silently leak production-shaped state
 

--- a/claude/.claude/skills/config-environments/SOURCES.md
+++ b/claude/.claude/skills/config-environments/SOURCES.md
@@ -1,0 +1,34 @@
+# Sources — config-environments
+
+Reference material that informed this skill. Not loaded during skill execution — consult when editing the skill to verify a rule still holds or to add new guidance.
+
+## Canonical references
+
+- **12-Factor App §III Config** — https://12factor.net/config  
+  Defines the canonical argument against environment-named variables. Key quote: *"env vars are granular controls, each fully orthogonal to other env vars. They are never grouped together as 'environments'."*
+
+- **Auth.js deployment guide** — https://authjs.dev/getting-started/deployment  
+  Explicitly recommends separate OAuth apps per environment: *"we recommend using a different OAuth app for development/production so that you don't mix your test and production user base."* Supports the credential-isolation-at-provisioning-time rule.
+
+- **Clerk instance prefixes** (`pk_test_` / `pk_live_`)  
+  Clerk bakes the pattern into their SDK: instance type is determined by the key prefix, not by a runtime `NODE_ENV` branch. Same principle as Stripe's `sk_live_`/`sk_test_` value encoding.
+
+## Framework resolution strategies (same variable name, different source)
+
+These show that mainstream frameworks all resolve per-env config by **source selection**, not **variable renaming**:
+
+- **Next.js** — lookup order: `process.env` → `.env.$(NODE_ENV).local` → `.env.local` → `.env.$(NODE_ENV)` → `.env`. Platform env stores (Vercel, Railway) populate `process.env` and win over file-based config.
+- **Rails** — `config/credentials/#{Rails.env}.yml.enc` per-env encrypted file, fallback to `config/credentials.yml.enc`.
+- **Kubernetes** — ConfigMap / Secret with Kustomize overlays or Helm values per env.
+- **Docker Compose** — `--env-file` flag selects a different source per invocation, not per-variable suffixes.
+- **Supabase Edge Functions** — local `supabase/functions/.env` vs `supabase secrets set FOO=…` in prod; same key name in both.
+
+## Managed secret stores
+
+AWS Secrets Manager, Doppler, HashiCorp Vault don't prescribe variable naming — they provide per-environment namespacing so the consumer's code keeps reading a single canonical name. The per-env isolation happens at the store level, not in code.
+
+## Language config libraries (extended notes)
+
+- **Go:** `kelseyhightower/envconfig` is widely used but largely unmaintained as of 2024; prefer `caarlos0/env` or `knadh/koanf`. In Go and Rust, parsing and validation are separate concerns (unlike Zod/pydantic which bundle them).
+- **Ruby (non-Rails):** Sinatra / scripts typically use `ENV.fetch` with manual validation in a `config.rb`.
+- **Rust:** `dotenvy` for `.env` loading; `config`/`figment` for parsing; `validator` or `garde` for field validation.

--- a/claude/.claude/skills/git-feature-branch-sync/SKILL.md
+++ b/claude/.claude/skills/git-feature-branch-sync/SKILL.md
@@ -23,69 +23,36 @@ user-invocable: false
 # Feature-Branch Sync: Rebase, Merge, and Force-Push
 
 Examples below use `main` / `origin/main` as the default-branch
-placeholder. If the repo's default is `master`, `trunk`, `develop`, or
-something else, substitute accordingly — check with
-`git symbolic-ref refs/remotes/origin/HEAD`.
+placeholder. Check with `git symbolic-ref refs/remotes/origin/HEAD`.
 
 Pre-creation concerns (branch naming, starting from a fresh default
-tip) live in the `branch-creation` skill — this one covers the
-lifecycle after the branch exists.
+tip) live in the `branch-creation` skill.
 
 ## The decision
 
-Keeping a feature branch current with the default branch has two shapes:
+- **Rebase** — `git fetch origin && git rebase origin/main`. Replays commits on top of the current default-branch tip. Linear history. Rewrites SHAs → force-push required.
+- **Merge** — `git merge --no-ff origin/main`. Creates a merge commit. Preserves SHAs. No force-push. (`--no-ff` matters: plain `git merge origin/main` fast-forwards if the feature branch is strictly behind.) `git pull --rebase` is equivalent to `fetch + rebase`; prefer the explicit two-step form.
 
-- **Rebase** — `git fetch origin && git rebase origin/main`. Replays your
-  commits on top of the current default-branch tip. Linear history.
-  Rewrites commit SHAs, so the next push must be a force-push.
-- **Merge** — `git merge --no-ff origin/main`. Creates a merge commit on
-  the feature branch. Preserves SHAs. No force-push needed. (`--no-ff`
-  matters: a plain `git merge origin/main` will fast-forward if the
-  feature branch is strictly behind, which is not what "merge main in"
-  implies.) `git pull --rebase` is equivalent to `fetch + rebase`;
-  prefer the explicit two-step form so the fetch result is auditable.
-
-**This skill's default is rebase on personal feature branches** — a
-reasonable and common choice, but not universal (many shops default to
-merge even on personal branches). Switch to merge when any
-*merge-required condition* below applies. Always defer to per-project
-policy when it contradicts this default.
+**Default is rebase on personal feature branches** — common choice, but not universal. Switch to merge when any *merge-required condition* applies. Defer to per-project policy when it contradicts this default.
 
 ## Merge-required conditions
 
 Any one of these → merge-main, do not rebase:
 
-- **Another active committer** on the branch. Rebasing rewrites history
-  they have based work on; they will need a recovery dance.
-- **Another branch is stacked on this one.** Rebase invalidates the
-  child's base. For stacked-PR workflows (Graphite, spr, stgit, or
-  hand-rolled), use `git rebase --update-refs` to update every
-  ancestor branch ref in one pass — or set `rebase.updateRefs=true` to
-  make this default. Then force-push each stacked branch separately,
-  leaf-to-root; a lease failure mid-stack leaves the stack half-rewritten.
-- **Review is already in flight** in a culture that anchors comments to
-  specific commit SHAs. Rebasing detaches comments from their anchors.
-  Some teams forbid rebase post-review; prefer "rework" commits.
-- **The repo's per-project policy mandates merge-only.** Example: the
-  repo's CLAUDE.md says "squash-merge PRs and use merge-main to stay
-  current" — defer to that. Check the project's CLAUDE.md or
-  project-scoped skill before recommending rebase.
+- **Another active committer** on the branch. Rebasing rewrites history they have based work on.
+- **Another branch is stacked on this one.** Rebase invalidates the child's base. Use `git rebase --update-refs` (or `rebase.updateRefs=true`) to update every ancestor branch in one pass, then force-push each stacked branch separately leaf-to-root.
+- **Review is in flight** in a culture that anchors comments to commit SHAs. Rebasing detaches comments. Prefer "rework" commits.
+- **The repo's per-project policy mandates merge-only.** Check the project's CLAUDE.md before recommending rebase.
 
-Otherwise, rebase. For long-lived branches that rebase repeatedly, set
-`rerere.enabled=true` — `rerere` caches conflict resolutions and replays
-them on re-conflict, which is the highest-ROI configuration for a
-weeks-old feature branch that eats main conflicts every few days.
+For long-lived branches, set `rerere.enabled=true` — `rerere` caches conflict resolutions and replays them on re-conflict.
 
 ## Force-push flavors
 
-A rebased feature branch has commits whose SHAs no longer match the
-remote's. The push must be a force-push. The flavor matters:
-
 | Flag | Safety check | When to use |
 |---|---|---|
-| `--force` | None. Unconditionally overwrites the remote ref. | Never on its own. |
+| `--force` | None. Unconditionally overwrites. | Never on its own. |
 | `--force-with-lease` | Fails if the remote ref moved since your last fetch. | Default for rebased feature branches. |
-| `--force-if-includes` | Additionally fails if the local branch doesn't contain the remote's tip. | Git ≥ 2.30. Pair with `--force-with-lease`. |
+| `--force-if-includes` | Also fails if local branch doesn't contain the remote's tip. | Git ≥ 2.30. Pair with `--force-with-lease`. |
 
 Recommended command after rebasing a personal branch:
 
@@ -93,20 +60,9 @@ Recommended command after rebasing a personal branch:
 git push --force-with-lease --force-if-includes
 ```
 
-`--force-with-lease` alone has a known gap: a stray `git fetch` updates
-the remote-tracking ref, which makes the lease look held even though you
-haven't integrated the remote's new commits. `--force-if-includes` closes
-that gap by checking your local reflog against the remote-tracking ref.
-Use both. Setting `push.useForceIfIncludes=true` makes the flag apply
-automatically whenever `--force-with-lease` is used.
+`--force-with-lease` alone has a gap: a stray `git fetch` updates the remote-tracking ref, making the lease look held even though you haven't integrated new commits. `--force-if-includes` closes that gap. Set `push.useForceIfIncludes=true` to apply it automatically.
 
-**Critical gotcha for automation and fresh clones:**
-`--force-with-lease` without an explicit expected value requires a
-*remote-tracking ref* (`refs/remotes/origin/<branch>`) to compute the
-lease against. In a shallow clone, `--single-branch` clone, or first
-push on a branch, that ref is missing or stale, and `--force-with-lease`
-silently degrades to `--force` semantics. In CI or any automated
-context, use the explicit form, which fails loudly if the ref is absent:
+**Critical gotcha for automation and fresh clones:** `--force-with-lease` without an explicit expected value requires a remote-tracking ref. In a shallow clone, `--single-branch` clone, or first push on a branch, that ref is missing and `--force-with-lease` silently degrades to `--force`. Use the explicit form:
 
 ```
 git fetch origin <branch>
@@ -114,149 +70,63 @@ git push --force-with-lease="<branch>:$(git rev-parse origin/<branch>)" \
          --force-if-includes origin <branch>
 ```
 
-`--force-if-includes` also depends on the local branch's reflog, which
-is empty on fresh/shallow clones — ephemeral CI runners hit this
-routinely. If reflogs are disabled (`core.logAllRefUpdates=false`),
-`--force-if-includes` silently no-ops.
+`--force-if-includes` also depends on the local branch's reflog, which is empty on fresh/shallow clones. If reflogs are disabled (`core.logAllRefUpdates=false`), `--force-if-includes` silently no-ops.
 
 ## Never-force-push targets
 
 Refuse to force-push to any of these regardless of flavor:
 
-- **The remote's default branch** — check
-  `git symbolic-ref refs/remotes/origin/HEAD` rather than assuming.
-  `main` is common but not universal (`master`, `trunk`, `develop`, or
-  anything else is possible); `init.defaultBranch` is the local default,
-  not authoritative.
-- `release/*`, `hotfix/*`, `staging`, `production`, `qa`, `uat`, or any
-  other shared / environment-tracking branch
-- **Tags** (`refs/tags/*`) — never force-push. Tags are the
-  supply-chain anchor for releases and SBOMs; signed tags especially
-  must never be rewritten.
+- **The remote's default branch** — check `git symbolic-ref refs/remotes/origin/HEAD`. `main` is common but not universal (`master`, `trunk`, `develop` are all possible).
+- `release/*`, `hotfix/*`, `staging`, `production`, `qa`, `uat`, or any other shared / environment-tracking branch
+- **Tags** (`refs/tags/*`) — supply-chain anchor for releases and SBOMs; never rewrite.
 - Any branch the user has not explicitly said is personal
 
-For those branches, rebasing the branch itself is also off the table —
-they keep merge history. Bringing the default branch into them (when it
-even makes sense) is a merge, not a rebase.
+For these branches, rebasing the branch itself is also off the table — they keep merge history.
 
-**Do not rely on server-side branch protection** to catch mistakes. On
-GitHub Free private repos the branch-protection API is inaccessible; on
-other repos the rules may simply not be configured. Treat the list above
-as the last line of defense, not the only one.
+**Do not rely on server-side branch protection** — GitHub Free private repos may lack protection API access; rules may not be configured. Treat this list as the last line of defense.
 
-**Protected-branch rules may further constrain strategy.** Configurations
-that change the decision tree:
-- **Required linear history** — rebase-merge or squash-merge only; a
-  merge commit from "merge-main-in" will be rejected at PR merge.
-- **Required signed commits** — see the signed-commits check in pre-flight.
-- **Required status checks** — force-pushing to a feature branch
-  invalidates in-flight check runs, re-enters the PR into pending, and
-  can knock it out of an auto-merge queue.
-- **Actor-specific rules (GitHub rulesets, GitLab push rules)** — bot
-  or app tokens may be excluded from force-push even when humans are
-  allowed. If an automated agent sees a 403 from `--force-with-lease`
-  but humans can push, this is likely the cause.
+**Protected-branch rules may further constrain strategy:**
+- **Required linear history** — rebase-merge or squash-merge only; a merge-main commit will be rejected at PR merge.
+- **Required signed commits** — rebase drops signatures. Ensure `commit.gpgsign=true` and the signing key is available non-interactively on CI, or merge instead.
+- **Required status checks** — force-pushing invalidates in-flight check runs and can knock PRs out of auto-merge queues.
+- **Actor-specific rules** — bot tokens may be excluded from force-push; a 403 from `--force-with-lease` when humans can push indicates this.
 
-Query the relevant protection API before acting on non-personal
-branches (GitHub: `GET /repos/:owner/:repo/rulesets/rules/branches/<branch>`).
-If the API is unreachable or the rules are ambiguous in an automated
-context, fail closed — merge instead.
+Query `GET /repos/:owner/:repo/rulesets/rules/branches/<branch>` before acting on non-personal branches. If unreachable or ambiguous in automation, fail closed — merge instead.
 
 ## Interaction with PR merge strategy
 
-The feature branch's internal history is either discarded or preserved
-at PR-merge time, depending on the repo's merge strategy:
+- **Squash-merge** — feature history collapses into one commit on `main`. Rebase vs merge-main affects only *your* dev experience.
+- **Rebase-merge** — feature commits replay onto `main`. Keeping the branch rebased keeps `main` clean; merge-main leaves merge commits in the replayed series.
+- **Merge-commit** — feature history plus a merge commit land on `main`. Merge-main noise becomes permanent `main` history.
 
-- **Squash-merge** — feature history collapses into one commit on `main`.
-  Rebase vs merge-main becomes purely about *your* dev experience during
-  the PR (reviewer diff cleanliness, conflict ergonomics). `main`'s
-  history is unaffected either way.
-- **Rebase-merge** — feature commits replay onto `main`. Internal
-  history survives. Keeping the branch rebased keeps `main` clean;
-  merge-main leaves merge commits in the replayed series.
-- **Merge-commit** — feature history plus a merge commit land on `main`.
-  Merge-main noise becomes permanent `main` history.
-
-**Before recommending rebase-only on history-cleanliness grounds, check
-the PR merge strategy.** On a squash-merge repo, the argument mostly
-dissolves; on a merge-commit repo, it's at its strongest. The project's
-CLAUDE.md should state the merge strategy.
+Check the PR merge strategy before recommending rebase on history-cleanliness grounds.
 
 ## Pre-flight checklist
 
 Before running `git push --force-with-lease` on a feature branch:
 
-1. Is this branch personal (only you committing)? If no → merge instead.
-   Verify with `git log --format='%ae %ce' origin/<branch> | sort -u` if
-   uncertain — include committer (`%ce`), not just author (`%ae`), so
-   rebases and cherry-picks don't hide a second contributor. On a
-   shallow clone, `git fetch --unshallow` first; the verification is
-   worthless against truncated history. Don't rely solely on a "yes
-   it's mine" claim.
+1. Is this branch personal? Verify with `git log --format='%ae %ce' origin/<branch> | sort -u` (include `%ce` for committer, not just `%ae` author — on a shallow clone, `git fetch --unshallow` first).
 2. Has anyone stacked a branch on this one? If yes → coordinate or merge.
-3. Is PR review in flight where comments anchor to SHAs? If yes → rework
-   commits, not rebase.
-4. Is the branch in the never-force-push list above (default branch,
-   environment branches, tags, shared branches)? → stop. Force-push is
-   forbidden regardless of flavor.
-5. Does the repo require signed commits? Rebase drops signatures and
-   recreates commits. Either (a) ensure `commit.gpgsign=true` **and the
-   signing key is available non-interactively** (critical on CI — a
-   headless runner without a provisioned key silently produces unsigned
-   commits that then fail `required_signatures`), or (b) skip rebase
-   and merge instead. Check `git config commit.gpgsign`, verify the key
-   is accessible, and confirm the repo's branch-protection
-   `required_signatures` rule.
-6. Running in CI / automation without a live human? Any ambiguous
-   "personal branch?" or "rebase safe?" answer → **fail closed, merge
-   instead**. Do not rebase when there's no one to escalate to.
-7. Using `--force-with-lease --force-if-includes` (with explicit
-   `<branch>:<expected-sha>` if on a fresh or shallow clone)? → proceed.
+3. Is PR review in flight with SHA-anchored comments? If yes → rework commits, not rebase.
+4. Is the branch in the never-force-push list? → stop.
+5. Does the repo require signed commits? Ensure `commit.gpgsign=true` and the key is accessible non-interactively, or merge.
+6. Running in CI without a live human? Any ambiguous answer → **fail closed, merge instead**.
+7. Using `--force-with-lease --force-if-includes` (explicit `<branch>:<sha>` on shallow/fresh clones)? → proceed.
 
 ## Recovery from a bad force-push
 
-`--force-with-lease --force-if-includes` will catch most of these. If
-one slips through and you clobber a teammate's commits:
+If `--force-with-lease --force-if-includes` slips and you clobber commits:
 
-1. Find the pre-force SHA. Your local `git reflog` has it if you
-   force-pushed; any teammate's `git reflog show origin/<branch>` in a
-   recently-fetched clone also has it. If no local reflog survives,
-   `git fsck --lost-found` may surface the dangling commits.
-2. **Pin it immediately**, before doing anything else. Reflog expiry and
-   `git gc` can reap unreachable commits; `gc.reflogExpireUnreachable`
-   defaults to 90 days but teams sometimes tighten it. Create a backup
-   ref: `git branch backup/<branch>-<date> <recovered-sha>`.
-3. **`git fetch origin` before restoring.** Someone may have pushed
-   legitimate reconciliation work on top of the clobbered tip. If so,
-   merge those commits onto the recovered SHA before pushing — do not
-   overwrite reconciliation work.
-4. Restore: `git push --force-with-lease origin <recovered-sha>:<branch>`
-5. Coordinate. The displaced teammate may have local work that now
-   needs rebasing onto the restored tip.
-
-For recovery from a bad *merge* (not force-push) that already landed,
-see `git-state-safety`.
+1. Find the pre-force SHA via `git reflog` or a teammate's `git reflog show origin/<branch>`. If no reflog survives, try `git fsck --lost-found`.
+2. **Pin it immediately** before `git gc` reaps it: `git branch backup/<branch>-<date> <recovered-sha>`.
+3. `git fetch origin` before restoring — someone may have pushed reconciliation work on top.
+4. Restore: `git push --force-with-lease origin <recovered-sha>:<branch>`.
+5. Coordinate with the displaced teammate.
 
 ## After a legitimate force-push: communicate
 
-Even a correct force-push invalidates commit SHAs, which breaks PR
-review-comment anchors, CI artifact links, external references, and
-bookmarks. After a rebase + force-push on a branch that has review
-activity, post a PR comment with:
-
-- The pre- and post-force SHAs, so reviewers can locate their prior
-  comments in their own checkouts.
-- A `git range-diff <old-sha>..<old-head> <new-sha>..<new-head>`
-  summary that shows which commits moved and what changed commit-by-
-  commit (not just the combined diff).
-
-This costs one comment and saves reviewers from guessing whether their
-prior feedback is addressed. Skip it only on branches with no active
-reviewers.
+Post a PR comment with the pre- and post-force SHAs and a `git range-diff <old-sha>..<old-head> <new-sha>..<new-head>` summary. Skip only on branches with no active reviewers.
 
 ## Rule of thumb
 
-On a personal branch with no stacked dependents and no in-flight review
-anchoring: `git fetch origin && git rebase origin/main && git push
---force-with-lease --force-if-includes`. Anywhere else: merge, or stop
-and ask.
+On a personal branch with no stacked dependents and no in-flight review anchoring: `git fetch origin && git rebase origin/main && git push --force-with-lease --force-if-includes`. Anywhere else: merge, or stop and ask.

--- a/claude/.claude/skills/git-state-safety/SKILL.md
+++ b/claude/.claude/skills/git-state-safety/SKILL.md
@@ -26,19 +26,16 @@ user-invocable: false
 During a merge/rebase/cherry-pick, the index holds a carefully constructed
 mid-state: files from both sides, deletion markers, unresolved paths.
 **Any mutation of the index before commit silently corrupts that state.**
-The resulting commit captures the corrupted index, not the intended merge.
 
-Common way this goes wrong: you want to compare how a file looks on another
-branch during conflict resolution, so you run
+Common way this goes wrong: you want to compare a file on another branch
+during conflict resolution, so you run
 `git checkout origin/main -- src/some-file.ts`. That *overwrites* the
-index entry for `src/some-file.ts`. If main had *deleted* some sibling
-file, the deletion marker can also get reset. The failure is silent until
-commit, when the captured tree is missing main's deletions.
+index entry for that path. If main had *deleted* a sibling file, the
+deletion marker can also get reset. The failure is silent until commit.
 
 ## Safe read-only inspection
 
-Use these during any fragile state. All are read-only — zero index /
-working-tree effect:
+Use these during any fragile state. All are read-only — zero index / working-tree effect:
 
 | Need | Command |
 |---|---|
@@ -48,15 +45,10 @@ working-tree effect:
 | Diff between two refs | `git diff <ref-a> <ref-b> -- <path>` |
 | Who last touched a line | `git blame <ref> -- <path>` |
 | Full tree inspection | `git ls-tree -r <ref>` |
-| **Inspect unmerged stages without touching the index** | `git ls-files -u` |
-| Need to actually build / test / browse another ref's code | `git worktree add <path> <ref>` (creates a disposable checkout that does not touch the current tree) |
+| Inspect unmerged stages without touching the index | `git ls-files -u` |
+| Genuinely need working files from another ref | `git worktree add <path> <ref>` |
 
-The worktree option is the escape hatch when you genuinely need working
-files: create a temporary worktree for *reading/testing*, do the
-investigation there, remove it with `git worktree remove <path>` (add
-`--force` if the worktree is dirty). Note: the worktree is for reading;
-do not run a test-merge inside it — that is a separate merge with
-separate state, not a rehearsal of the one you are in.
+The worktree option is the escape hatch when you need working files: create a temporary worktree for reading/testing, investigate there, remove with `git worktree remove <path>`. The worktree is for reading — do not run a test-merge inside it.
 
 ## Stage numbering
 
@@ -66,111 +58,49 @@ Mid-merge, the index holds up to three versions of each conflicted path:
 - **Stage 2** — current branch ("ours")
 - **Stage 3** — incoming branch ("theirs")
 
-`git ls-files -u` prints `<mode> <sha> <stage>\t<path>` for every
-conflicted entry. These stages are what `git checkout --ours <path>` and
-`git checkout --theirs <path>` select from (see the safe-mutations
-section below). Knowing the numbering is a prerequisite for reading
-`git status -s` codes (`UU`, `AU`, `UA`, `DU`, `UD`, `AA`, `DD`) without
-guessing.
+`git ls-files -u` prints `<mode> <sha> <stage>\t<path>` for every conflicted entry. These are what `git checkout --ours <path>` and `git checkout --theirs <path>` select from.
 
 ## Unsafe mutations during fragile state
 
-Never run these while merge/rebase/cherry-pick state exists, or while a
-conflict is partially resolved:
+Never run these while merge/rebase/cherry-pick state exists, or while a conflict is partially resolved:
 
-- `git checkout <ref> -- <path>` — overwrites the index entry for
-  `<path>`. Can silently cancel staged deletions, modifications, or
-  unresolved markers from the merge.
-- **`git restore --source=<ref> <path>` / `git restore --staged <path>`** —
-  modern equivalents of the `checkout` hazard, and the form current
-  agents will reach for by default. Same failure mode.
-- **`git add <path>` / `git add -p` on a conflicted path** — collapses
-  stages 1/2/3 into stage 0 using the current worktree content. If the
-  worktree still has `<<<<<<<` markers, you will commit literal conflict
-  markers. If it has a half-resolution, you lose the other stages
-  irrecoverably.
-- **`git update-index`** (any form) — direct index mutation, same or
-  worse blast radius.
-- **`git rm <path>` on a conflicted path** — resolves-by-deletion; easy
-  to do accidentally when intending to delete an unrelated file.
-- **`git clean`** — wipes untracked files, including merge leftovers
-  (conflict backups, `*.orig`, notes you may need).
-- **`git commit -a` / `git commit --all` during a merge** — pulls in
-  unresolved worktree state wholesale.
-- `git checkout <ref>` (branch switch) — blocked by git if conflicts are
-  present, but succeeds and throws away the merge state if you force
-  past it.
-- `git reset` — always destructive to index/working tree state. Even
-  `git reset HEAD <path>` can unstage a merge resolution.
-- `git stash` — on modern Git, stash refuses mid-merge by default; with
-  `-f` / `--all` or on older versions it resets `.git/MERGE_HEAD` and
-  there is no supported `stash pop` path that restores the merge state.
-  Treat as unrecoverable.
+- `git checkout <ref> -- <path>` — overwrites the index entry. Can silently cancel staged deletions, modifications, or unresolved markers.
+- **`git restore --source=<ref> <path>` / `git restore --staged <path>`** — modern equivalents; same failure mode.
+- **`git add <path>` / `git add -p` on a conflicted path** — collapses stages 1/2/3 into stage 0. If the worktree still has `<<<<<<<` markers, you commit literal conflict markers.
+- **`git update-index`** (any form) — direct index mutation, same or worse blast radius.
+- **`git rm <path>` on a conflicted path** — resolves-by-deletion; easy to do accidentally.
+- **`git clean`** — wipes untracked files, including merge leftovers and `*.orig` notes.
+- **`git commit -a` / `git commit --all` during a merge** — pulls in unresolved worktree state wholesale.
+- `git checkout <ref>` (branch switch) — blocked by git if conflicts are present, but succeeds and throws away merge state if forced.
+- `git reset` — always destructive to index/working tree state. Even `git reset HEAD <path>` can unstage a merge resolution.
+- `git stash` — refuses mid-merge by default; with `-f` / `--all` or on older Git it resets `.git/MERGE_HEAD`. No supported `stash pop` path restores merge state. Treat as unrecoverable.
 - `git switch` — same hazard as `git checkout <ref>`.
 
-If you need to abandon and restart a merge, use `git merge --abort` (or
-`git rebase --abort`, `git cherry-pick --abort`). Those are the only
-supported ways to back out. `git merge --abort` requires `ORIG_HEAD` to
-point at the pre-merge tip; if you have already run a `git reset` or
-started a second merge, `--abort` may refuse or restore the wrong state.
+To abandon and restart a merge, use `git merge --abort` (or `git rebase --abort`, `git cherry-pick --abort`). Note: `git merge --abort` requires `ORIG_HEAD` to point at the pre-merge tip — if you have already run a `git reset` or started a second merge, `--abort` may refuse or restore the wrong state.
 
 ## Safe per-path conflict resolution
 
-These *are* safe mid-merge and often the right tool for picking one
-side on a specific path:
+These *are* safe mid-merge:
 
-- `git checkout --ours <path>` — resolve `<path>` using stage 2 (current
-  branch's version). Stages the resolution.
-- `git checkout --theirs <path>` — resolve `<path>` using stage 3
-  (incoming branch's version). Stages the resolution.
+- `git checkout --ours <path>` — resolve using stage 2 (current branch's version). Stages the resolution.
+- `git checkout --theirs <path>` — resolve using stage 3 (incoming branch's version). Stages the resolution.
 
-These differ from `git checkout <ref> -- <path>` (unsafe, above)
-because they operate on the conflict stages already in the index, not
-by fetching from a ref. After running one, `<path>` moves from stages
-1/2/3 to stage 0 (resolved).
+These differ from `git checkout <ref> -- <path>` (unsafe) because they operate on conflict stages already in the index.
 
-**Cheap insurance:** `cp .git/index .git/index.bak` before any risky
-operation. Restore with `cp .git/index.bak .git/index` if the
-experiment goes sideways. Trivial cost, recoverable footgun.
+**Cheap insurance:** `cp .git/index .git/index.bak` before any risky operation. Restore with `cp .git/index.bak .git/index`.
 
 ## Recovery when a bad merge already landed
 
-The worst case: the merge commit is already created and the merge tree
-is wrong (e.g., files deleted on the other side are still present on
-your branch).
+**If the bad merge is local-only (not yet pushed):** `git reset --hard ORIG_HEAD` — `git merge` writes `ORIG_HEAD` to the pre-merge tip. Only works pre-push and only if no subsequent merge/reset has run.
 
-**If the bad merge is local-only (not yet pushed):** `git reset --hard
-ORIG_HEAD` — `git merge` writes `ORIG_HEAD` to the pre-merge tip, so
-this is the single-command undo. Only works pre-push and only if you
-have not run another merge / reset since. This is the highest-leverage
-recovery there is; try it first.
+**If the bad merge is already pushed** and no-force-push applies, reverse the effect with a follow-on commit. This assumes `git status` shows a clean tree (the merge is committed; fragile-index rules above no longer apply).
 
-**If the bad merge is already pushed** and the no-force-push rule binds,
-the recipe below reverses the effect by restoring upstream content in a
-follow-on commit.
-
-This recipe applies **after** the bad merge is already committed —
-`git status` shows a clean tree (including empty `git diff --cached`)
-and the merge commit is in history. The fragile-index rules in the
-sections above apply during the *active* merge; once the merge is
-committed, standard index operations (`git rm`, `git checkout <ref> -- <path>`)
-are safe again.
-
-For the rest of this section, **`<upstream>`** means the ref whose state
-the merge was intended to produce — typically `origin/<target-branch>`
-at the time of the attempted merge.
+For the rest of this section, **`<upstream>`** = the ref whose state the merge was intended to produce.
 
 ### Recipe
 
-1. **Confirm the damage:**
-   - `git diff <upstream>...<your-branch> --name-status` shows what your
-     branch has that upstream does not.
-   - `git show <merge-commit> --name-status` should match expectations;
-     if the merge commit only touches the conflict-resolved files and
-     nothing else, that is the smoking gun.
-2. **Partition the diverged files by how they diverged.** Piping a mixed
-   list to `xargs git checkout` silently skips deletions; handle each
-   class explicitly:
+1. **Confirm the damage:** `git diff <upstream>...<your-branch> --name-status`
+2. **Partition and fix by diff filter:**
 
    ```
    # Files the branch kept that upstream DELETED — remove them
@@ -185,59 +115,23 @@ at the time of the attempted merge.
    git diff <upstream>...<your-branch> --diff-filter=D --name-only \
      | xargs -I{} git checkout <upstream> -- {}
    ```
-3. **Verify the diff is now clean:** `git diff <upstream>...<your-branch>
-   --name-status` should list only the files your change actually
-   touches.
-4. **Commit the recovery** as its own commit on top — do not amend the
-   merge commit and do not force-push. The bad merge stays in history
-   but its effect is reversed by the recovery commit. Amending is worse
-   than a follow-up because other branches / PRs / comments may already
-   reference the merge commit SHA.
-5. Pre-commit hooks may complain about pre-existing warnings in the
-   restored files (the upstream content that you did not author). If so,
-   request explicit engineer approval before using `--no-verify`;
-   skipping hooks without approval is forbidden.
+3. **Verify:** `git diff <upstream>...<your-branch> --name-status` should list only files your change actually touches.
+4. **Commit the recovery** as its own commit — do not amend the merge commit and do not force-push. The bad merge stays in history but its effect is reversed.
+5. Pre-commit hooks may complain about pre-existing warnings in restored files. Request explicit engineer approval before using `--no-verify`.
 
-Force-push + coordination is a legitimate alternative on short-lived
-single-author branches or release branches where the bad merge poisoned
-a tag candidate. That is out of scope for this skill — see
-`git-feature-branch-sync` for the never-force-push list and the
-`--force-with-lease --force-if-includes` recipe.
+### If GitHub's PR diff still shows restored files
 
-### If GitHub's PR diff still shows restored files after the recovery commit
-
-GitHub's Files-changed view renders `git diff <base>...<head>`
-(three-dot) — the diff from the branch's *merge-base* to its tip, not
-from the upstream's current tip to the branch's tip. Any file modified
-on the branch relative to the merge-base stays in the PR diff even
-after the content now matches current `<upstream>`.
-
-The recovery commit restores content but cannot rewrite history. If
-the clean PR diff matters (visual review scope, CI file-filter
-triggers, reviewer trust), the only clean fix is to **open a fresh
-branch off current upstream containing only the intended changes**,
-then close the original PR and point at the new one. Further commits
-on the corrupted branch do not reduce the set of files GitHub shows.
+GitHub's Files-changed view renders `git diff <base>...<head>` (three-dot) — diff from the branch's *merge-base* to its tip. Files modified on the branch relative to the merge-base remain in the PR diff even after content now matches `<upstream>`. The only clean fix is a **fresh branch off current upstream** containing only the intended changes.
 
 ## Rule of thumb
 
-If `git status` shows `MERGING`, `REBASING`, `CHERRY-PICKING`, or any
-`UU` / `DU` / `UD` / `AU` / `UA` / `AA` / `DD` entries, treat the index
-as read-only for inspection purposes. If you need to see something from
-another ref, use the read-only operations in the table above.
+If `git status` shows `MERGING`, `REBASING`, `CHERRY-PICKING`, or any `UU` / `DU` / `UD` / `AU` / `UA` / `AA` / `DD` entries, treat the index as read-only.
 
-**Detection without parsing `git status`:** in scripts, checking file
-existence is more robust and locale-independent. Any of these means a
-fragile state:
+**Detection in scripts** (locale-independent):
 
 - `test -e "$(git rev-parse --git-path MERGE_HEAD)"` — active merge
-- `test -d "$(git rev-parse --git-path rebase-merge)"` — active rebase (interactive / merge-based)
-- `test -d "$(git rev-parse --git-path rebase-apply)"` — active rebase (apply-based)
+- `test -d "$(git rev-parse --git-path rebase-merge)"` — active interactive/merge rebase
+- `test -d "$(git rev-parse --git-path rebase-apply)"` — active apply-based rebase
 - `test -e "$(git rev-parse --git-path CHERRY_PICK_HEAD)"` — active cherry-pick
 
-**When in doubt, the reflog is your safety net.** `git reflog` logs
-every ref movement for 90 days by default (`gc.reflogExpire`). An
-accidental `reset --hard` or `checkout` is usually recoverable via
-`git reset --hard HEAD@{1}` or similar, *if you catch it before the
-reflog entry expires and before another `git gc` reaps the orphaned
-commits.*
+**The reflog is your safety net.** `git reflog` logs every ref movement for 90 days (`gc.reflogExpire`). An accidental `reset --hard` is usually recoverable via `git reset --hard HEAD@{1}` if caught before `git gc` reaps the orphaned commits.


### PR DESCRIPTION
## Summary

- Trims \`config-environments\` from 260 → 179 lines: consolidated Why bullet points, tightened language equivalents table, merged verbose code fence comments into prose. Sources section moved to \`REFERENCES.md\` (co-located editorial context, not loaded during skill execution). Inline 12-Factor URL removed (link now in REFERENCES.md). Added "Recommended pattern" label to Stripe value-prefix example for contrast with the bad pattern above it.
- Trims \`git-feature-branch-sync\` from 263 → 132 lines: condensed decision/merge-required/force-push sections into tighter prose; restored the "no rebasing shared branches" rule that the \`/code-review\` pass caught.
- Trims \`git-state-safety\` from 244 → 137 lines: collapsed verbose recovery recipe prose, tightened the GitHub PR diff caveat subsection, and simplified rule-of-thumb section.
- Adds \`REFERENCES.md\` to \`config-environments/\` with canonical references (12-Factor, Auth.js, Clerk, framework resolution strategies, library notes) not loaded at runtime. Name follows Anthropic's content-descriptive convention for co-located skill supplementary files.
- Documents the \`REFERENCES.md\` convention in README so human editors know to look for it.

All TRIGGER/DO NOT TRIGGER frontmatter intact. All routing tokens (\`_DEV\`, \`_PROD\`, \`--force-with-lease\`, \`--force-if-includes\`, \`MERGING\`, \`REBASING\`, \`CHERRY-PICKING\`, stage codes, etc.) preserved. Checklists and anti-pattern rules preserved.

## Test plan

- [ ] Line counts: \`config-environments\` 179, \`git-feature-branch-sync\` 132, \`git-state-safety\` 137 — all ≤200
- [ ] Read each trimmed skill and verify TRIGGER/DO NOT TRIGGER frontmatter unchanged
- [ ] Spot-check routing tokens \`_DEV\`/\`_PROD\`/\`_STAGING\`, \`--force-with-lease\`, \`--force-if-includes\`, \`MERGING\`/\`REBASING\`/\`CHERRY-PICKING\` still appear in respective skills
- [ ] Verify \`config-environments/REFERENCES.md\` exists and contains 12-Factor, Auth.js, Clerk, and framework references
- [ ] Verify \`config-environments/SKILL.md\` no longer contains \`12factor.net\` URL inline

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)