### PR TITLE
statusline: fix rounding, shrink bar, dynamic path/branch truncation

### DIFF
--- a/claude/.claude/statusline-command.sh
+++ b/claude/.claude/statusline-command.sh
@@ -59,8 +59,8 @@ rate_color() {
 }
 
 if [ -n "$rate_5h" ] || [ -n "$rate_7d" ]; then
-    h_pct="${rate_5h:-0}"
-    d_pct="${rate_7d:-0}"
+    h_pct=$(printf "%.0f" "${rate_5h:-0}")
+    d_pct=$(printf "%.0f" "${rate_7d:-0}")
     h_color=$(rate_color "$h_pct")
     d_color=$(rate_color "$d_pct")
     rate_display=$(printf "${h_color}5h:${h_pct}%%${RESET} ${d_color}7d:${d_pct}%%${RESET}")
@@ -80,9 +80,13 @@ if [ -n "$cwd" ] && [ -d "$cwd" ]; then
     fi
 fi
 
-# --- Working directory (shorten home) ---
+# --- Working directory (shorten home, truncate long paths) ---
 home_dir="$HOME"
 short_cwd="${cwd/#$home_dir/~}"
+max_path_len=25
+if [ "${#short_cwd}" -gt "$max_path_len" ]; then
+    short_cwd="…${short_cwd: -$((max_path_len - 1))}"
+fi
 
 # --- Assemble status line ---
 echo -e "${CYAN}${model}${RESET}  ${ctx_display}  ${rate_display}  ${YELLOW}${cost_display}${RESET}  ${BLUE}${short_cwd}${RESET}${git_branch}"

--- a/claude/.claude/statusline-command.sh
+++ b/claude/.claude/statusline-command.sh
@@ -73,8 +73,8 @@ cost_display=$(printf "\$%.4f" "$total_cost")
 
 # --- Dynamic truncation limits based on terminal width ---
 # Fixed visible chars: model(~12) + separators(~8) + bar([10 wide]=15) + rates(12) + cost(7) ≈ 54
-_terminal_cols=$(tput cols 2>/dev/null)
-[[ "$_terminal_cols" =~ ^[0-9]+$ ]] || _terminal_cols=${COLUMNS:-120}
+_terminal_cols=$(stty size </dev/tty 2>/dev/null | awk '{print $2}')
+[[ "$_terminal_cols" =~ ^[0-9]+$ ]] || _terminal_cols=${COLUMNS:-80}
 _available=$(( _terminal_cols - 54 ))
 [ "$_available" -lt 20 ] && _available=20
 max_path_len=$(( _available * 55 / 100 ))

--- a/claude/.claude/statusline-command.sh
+++ b/claude/.claude/statusline-command.sh
@@ -24,7 +24,7 @@ RED='\033[31m'
 # --- Context progress bar ---
 build_bar() {
     local pct="${1:-0}"
-    local width=20
+    local width=10
     local filled=$(( pct * width / 100 ))
     local empty=$(( width - filled ))
     local bar=""
@@ -46,7 +46,7 @@ if [ -n "$used_pct" ]; then
     fi
     ctx_display=$(printf "${bar_color}[${bar}]${RESET} ${used_int}%%")
 else
-    ctx_display=$(printf "${DIM}[--------------------] --%${RESET}")
+    ctx_display=$(printf "${DIM}[----------] --%${RESET}")
 fi
 
 # --- Rate limit display (5h / 7d) ---
@@ -71,22 +71,32 @@ fi
 # --- Session cost ---
 cost_display=$(printf "\$%.4f" "$total_cost")
 
+# --- Dynamic truncation limits based on terminal width ---
+# Fixed visible chars: model(~12) + separators(~8) + bar([10 wide]=15) + rates(12) + cost(7) ≈ 54
+_terminal_cols=$(tput cols 2>/dev/null)
+[[ "$_terminal_cols" =~ ^[0-9]+$ ]] || _terminal_cols=${COLUMNS:-120}
+_available=$(( _terminal_cols - 54 ))
+[ "$_available" -lt 20 ] && _available=20
+max_path_len=$(( _available * 55 / 100 ))
+_max_branch_name=$(( _available * 45 / 100 - 3 ))
+[ "$max_path_len" -lt 8 ] && max_path_len=8
+[ "$_max_branch_name" -lt 4 ] && _max_branch_name=4
+
 # --- Git branch ---
 git_branch=""
 if [ -n "$cwd" ] && [ -d "$cwd" ]; then
     branch=$(git -C "$cwd" --no-optional-locks symbolic-ref --short HEAD 2>/dev/null)
     if [ -n "$branch" ]; then
-        if [ "${#branch}" -gt 13 ]; then
-            branch="${branch:0:12}…"
+        if [ "${#branch}" -gt "$_max_branch_name" ]; then
+            branch="${branch:0:$((_max_branch_name - 1))}…"
         fi
         git_branch=$(printf " ${MAGENTA}(%s)${RESET}" "$branch")
     fi
 fi
 
-# --- Working directory (shorten home, truncate long paths) ---
+# --- Working directory (shorten home, truncate to fit terminal) ---
 home_dir="$HOME"
 short_cwd="${cwd/#$home_dir/~}"
-max_path_len=15
 if [ "${#short_cwd}" -gt "$max_path_len" ]; then
     short_cwd="…${short_cwd: -$((max_path_len - 1))}"
 fi

--- a/claude/.claude/statusline-command.sh
+++ b/claude/.claude/statusline-command.sh
@@ -76,6 +76,9 @@ git_branch=""
 if [ -n "$cwd" ] && [ -d "$cwd" ]; then
     branch=$(git -C "$cwd" --no-optional-locks symbolic-ref --short HEAD 2>/dev/null)
     if [ -n "$branch" ]; then
+        if [ "${#branch}" -gt 13 ]; then
+            branch="${branch:0:12}…"
+        fi
         git_branch=$(printf " ${MAGENTA}(%s)${RESET}" "$branch")
     fi
 fi
@@ -83,7 +86,7 @@ fi
 # --- Working directory (shorten home, truncate long paths) ---
 home_dir="$HOME"
 short_cwd="${cwd/#$home_dir/~}"
-max_path_len=25
+max_path_len=15
 if [ "${#short_cwd}" -gt "$max_path_len" ]; then
     short_cwd="…${short_cwd: -$((max_path_len - 1))}"
 fi


### PR DESCRIPTION
## Summary
- Round `h_pct`/`d_pct` via `printf "%.0f"` so float values like `7.0000000000000001` render as integers
- Shrink progress bar from 20 to 10 chars wide, freeing ~10 visible chars
- Replace hardcoded path/branch truncation limits with `stty size </dev/tty`-based allocation: path gets 55% and branch name 45% of chars remaining after fixed elements, scaling with actual terminal width on each invocation. Falls back to `$COLUMNS`, then 80, when the controlling TTY is unavailable. (`tput cols` was tried first but fails silently when the hook subprocess has stdout redirected.)

## Test plan
- [ ] Verify rate limit percentages display as integers (e.g. `5h:22% 7d:7%`)
- [ ] Verify path and branch expand when the terminal window is widened
- [ ] Verify both truncate gracefully on a narrow terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)