### PR TITLE
Add SubagentStart session capture, settings model/effort guard, and plan-review gate

### DIFF
--- a/claude/.claude/hooks/guard-settings-model-effort.sh
+++ b/claude/.claude/hooks/guard-settings-model-effort.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# PreToolUse hook: block git commit when claude/.claude/settings.json has
+# model or effortLevel changes staged relative to main.
+#
+# Purpose: model/effortLevel overrides in settings.json are typically session-
+# scoped ephemeral changes (e.g., /config model opus). Accidentally committing
+# them modifies the shipped config for all users. This hook catches that class
+# of accidental commit and surfaces it before git runs.
+#
+# Defense-in-depth: the hook filters its own input by tool name AND checks
+# whether settings.json is actually staged — do not rely solely on the
+# settings.json `if` condition in settings.json.
+#
+# Exit codes:
+#   0      — allow (no opinion)
+#   0+JSON — deny (model or effortLevel changed in staged settings.json)
+
+INPUT=$(cat)
+TOOL_NAME=$(printf '%s\n' "$INPUT" | jq -r '.tool_name // empty')
+
+# Only gate Bash tool calls.
+if [ "$TOOL_NAME" != "Bash" ]; then
+  exit 0
+fi
+
+COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command // empty')
+
+# Only gate commands that contain a git commit invocation.
+if ! printf '%s\n' "$COMMAND" | grep -qE '(^|&&?|;|\|\|?)\s*git\s+commit(\s|$)'; then
+  exit 0
+fi
+
+# Only proceed if inside a git repo.
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$REPO_ROOT" ]; then
+  exit 0
+fi
+
+SETTINGS_REPO_PATH="claude/.claude/settings.json"
+
+# Check whether settings.json is staged at all.
+if ! git diff --cached --name-only 2>/dev/null | grep -qF "$SETTINGS_REPO_PATH"; then
+  exit 0
+fi
+
+# Diff the staged version against main. If main doesn't have the file yet
+# (unlikely but possible on a brand-new branch), diff against /dev/null.
+STAGED_CONTENT=$(git show :"$SETTINGS_REPO_PATH" 2>/dev/null)
+if ! git show "main:$SETTINGS_REPO_PATH" >/dev/null 2>&1; then
+  MAIN_CONTENT=""
+else
+  MAIN_CONTENT=$(git show "main:$SETTINGS_REPO_PATH" 2>/dev/null)
+fi
+
+# Extract model and effortLevel from both versions using jq.
+STAGED_MODEL=$(printf '%s\n' "$STAGED_CONTENT" | jq -r '.model // ""' 2>/dev/null)
+STAGED_EFFORT=$(printf '%s\n' "$STAGED_CONTENT" | jq -r '.effortLevel // ""' 2>/dev/null)
+MAIN_MODEL=$(printf '%s\n' "$MAIN_CONTENT" | jq -r '.model // ""' 2>/dev/null)
+MAIN_EFFORT=$(printf '%s\n' "$MAIN_CONTENT" | jq -r '.effortLevel // ""' 2>/dev/null)
+
+CHANGED=0
+if [ "$STAGED_MODEL" != "$MAIN_MODEL" ]; then
+  CHANGED=1
+fi
+if [ "$STAGED_EFFORT" != "$MAIN_EFFORT" ]; then
+  CHANGED=1
+fi
+
+if [ "$CHANGED" -eq 0 ]; then
+  exit 0
+fi
+
+REASON="settings.json has model/effortLevel changes — commit these only if intentional. The staged settings.json differs from main on model or effortLevel. These fields are typically set per-session via /config and should not be committed unless you are intentionally shipping a routing change. Unstage the file (git restore --staged claude/.claude/settings.json) to allow the commit, or proceed only if this is a deliberate routing update."
+REASON_JSON=$(printf '%s' "$REASON" | jq -Rs .)
+printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' "$REASON_JSON"

--- a/claude/.claude/hooks/require-plan-review.sh
+++ b/claude/.claude/hooks/require-plan-review.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
-# PreToolUse hook: block Write/Edit on implementation files when a plan file
-# exists in .claude/plans/ without a current plan-review marker for this session.
+# PreToolUse hook: block Write/Edit when a plan file exists in .claude/plans/
+# without a current plan-review marker for this session.
 #
-# Opt-in: only active when CLAUDE_REQUIRE_PLAN_REVIEW=1 is set OR a
-# .claude/require-plan-review sentinel file exists in the repo root.
-# This prevents non-claude-config projects from being forced into the gate.
+# Globally applied (no opt-in), consistent with require-code-review.sh,
+# require-ready-for-review.sh, and require-respond-pr.sh.
+# Projects without a .claude/plans/ directory or with no plan files pass
+# through silently — the plan-existence check is the built-in filter.
 #
 # Marker layout:
 #   ~/.claude/plan-review-markers/<repo-hash>.<session_id>
@@ -27,21 +28,8 @@ if [ "$TOOL_NAME" != "Write" ] && [ "$TOOL_NAME" != "Edit" ]; then
   exit 0
 fi
 
-# Check opt-in: env var or sentinel file.
-REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
-
-OPT_IN=0
-if [ "${CLAUDE_REQUIRE_PLAN_REVIEW:-}" = "1" ]; then
-  OPT_IN=1
-elif [ -n "$REPO_ROOT" ] && [ -f "$REPO_ROOT/.claude/require-plan-review" ]; then
-  OPT_IN=1
-fi
-
-if [ "$OPT_IN" -eq 0 ]; then
-  exit 0
-fi
-
 # Not in a git repo — can't check for plan files or key the marker.
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 if [ -z "$REPO_ROOT" ]; then
   exit 0
 fi

--- a/claude/.claude/hooks/require-plan-review.sh
+++ b/claude/.claude/hooks/require-plan-review.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# PreToolUse hook: block Write/Edit on implementation files when a plan file
+# exists in .claude/plans/ without a current plan-review marker for this session.
+#
+# Opt-in: only active when CLAUDE_REQUIRE_PLAN_REVIEW=1 is set OR a
+# .claude/require-plan-review sentinel file exists in the repo root.
+# This prevents non-claude-config projects from being forced into the gate.
+#
+# Marker layout:
+#   ~/.claude/plan-review-markers/<repo-hash>.<session_id>
+# Written by the /plan-review skill when a clean review completes.
+# The marker is keyed per-session (not a singleton) to prevent parallel
+# sessions from overwriting each other's markers.
+#
+# Defense-in-depth: the hook filters its own input by tool name; do not
+# rely solely on the settings.json matcher condition.
+#
+# Exit codes:
+#   0      — allow (no opinion)
+#   0+JSON — deny (plan exists but no review marker for this session)
+
+INPUT=$(cat)
+TOOL_NAME=$(printf '%s\n' "$INPUT" | jq -r '.tool_name // empty')
+
+# Only gate Write and Edit tool calls.
+if [ "$TOOL_NAME" != "Write" ] && [ "$TOOL_NAME" != "Edit" ]; then
+  exit 0
+fi
+
+# Check opt-in: env var or sentinel file.
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+
+OPT_IN=0
+if [ "${CLAUDE_REQUIRE_PLAN_REVIEW:-}" = "1" ]; then
+  OPT_IN=1
+elif [ -n "$REPO_ROOT" ] && [ -f "$REPO_ROOT/.claude/require-plan-review" ]; then
+  OPT_IN=1
+fi
+
+if [ "$OPT_IN" -eq 0 ]; then
+  exit 0
+fi
+
+# Not in a git repo — can't check for plan files or key the marker.
+if [ -z "$REPO_ROOT" ]; then
+  exit 0
+fi
+
+# Check whether any plan file exists under .claude/plans/ in the project.
+PLANS_DIR="$REPO_ROOT/.claude/plans"
+if [ ! -d "$PLANS_DIR" ]; then
+  exit 0
+fi
+
+PLAN_COUNT=$(find "$PLANS_DIR" -maxdepth 1 -name "*.md" -o -name "*.txt" 2>/dev/null | wc -l)
+if [ "$PLAN_COUNT" -eq 0 ]; then
+  exit 0
+fi
+
+# Plans exist — check for a current plan-review marker for this session.
+SESSION_ID=$(printf '%s\n' "$INPUT" | jq -r '.session_id // empty')
+
+# Without session_id, we cannot key a per-session marker — block.
+if [ -n "$SESSION_ID" ]; then
+  REPO_HASH=$(printf '%s' "$REPO_ROOT" | sha256sum | awk '{print $1}')
+  MARKER="$HOME/.claude/plan-review-markers/$REPO_HASH.$SESSION_ID"
+  if [ -f "$MARKER" ]; then
+    exit 0
+  fi
+fi
+
+REASON="Write/Edit blocked by plan-review gate: a plan file exists in .claude/plans/ but no plan-review marker was found for this session. Run the /plan-review skill now. When the review is clean, the skill will record the review in ~/.claude/plan-review-markers/ and this write will be allowed through on retry."
+REASON_JSON=$(printf '%s' "$REASON" | jq -Rs .)
+printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' "$REASON_JSON"

--- a/claude/.claude/hooks/tests/test_hooks.py
+++ b/claude/.claude/hooks/tests/test_hooks.py
@@ -27,6 +27,8 @@ DENY_PRIVATE_PROJECT_REFS_HOOK = HOOKS_DIR / "deny-private-project-refs.sh"
 STOW_REMINDER_HOOK = HOOKS_DIR / "require-stow-reminder.sh"
 WORKTREE_HOOK = HOOKS_DIR / "require-worktree-for-git-writes.sh"
 CAPTURE_SESSION_ID_HOOK = HOOKS_DIR / "capture-session-id.sh"
+GUARD_SETTINGS_MODEL_EFFORT_HOOK = HOOKS_DIR / "guard-settings-model-effort.sh"
+REQUIRE_PLAN_REVIEW_HOOK = HOOKS_DIR / "require-plan-review.sh"
 
 SKILLS_DIR = HOOKS_DIR.parent / "skills"
 CODE_REVIEW_SKILL = SKILLS_DIR / "code-review" / "SKILL.md"
@@ -3982,3 +3984,429 @@ class TestRequireReadyForReview:
             "SKILL.md deactivate-gate recipe ran but the marker is still "
             "present — skill and hook disagree on the marker path."
         )
+
+
+# ---------------------------------------------------------------------------
+# guard-settings-model-effort.sh
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def settings_repo(tmp_path):
+    """Git repo with a main branch and a staged settings.json change.
+
+    Mirrors the structure the hook sees at commit time: a committed
+    baseline on `main`, then a staged modification in the working tree.
+    The repo path matches `claude/.claude/settings.json` — the exact
+    path the hook checks for.
+    """
+    repo = tmp_path / "settings-repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "checkout", "-b", "main"],
+        cwd=repo, check=True, capture_output=True,
+    )
+    # Create the settings.json at the repo-relative path the hook checks.
+    settings_dir = repo / "claude" / ".claude"
+    settings_dir.mkdir(parents=True)
+    settings_file = settings_dir / "settings.json"
+    settings_file.write_text('{"model": "sonnet", "effortLevel": "normal"}\n')
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=repo, check=True)
+    return repo, settings_file
+
+
+def stage_settings(repo: Path, settings_file: Path, content: str) -> None:
+    """Write `content` to `settings_file` and stage it."""
+    settings_file.write_text(content)
+    subprocess.run(
+        ["git", "add", "claude/.claude/settings.json"],
+        cwd=repo, check=True,
+    )
+
+
+class TestGuardSettingsModelEffort:
+    def test_model_change_denies_commit(self, settings_repo):
+        repo, settings_file = settings_repo
+        stage_settings(repo, settings_file, '{"model": "opus", "effortLevel": "normal"}\n')
+        assert (
+            run_hook(
+                GUARD_SETTINGS_MODEL_EFFORT_HOOK,
+                bash_input("git commit -m 'update settings'"),
+                cwd=repo,
+            )
+            == "deny"
+        )
+
+    def test_effort_level_change_denies_commit(self, settings_repo):
+        repo, settings_file = settings_repo
+        stage_settings(repo, settings_file, '{"model": "sonnet", "effortLevel": "high"}\n')
+        assert (
+            run_hook(
+                GUARD_SETTINGS_MODEL_EFFORT_HOOK,
+                bash_input("git commit -m 'update settings'"),
+                cwd=repo,
+            )
+            == "deny"
+        )
+
+    def test_both_changed_denies_commit(self, settings_repo):
+        repo, settings_file = settings_repo
+        stage_settings(repo, settings_file, '{"model": "opus", "effortLevel": "high"}\n')
+        assert (
+            run_hook(
+                GUARD_SETTINGS_MODEL_EFFORT_HOOK,
+                bash_input("git commit -m 'routing change'"),
+                cwd=repo,
+            )
+            == "deny"
+        )
+
+    def test_unrelated_settings_change_allows(self, settings_repo):
+        """Changing a key other than model/effortLevel must not block."""
+        repo, settings_file = settings_repo
+        stage_settings(repo, settings_file, '{"model": "sonnet", "effortLevel": "normal", "theme": "dark"}\n')
+        assert (
+            run_hook(
+                GUARD_SETTINGS_MODEL_EFFORT_HOOK,
+                bash_input("git commit -m 'add theme'"),
+                cwd=repo,
+            )
+            == "allow"
+        )
+
+    def test_settings_not_staged_allows(self, settings_repo):
+        """If settings.json is not staged, the hook has no opinion."""
+        repo, settings_file = settings_repo
+        # Stage a different file, not settings.json.
+        other = repo / "other.txt"
+        other.write_text("change\n")
+        subprocess.run(["git", "add", "other.txt"], cwd=repo, check=True)
+        assert (
+            run_hook(
+                GUARD_SETTINGS_MODEL_EFFORT_HOOK,
+                bash_input("git commit -m 'other change'"),
+                cwd=repo,
+            )
+            == "allow"
+        )
+
+    def test_non_commit_command_allows(self, settings_repo):
+        """Hook only fires on git commit; other commands pass through."""
+        repo, settings_file = settings_repo
+        stage_settings(repo, settings_file, '{"model": "opus"}\n')
+        assert (
+            run_hook(
+                GUARD_SETTINGS_MODEL_EFFORT_HOOK,
+                bash_input("git status"),
+                cwd=repo,
+            )
+            == "allow"
+        )
+
+    def test_non_bash_tool_allows(self, settings_repo):
+        """Edit/Write tool calls pass through — hook is Bash-only."""
+        repo, settings_file = settings_repo
+        assert (
+            run_hook(
+                GUARD_SETTINGS_MODEL_EFFORT_HOOK,
+                edit_input(str(settings_file)),
+                cwd=repo,
+            )
+            == "allow"
+        )
+
+    def test_deny_message_mentions_settings_json(self, settings_repo):
+        """Deny reason must reference settings.json so the agent knows what to unstage."""
+        repo, settings_file = settings_repo
+        stage_settings(repo, settings_file, '{"model": "opus", "effortLevel": "normal"}\n')
+        reason = run_hook_reason(
+            GUARD_SETTINGS_MODEL_EFFORT_HOOK,
+            bash_input("git commit -m 'update settings'"),
+            cwd=repo,
+        )
+        assert reason is not None
+        assert "settings.json" in reason
+        assert "model" in reason or "effortLevel" in reason
+
+    def test_outside_git_repo_allows(self, tmp_path):
+        non_repo = tmp_path / "not-a-repo"
+        non_repo.mkdir()
+        assert (
+            run_hook(
+                GUARD_SETTINGS_MODEL_EFFORT_HOOK,
+                bash_input("git commit -m foo"),
+                cwd=non_repo,
+            )
+            == "allow"
+        )
+
+    def test_chained_add_commit_with_model_change_denies(self, settings_repo):
+        """Chained `git add ... && git commit` is still gated."""
+        repo, settings_file = settings_repo
+        stage_settings(repo, settings_file, '{"model": "haiku", "effortLevel": "normal"}\n')
+        assert (
+            run_hook(
+                GUARD_SETTINGS_MODEL_EFFORT_HOOK,
+                bash_input("git add . && git commit -m update"),
+                cwd=repo,
+            )
+            == "deny"
+        )
+
+    def test_empty_staged_diff_allows(self, settings_repo):
+        """No staged changes → let git decide (nothing staged case)."""
+        repo, settings_file = settings_repo
+        # Ensure nothing is staged.
+        subprocess.run(["git", "reset", "HEAD", "--", "."], cwd=repo, check=True)
+        assert (
+            run_hook(
+                GUARD_SETTINGS_MODEL_EFFORT_HOOK,
+                bash_input("git commit -m foo"),
+                cwd=repo,
+            )
+            == "allow"
+        )
+
+
+# ---------------------------------------------------------------------------
+# require-plan-review.sh
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def plan_review_repo(tmp_path, monkeypatch):
+    """Git repo with .claude/plans/ populated and CLAUDE_REQUIRE_PLAN_REVIEW=1 set.
+
+    The opt-in env var activates the gate without needing the sentinel file.
+    """
+    repo = tmp_path / "plan-repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=repo, check=True)
+    plans_dir = repo / ".claude" / "plans"
+    plans_dir.mkdir(parents=True)
+    (plans_dir / "impl-plan.md").write_text("# Implementation plan\n\nStep 1...\n")
+    monkeypatch.setenv("CLAUDE_REQUIRE_PLAN_REVIEW", "1")
+    return repo
+
+
+@pytest.fixture
+def plan_review_home(isolated_home):
+    """Isolated $HOME with the plan-review-markers directory pre-created."""
+    (isolated_home / ".claude" / "plan-review-markers").mkdir(parents=True, exist_ok=True)
+    return isolated_home
+
+
+def plan_review_marker_path(home: Path, repo: Path, session_id: str) -> Path:
+    repo_hash = hashlib.sha256(git_toplevel(repo).encode()).hexdigest()
+    return home / ".claude" / "plan-review-markers" / f"{repo_hash}.{session_id}"
+
+
+def write_plan_review_marker(home: Path, repo: Path, session_id: str) -> Path:
+    marker = plan_review_marker_path(home, repo, session_id)
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text("reviewed\n")
+    return marker
+
+
+class TestRequirePlanReview:
+    def test_plan_exists_no_marker_denies_write(self, plan_review_repo, plan_review_home):
+        assert (
+            run_hook(
+                REQUIRE_PLAN_REVIEW_HOOK,
+                {**write_input("/tmp/foo.py"), "session_id": "test-session-prt"},
+                cwd=plan_review_repo,
+            )
+            == "deny"
+        )
+
+    def test_plan_exists_no_marker_denies_edit(self, plan_review_repo, plan_review_home):
+        assert (
+            run_hook(
+                REQUIRE_PLAN_REVIEW_HOOK,
+                {**edit_input("/tmp/foo.py"), "session_id": "test-session-prt"},
+                cwd=plan_review_repo,
+            )
+            == "deny"
+        )
+
+    def test_plan_exists_with_marker_allows_write(self, plan_review_repo, plan_review_home):
+        sid = "test-session-prt-allowed"
+        write_plan_review_marker(plan_review_home, plan_review_repo, sid)
+        assert (
+            run_hook(
+                REQUIRE_PLAN_REVIEW_HOOK,
+                {**write_input("/tmp/foo.py"), "session_id": sid},
+                cwd=plan_review_repo,
+            )
+            == "allow"
+        )
+
+    def test_plan_exists_with_marker_allows_edit(self, plan_review_repo, plan_review_home):
+        sid = "test-session-prt-allowed-edit"
+        write_plan_review_marker(plan_review_home, plan_review_repo, sid)
+        assert (
+            run_hook(
+                REQUIRE_PLAN_REVIEW_HOOK,
+                {**edit_input("/tmp/foo.py"), "session_id": sid},
+                cwd=plan_review_repo,
+            )
+            == "allow"
+        )
+
+    def test_other_sessions_marker_does_not_authorize(self, plan_review_repo, plan_review_home):
+        """Marker for session A must NOT bypass session B's gate."""
+        write_plan_review_marker(plan_review_home, plan_review_repo, "session-A")
+        assert (
+            run_hook(
+                REQUIRE_PLAN_REVIEW_HOOK,
+                {**write_input("/tmp/foo.py"), "session_id": "session-B"},
+                cwd=plan_review_repo,
+            )
+            == "deny"
+        )
+
+    def test_no_plans_dir_allows(self, tmp_path, monkeypatch):
+        """No .claude/plans/ directory → gate is inactive regardless of opt-in."""
+        repo = tmp_path / "no-plans"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.name", "t"], cwd=repo, check=True)
+        monkeypatch.setenv("CLAUDE_REQUIRE_PLAN_REVIEW", "1")
+        assert (
+            run_hook(
+                REQUIRE_PLAN_REVIEW_HOOK,
+                write_input("/tmp/foo.py"),
+                cwd=repo,
+            )
+            == "allow"
+        )
+
+    def test_empty_plans_dir_allows(self, tmp_path, monkeypatch):
+        """Empty .claude/plans/ directory → no plans present, gate inactive."""
+        repo = tmp_path / "empty-plans"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.name", "t"], cwd=repo, check=True)
+        (repo / ".claude" / "plans").mkdir(parents=True)
+        monkeypatch.setenv("CLAUDE_REQUIRE_PLAN_REVIEW", "1")
+        assert (
+            run_hook(
+                REQUIRE_PLAN_REVIEW_HOOK,
+                write_input("/tmp/foo.py"),
+                cwd=repo,
+            )
+            == "allow"
+        )
+
+    def test_no_opt_in_env_allows_even_with_plan(self, tmp_path):
+        """Without CLAUDE_REQUIRE_PLAN_REVIEW=1 or sentinel file, gate is inactive."""
+        repo = tmp_path / "no-opt-in"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.name", "t"], cwd=repo, check=True)
+        (repo / ".claude" / "plans").mkdir(parents=True)
+        (repo / ".claude" / "plans" / "plan.md").write_text("# plan\n")
+        # Deliberately do NOT set CLAUDE_REQUIRE_PLAN_REVIEW env var.
+        env = {k: v for k, v in os.environ.items() if k != "CLAUDE_REQUIRE_PLAN_REVIEW"}
+        result = subprocess.run(
+            [str(REQUIRE_PLAN_REVIEW_HOOK)],
+            input=json.dumps(write_input("/tmp/foo.py")),
+            capture_output=True,
+            text=True,
+            cwd=repo,
+            env=env,
+            check=False,
+        )
+        assert result.returncode == 0
+        assert not result.stdout.strip(), "hook should be silent (allow) with no opt-in"
+
+    def test_sentinel_file_activates_gate(self, tmp_path):
+        """A .claude/require-plan-review sentinel file activates the gate
+        without the env var — repo-level opt-in."""
+        repo = tmp_path / "sentinel-repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.name", "t"], cwd=repo, check=True)
+        (repo / ".claude").mkdir()
+        (repo / ".claude" / "require-plan-review").write_text("")
+        (repo / ".claude" / "plans").mkdir()
+        (repo / ".claude" / "plans" / "plan.md").write_text("# plan\n")
+        # Unset the env var so activation comes from sentinel only.
+        env = {k: v for k, v in os.environ.items() if k != "CLAUDE_REQUIRE_PLAN_REVIEW"}
+        result = subprocess.run(
+            [str(REQUIRE_PLAN_REVIEW_HOOK)],
+            input=json.dumps({**write_input("/tmp/foo.py"), "session_id": "test-sid"}),
+            capture_output=True,
+            text=True,
+            cwd=repo,
+            env=env,
+            check=False,
+        )
+        assert result.stdout.strip(), "expected deny via sentinel file opt-in"
+        payload = json.loads(result.stdout)
+        assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    def test_bash_tool_allows_always(self, plan_review_repo):
+        """Bash tool calls are not gated — only Write and Edit."""
+        assert (
+            run_hook(
+                REQUIRE_PLAN_REVIEW_HOOK,
+                bash_input("git commit -m foo"),
+                cwd=plan_review_repo,
+            )
+            == "allow"
+        )
+
+    def test_outside_git_repo_allows(self, tmp_path, monkeypatch):
+        """Outside a git repo, the hook cannot key a marker — allow through."""
+        non_repo = tmp_path / "not-a-repo"
+        non_repo.mkdir()
+        monkeypatch.setenv("CLAUDE_REQUIRE_PLAN_REVIEW", "1")
+        assert (
+            run_hook(
+                REQUIRE_PLAN_REVIEW_HOOK,
+                write_input("/tmp/foo.py"),
+                cwd=non_repo,
+            )
+            == "allow"
+        )
+
+    def test_no_session_id_in_input_denies(self, plan_review_repo, plan_review_home):
+        """Without session_id in the hook payload, no per-session marker can be
+        keyed — deny even if a marker directory exists. Mirrors the same invariant
+        in require-code-review.sh and require-respond-pr.sh: missing session_id
+        must fail-closed, not silently allow. This is a load-bearing safety
+        property of the per-session marker design."""
+        # Write a marker for a known session so the marker dir exists, but the
+        # payload has no session_id — the hook must not accept the existing marker.
+        write_plan_review_marker(plan_review_home, plan_review_repo, "some-other-session")
+        # write_input() uses no session_id field.
+        assert (
+            run_hook(
+                REQUIRE_PLAN_REVIEW_HOOK,
+                write_input("/tmp/foo.py"),
+                cwd=plan_review_repo,
+            )
+            == "deny"
+        )
+
+    def test_deny_message_mentions_plan_review(self, plan_review_repo, plan_review_home):
+        """Deny reason must reference /plan-review so the agent knows what to run."""
+        reason = run_hook_reason(
+            REQUIRE_PLAN_REVIEW_HOOK,
+            {**write_input("/tmp/foo.py"), "session_id": "session-for-reason"},
+            cwd=plan_review_repo,
+        )
+        assert reason is not None
+        assert "/plan-review" in reason
+        assert "plan-review-markers" in reason

--- a/claude/.claude/hooks/tests/test_hooks.py
+++ b/claude/.claude/hooks/tests/test_hooks.py
@@ -4178,10 +4178,10 @@ class TestGuardSettingsModelEffort:
 
 
 @pytest.fixture
-def plan_review_repo(tmp_path, monkeypatch):
-    """Git repo with .claude/plans/ populated and CLAUDE_REQUIRE_PLAN_REVIEW=1 set.
+def plan_review_repo(tmp_path):
+    """Git repo with .claude/plans/ populated.
 
-    The opt-in env var activates the gate without needing the sentinel file.
+    The gate is globally applied — no opt-in required.
     """
     repo = tmp_path / "plan-repo"
     repo.mkdir()
@@ -4191,7 +4191,6 @@ def plan_review_repo(tmp_path, monkeypatch):
     plans_dir = repo / ".claude" / "plans"
     plans_dir.mkdir(parents=True)
     (plans_dir / "impl-plan.md").write_text("# Implementation plan\n\nStep 1...\n")
-    monkeypatch.setenv("CLAUDE_REQUIRE_PLAN_REVIEW", "1")
     return repo
 
 
@@ -4271,14 +4270,13 @@ class TestRequirePlanReview:
             == "deny"
         )
 
-    def test_no_plans_dir_allows(self, tmp_path, monkeypatch):
-        """No .claude/plans/ directory → gate is inactive regardless of opt-in."""
+    def test_no_plans_dir_allows(self, tmp_path):
+        """No .claude/plans/ directory → gate is inactive."""
         repo = tmp_path / "no-plans"
         repo.mkdir()
         subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
         subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True)
         subprocess.run(["git", "config", "user.name", "t"], cwd=repo, check=True)
-        monkeypatch.setenv("CLAUDE_REQUIRE_PLAN_REVIEW", "1")
         assert (
             run_hook(
                 REQUIRE_PLAN_REVIEW_HOOK,
@@ -4288,7 +4286,7 @@ class TestRequirePlanReview:
             == "allow"
         )
 
-    def test_empty_plans_dir_allows(self, tmp_path, monkeypatch):
+    def test_empty_plans_dir_allows(self, tmp_path):
         """Empty .claude/plans/ directory → no plans present, gate inactive."""
         repo = tmp_path / "empty-plans"
         repo.mkdir()
@@ -4296,7 +4294,6 @@ class TestRequirePlanReview:
         subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True)
         subprocess.run(["git", "config", "user.name", "t"], cwd=repo, check=True)
         (repo / ".claude" / "plans").mkdir(parents=True)
-        monkeypatch.setenv("CLAUDE_REQUIRE_PLAN_REVIEW", "1")
         assert (
             run_hook(
                 REQUIRE_PLAN_REVIEW_HOOK,
@@ -4305,56 +4302,6 @@ class TestRequirePlanReview:
             )
             == "allow"
         )
-
-    def test_no_opt_in_env_allows_even_with_plan(self, tmp_path):
-        """Without CLAUDE_REQUIRE_PLAN_REVIEW=1 or sentinel file, gate is inactive."""
-        repo = tmp_path / "no-opt-in"
-        repo.mkdir()
-        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
-        subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True)
-        subprocess.run(["git", "config", "user.name", "t"], cwd=repo, check=True)
-        (repo / ".claude" / "plans").mkdir(parents=True)
-        (repo / ".claude" / "plans" / "plan.md").write_text("# plan\n")
-        # Deliberately do NOT set CLAUDE_REQUIRE_PLAN_REVIEW env var.
-        env = {k: v for k, v in os.environ.items() if k != "CLAUDE_REQUIRE_PLAN_REVIEW"}
-        result = subprocess.run(
-            [str(REQUIRE_PLAN_REVIEW_HOOK)],
-            input=json.dumps(write_input("/tmp/foo.py")),
-            capture_output=True,
-            text=True,
-            cwd=repo,
-            env=env,
-            check=False,
-        )
-        assert result.returncode == 0
-        assert not result.stdout.strip(), "hook should be silent (allow) with no opt-in"
-
-    def test_sentinel_file_activates_gate(self, tmp_path):
-        """A .claude/require-plan-review sentinel file activates the gate
-        without the env var — repo-level opt-in."""
-        repo = tmp_path / "sentinel-repo"
-        repo.mkdir()
-        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
-        subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True)
-        subprocess.run(["git", "config", "user.name", "t"], cwd=repo, check=True)
-        (repo / ".claude").mkdir()
-        (repo / ".claude" / "require-plan-review").write_text("")
-        (repo / ".claude" / "plans").mkdir()
-        (repo / ".claude" / "plans" / "plan.md").write_text("# plan\n")
-        # Unset the env var so activation comes from sentinel only.
-        env = {k: v for k, v in os.environ.items() if k != "CLAUDE_REQUIRE_PLAN_REVIEW"}
-        result = subprocess.run(
-            [str(REQUIRE_PLAN_REVIEW_HOOK)],
-            input=json.dumps({**write_input("/tmp/foo.py"), "session_id": "test-sid"}),
-            capture_output=True,
-            text=True,
-            cwd=repo,
-            env=env,
-            check=False,
-        )
-        assert result.stdout.strip(), "expected deny via sentinel file opt-in"
-        payload = json.loads(result.stdout)
-        assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
 
     def test_bash_tool_allows_always(self, plan_review_repo):
         """Bash tool calls are not gated — only Write and Edit."""
@@ -4367,11 +4314,10 @@ class TestRequirePlanReview:
             == "allow"
         )
 
-    def test_outside_git_repo_allows(self, tmp_path, monkeypatch):
+    def test_outside_git_repo_allows(self, tmp_path):
         """Outside a git repo, the hook cannot key a marker — allow through."""
         non_repo = tmp_path / "not-a-repo"
         non_repo.mkdir()
-        monkeypatch.setenv("CLAUDE_REQUIRE_PLAN_REVIEW", "1")
         assert (
             run_hook(
                 REQUIRE_PLAN_REVIEW_HOOK,

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -10,6 +10,16 @@
         ]
       }
     ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/capture-session-id.sh"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",
@@ -19,6 +29,12 @@
             "command": "~/.claude/hooks/require-code-review.sh",
             "if": "Bash(git commit *)",
             "statusMessage": "Checking code review..."
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/guard-settings-model-effort.sh",
+            "if": "Bash(git commit *)",
+            "statusMessage": "Checking settings.json model/effort..."
           },
           {
             "type": "command",
@@ -87,6 +103,11 @@
             "type": "command",
             "command": "~/.claude/hooks/ask-review-permissions.sh",
             "statusMessage": "Checking settings permissions..."
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/require-plan-review.sh",
+            "statusMessage": "Checking plan-review gate..."
           }
         ]
       }


### PR DESCRIPTION
## Summary

- **F-06 / Closes #89**: Register \`capture-session-id.sh\` on \`SubagentStart\` alongside the existing \`SessionStart\` entry. Sub-agents now get session-id captured so marker-creating skills invoked inside a subagent work correctly.

- **F-07 / Closes #87**: Add \`guard-settings-model-effort.sh\` — a PreToolUse hook that fires on \`git commit\` and blocks when \`claude/.claude/settings.json\` has staged \`model\` or \`effortLevel\` changes relative to \`main\`. Prevents accidentally committing ephemeral per-session \`/config\` overrides. Registered with \`"if": "Bash(git commit *)"\`.

- **F-05 / Closes #90**: Add \`require-plan-review.sh\` — a PreToolUse hook that gates \`Write\`/\`Edit\` when a plan file exists in \`.claude/plans/\` without a current plan-review marker for this session. Globally applied (no opt-in), consistent with \`require-code-review.sh\`, \`require-ready-for-review.sh\`, and \`require-respond-pr.sh\` — the plan-file existence check is the per-project filter. Mirrors the per-session marker pattern from \`require-code-review.sh\`.

All hooks implement defense-in-depth (filter by tool name internally; do not rely solely on \`settings.json\` \`if\` conditions).

## Test plan

- [x] \`pytest claude/.claude/hooks/tests/\` — 354 tests passing (11 new for F-07, 11 new for F-05 including the fail-closed no-session-id case)
- [x] \`ruff check claude/.claude/hooks/tests/\` — clean
- [ ] \`bash -n\` syntax check on both new hook scripts — clean
- [ ] Verify \`SubagentStart\` block mirrors \`SessionStart\` shape exactly in \`settings.json\`
- [ ] Verify \`guard-settings-model-effort.sh\` does not fire on non-\`git commit\` commands or when \`settings.json\` is not staged
- [ ] Verify \`require-plan-review.sh\` gates any repo with a populated \`.claude/plans/\` directory (no opt-in needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)