### PR TITLE
hooks: block Edit/Write/MultiEdit to main tree in worktree-enforced repos

### DIFF
--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -29,6 +29,7 @@
 
 - When spawning sub-agents with `isolation: "worktree"`, do NOT include an explicit `Working directory: /path/to/repo` line. The harness sets the agent's CWD to the isolated worktree automatically; naming the main repo path causes the agent to use `git -C <main-path>` operations that bypass isolation and mutate the main working tree directly.
 - Before delegating execution to a sub-agent from a session that has been in plan mode, call `ExitPlanMode` in the parent first. Sub-agents inherit harness-enforced plan-mode state and will refuse to execute — returning a plan file even when the prompt says "execute, do not plan" — until the parent exits plan mode. Symptom: the sub-agent cites a "plan-mode system-reminder" as harness-enforced and asks the user to exit plan mode.
+- In a repo with worktree enforcement opt-in (`.claude/worktree-required` committed), Edit and Write must also target the worktree path — the hook blocks main-tree file writes, but resolving paths to `.claude/worktrees/<branch>/...` up front avoids the round-trip denial.
 
 ## Model Routing
 

--- a/claude/.claude/hooks/require-worktree-for-file-writes.sh
+++ b/claude/.claude/hooks/require-worktree-for-file-writes.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Gate: block Edit, Write, and MultiEdit to files in the main working tree of
+# a repo that has opted into worktree discipline (.claude/worktree-required
+# committed at the repo root). Companion to require-worktree-for-git-writes.sh,
+# which blocks git write ops from the main tree.
+#
+# Defensive: prevent GIT_DIR / GIT_WORK_TREE env overrides from making the
+# main tree impersonate a linked worktree via rev-parse output.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE
+
+INPUT=$(cat)
+
+emit_deny() {
+  local reason="$1"
+  local reason_json
+  reason_json=$(printf '%s' "$reason" | jq -Rs .)
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}' \
+    "$reason_json"
+}
+
+# Fail-closed on malformed input: capture jq's exit code (not cat's) to detect
+# a broken jq binary or non-JSON harness output.
+TOOL_NAME=$(printf '%s\n' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+JQ_EXIT=$?
+if [ "$JQ_EXIT" -ne 0 ]; then
+  emit_deny "Blocked by worktree-enforcement hook (file-writes): could not parse tool-input JSON. Refusing to evaluate worktree discipline under malformed input."
+  exit 0
+fi
+
+FILE_PATH=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+
+# Only applies to file-writing tools; other tools pass through immediately.
+case "$TOOL_NAME" in
+  Edit|Write|MultiEdit) ;;
+  *) exit 0 ;;
+esac
+
+# Nothing to check without a path.
+[ -z "$FILE_PATH" ] && exit 0
+
+# Walk up from the file's parent directory to find an existing ancestor.
+# Write may target a file that does not exist yet; git -C on a missing dir
+# returns nothing, so we must find an existing ancestor.
+lookup_dir="$(dirname "$FILE_PATH")"
+while [ -n "$lookup_dir" ] && [ "$lookup_dir" != "/" ] && [ ! -d "$lookup_dir" ]; do
+  lookup_dir="$(dirname "$lookup_dir")"
+done
+[ ! -d "$lookup_dir" ] && exit 0
+
+# Find the repo root from the existing ancestor directory.
+REPO_ROOT=$(git -C "$lookup_dir" rev-parse --show-toplevel 2>/dev/null)
+[ -z "$REPO_ROOT" ] && exit 0
+
+# Per-repo opt-in: only enforce if the sentinel is committed.
+[ ! -f "$REPO_ROOT/.claude/worktree-required" ] && exit 0
+
+# Detect main tree vs linked worktree using the same git-dir comparison as
+# require-worktree-for-git-writes.sh: in a linked worktree, --absolute-git-dir
+# and --git-common-dir differ; in the main tree they resolve to the same path.
+GIT_DIR_ABS=$(git -C "$lookup_dir" rev-parse --absolute-git-dir 2>/dev/null)
+GIT_COMMON_DIR=$(git -C "$lookup_dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
+
+if [ -z "$GIT_DIR_ABS" ] || [ -z "$GIT_COMMON_DIR" ]; then
+  emit_deny "Blocked by worktree-enforcement hook (file-writes): could not determine git state for '$FILE_PATH'. This repo has opted into worktree discipline (.claude/worktree-required is committed). Run $TOOL_NAME from inside a linked worktree — cd into an existing worktree under .claude/worktrees/, or spawn an agent with isolation: worktree."
+  exit 0
+fi
+
+# Already in a linked worktree: allow.
+[ "$GIT_DIR_ABS" != "$GIT_COMMON_DIR" ] && exit 0
+
+# In the main working tree: deny.
+REL_PATH="${FILE_PATH#"$REPO_ROOT"/}"
+emit_deny "Blocked by worktree-enforcement hook (file-writes): $TOOL_NAME targets '$FILE_PATH' which is in the main working tree of a repo that has opted into worktree discipline (.claude/worktree-required is committed). Write the file at its worktree path instead — e.g. .claude/worktrees/<branch>/$REL_PATH — or spawn an agent with isolation: worktree."
+exit 0

--- a/claude/.claude/hooks/tests/test_hooks.py
+++ b/claude/.claude/hooks/tests/test_hooks.py
@@ -26,6 +26,7 @@ REVIEW_PERMS_HOOK = HOOKS_DIR / "ask-review-permissions.sh"
 DENY_PRIVATE_PROJECT_REFS_HOOK = HOOKS_DIR / "deny-private-project-refs.sh"
 STOW_REMINDER_HOOK = HOOKS_DIR / "require-stow-reminder.sh"
 WORKTREE_HOOK = HOOKS_DIR / "require-worktree-for-git-writes.sh"
+FILE_WRITES_HOOK = HOOKS_DIR / "require-worktree-for-file-writes.sh"
 CAPTURE_SESSION_ID_HOOK = HOOKS_DIR / "capture-session-id.sh"
 GUARD_SETTINGS_MODEL_EFFORT_HOOK = HOOKS_DIR / "guard-settings-model-effort.sh"
 REQUIRE_PLAN_REVIEW_HOOK = HOOKS_DIR / "require-plan-review.sh"
@@ -128,6 +129,10 @@ def edit_input(file_path: str) -> dict:
 
 def write_input(file_path: str) -> dict:
     return {"tool_name": "Write", "tool_input": {"file_path": file_path, "content": "x"}}
+
+
+def multiedit_input(file_path: str) -> dict:
+    return {"tool_name": "MultiEdit", "tool_input": {"file_path": file_path, "edits": []}}
 
 
 @pytest.fixture
@@ -4356,3 +4361,98 @@ class TestRequirePlanReview:
         assert reason is not None
         assert "/plan-review" in reason
         assert "plan-review-markers" in reason
+
+
+# ---------------------------------------------------------------------------
+# require-worktree-for-file-writes.sh
+# ---------------------------------------------------------------------------
+
+
+class TestRequireWorktreeForFileWrites:
+    def test_no_sentinel_allows_edit(self, non_opted_repo):
+        """Repo without the sentinel: Edit passes through unconditionally."""
+        path = str(non_opted_repo / "file.txt")
+        assert run_hook(FILE_WRITES_HOOK, edit_input(path)) == "allow"
+
+    def test_no_sentinel_allows_write(self, non_opted_repo):
+        """Repo without the sentinel: Write passes through unconditionally."""
+        path = str(non_opted_repo / "new.txt")
+        assert run_hook(FILE_WRITES_HOOK, write_input(path)) == "allow"
+
+    def test_opted_in_main_tree_denies_edit(self, opted_in_repo):
+        """Edit targeting an existing file in the main tree is denied."""
+        path = str(opted_in_repo / "file.txt")
+        assert run_hook(FILE_WRITES_HOOK, edit_input(path)) == "deny"
+
+    def test_opted_in_main_tree_denies_write(self, opted_in_repo):
+        """Write targeting the main tree is denied even for a new file."""
+        path = str(opted_in_repo / "newfile.txt")
+        assert run_hook(FILE_WRITES_HOOK, write_input(path)) == "deny"
+
+    def test_opted_in_main_tree_denies_multiedit(self, opted_in_repo):
+        """MultiEdit targeting the main tree is denied."""
+        path = str(opted_in_repo / "file.txt")
+        assert run_hook(FILE_WRITES_HOOK, multiedit_input(path)) == "deny"
+
+    def test_opted_in_worktree_allows_edit(self, opted_in_with_worktree):
+        """Edit targeting a file inside a linked worktree is allowed."""
+        _, worktree = opted_in_with_worktree
+        path = str(worktree / "file.txt")
+        assert run_hook(FILE_WRITES_HOOK, edit_input(path)) == "allow"
+
+    def test_opted_in_worktree_allows_write(self, opted_in_with_worktree):
+        """Write targeting a new file inside a linked worktree is allowed."""
+        _, worktree = opted_in_with_worktree
+        path = str(worktree / "new.txt")
+        assert run_hook(FILE_WRITES_HOOK, write_input(path)) == "allow"
+
+    def test_opted_in_worktree_allows_multiedit(self, opted_in_with_worktree):
+        """MultiEdit targeting a file inside a linked worktree is allowed."""
+        _, worktree = opted_in_with_worktree
+        path = str(worktree / "file.txt")
+        assert run_hook(FILE_WRITES_HOOK, multiedit_input(path)) == "allow"
+
+    def test_non_git_path_allows_edit(self, tmp_path):
+        """Edit to a path outside any git repo is allowed."""
+        non_repo = tmp_path / "not-a-repo"
+        non_repo.mkdir()
+        path = str(non_repo / "file.txt")
+        assert run_hook(FILE_WRITES_HOOK, edit_input(path)) == "allow"
+
+    def test_new_file_nested_path_denied_in_main_tree(self, opted_in_repo):
+        """Write to a not-yet-existing nested path whose ancestor is in the
+        main tree is denied — the hook must walk up to the existing dir."""
+        path = str(opted_in_repo / "subdir" / "deeply" / "new.txt")
+        assert run_hook(FILE_WRITES_HOOK, write_input(path)) == "deny"
+
+    def test_bash_tool_allowed(self, opted_in_repo):
+        """Non-file-write tool (Bash) passes through: the hook is scoped to
+        Edit/Write/MultiEdit only."""
+        assert run_hook(FILE_WRITES_HOOK, bash_input("echo hi")) == "allow"
+
+    def test_deny_message_names_relative_path(self, opted_in_repo):
+        """Deny message should include the relative worktree path hint."""
+        path = str(opted_in_repo / "src" / "main.sh")
+        reason = run_hook_reason(FILE_WRITES_HOOK, edit_input(path))
+        assert reason is not None
+        assert "src/main.sh" in reason
+
+    def test_deny_message_names_tool(self, opted_in_repo):
+        """Deny message should name the tool that was blocked."""
+        path = str(opted_in_repo / "file.txt")
+        reason = run_hook_reason(FILE_WRITES_HOOK, write_input(path))
+        assert reason is not None
+        assert "Write" in reason
+
+    def test_malformed_json_stdin_denies(self):
+        """Malformed JSON input must produce a deny, not a silent allow."""
+        result = subprocess.run(
+            [str(FILE_WRITES_HOOK)],
+            input="not-json{{{",
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.stdout.strip(), "Expected deny output on malformed JSON, got silent allow"
+        payload = json.loads(result.stdout)
+        assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -108,6 +108,11 @@
             "type": "command",
             "command": "~/.claude/hooks/require-plan-review.sh",
             "statusMessage": "Checking plan-review gate..."
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/require-worktree-for-file-writes.sh",
+            "statusMessage": "Checking worktree enforcement..."
           }
         ]
       }


### PR DESCRIPTION
## Summary

- Adds `require-worktree-for-file-writes.sh`: a new PreToolUse hook that blocks Edit, Write, and MultiEdit targeting files in the main working tree of any repo with `.claude/worktree-required` opted in
- Registers the hook in `settings.json` under the existing `Edit|Write|MultiEdit` matcher (alongside `ask-review-permissions.sh` and `require-plan-review.sh`)
- Adds a one-line bullet to global `CLAUDE.md` Agent Briefing section so Claude resolves to the worktree path before hitting a hook denial (saves the round-trip)
- 14 new tests: deny/allow paths across Edit/Write/MultiEdit, main-tree vs linked-worktree, non-opted-in repos, new-file nested paths, wrong tool pass-through, deny message content, malformed JSON fail-closed

## Motivation

The existing `require-worktree-for-git-writes.sh` blocks git write ops from the main tree but leaves Edit/Write/MultiEdit unguarded. This let Claude edit files at the main-tree path and copy them into the worktree before committing — leaving uncommitted edits in the main tree that blocked `git merge --ff-only origin/main` during cleanup. This hook closes that gap.

## Test plan

- [ ] `pytest claude/.claude/hooks/tests/test_hooks.py -k TestRequireWorktreeForFileWrites` — 14 tests
- [ ] `pytest claude/.claude/hooks/tests/test_hooks.py` — full suite (368 tests)
- [ ] Confirm the hook fires in a live session: try `Edit` on a main-tree file in this repo and verify the deny message names the worktree path

🤖 Generated with [Claude Code](https://claude.com/claude-code)