### PR TITLE
plan-review: agent selection guidance, schema routing, dedupe rule, output budget

### DIFF
--- a/claude/.claude/skills/plan-review/SKILL.md
+++ b/claude/.claude/skills/plan-review/SKILL.md
@@ -208,7 +208,7 @@ When you spawn: pick the specialist that serves the question (table below is ref
 
 Project-level plan-review skills may extend this table with project-specific reviewer roles, but must not remove or narrow the `ciso-reviewer` trigger conditions.
 
-Specialist agents must return ≤2K tokens of structured findings (checklist-item-keyed bullets), not narrative prose. When spawning, include this constraint in the agent prompt.
+Specialist agents must return ≤2K tokens of structured findings (checklist-item-keyed bullets), not narrative prose. If findings genuinely exceed the budget, the agent must prioritize by severity and explicitly note that lower-severity items were omitted. When spawning, include this constraint in the agent prompt.
 
 ## Reconciliation
 

--- a/claude/.claude/skills/plan-review/SKILL.md
+++ b/claude/.claude/skills/plan-review/SKILL.md
@@ -22,7 +22,7 @@ Find the plan to review. Check, in order:
 
 ## Step 1 — Detect domains
 
-Read the plan and classify which domains it touches:
+Read the plan and classify which domains it touches. When using an agent to explore the codebase for plan context, use `general-purpose` — not `Explore`. The `Explore` agent reads excerpts and is not suitable for design-doc auditing or cross-file consistency checks; it misses content past its read window.
 
 - **Infrastructure**: CI/CD, workflows, deployment, hosting, config files
 - **Data infrastructure**: Database migrations, schema DDL, RLS policies, CDC / change-stream config, ETL/ELT pipelines, warehouse ingestion connectors, raw landing schemas, schema-drift handling
@@ -31,6 +31,8 @@ Read the plan and classify which domains it touches:
 - **Frontend**: Client components, hooks, client-side state, UI behavior, routing, forms, optimistic mutations
 - **Backend**: Server-side code (HTTP/RPC handlers, edge functions, background jobs, queue consumers, SDK integrations, shared utilities) AND application data-store schema design
 - **Security**: Authentication or authorization, token handling, secret management, data exposure, RLS / RBAC / ACL changes
+
+**Schema change routing:** Route schema changes by change type: new nullable column, index, or view → `staff-backend-engineer` only; new table → `staff-backend-engineer` + `staff-analytics-engineer`; rename, drop, type change, NOT NULL constraint added, partition key, or RLS policy → `staff-backend-engineer` + `staff-data-engineer` + `staff-analytics-engineer`. Add `staff-product-engineer` if user-visible.
 
 ## Step 2 — Design-fitness gate
 
@@ -206,11 +208,13 @@ When you spawn: pick the specialist that serves the question (table below is ref
 
 Project-level plan-review skills may extend this table with project-specific reviewer roles, but must not remove or narrow the `ciso-reviewer` trigger conditions.
 
+Specialist agents must return ≤2K tokens of structured findings (checklist-item-keyed bullets), not narrative prose. When spawning, include this constraint in the agent prompt.
+
 ## Reconciliation
 
 Same logic as code-review's Reconciliation — repeated because skills load on demand.
 
-After spawned reviewers return findings, pause if findings concentrate on a single surface — the same feature, implementation detail, or design choice attracting multiple gaps. Two readings:
+After spawned reviewers return findings, pause if findings concentrate on a single surface — the same feature, implementation detail, or design choice attracting multiple gaps. If two specialists flag the same `file:line` with the same root cause, present the finding once with both reviewer attributions rather than as duplicate findings. Two readings:
 
 - **Design-wrong-shape.** The surface is the wrong abstraction; gaps will keep multiplying as you patch. Replace, don't patch-by-patch.
 - **Prompt-overlap artifact.** Reviewers given similar prompts produce N voices of the same observation. Convergence looks like signal but is framing-induced.


### PR DESCRIPTION
## Summary

- **F-13 (Closes #95):** Step 1 now warns that `general-purpose` must be used (not `Explore`) for codebase research during plan context gathering; `Explore` reads excerpts and misses content past its read window, making it unsuitable for design-doc auditing or cross-file consistency checks.
- **F-15 (Refs #96):** Bold schema-change routing callout added after the domain list in Step 1, keying on change type (nullable column/index/view → backend only; new table → backend + analytics; rename/drop/type/NOT NULL/partition key/RLS → backend + data + analytics; + product if user-visible). Identical wording to A1's code-review addition.
- **F-16 (Refs #97):** First sentence added in Reconciliation — same `file:line` same-root-cause findings from two specialists are presented once with both reviewer attributions. Identical wording to A1's code-review addition.
- **F-21 (Refs #104):** Specialist output budget (≤2K tokens, checklist-item-keyed bullets, not narrative prose) added after the dispatch table and before Reconciliation. When findings genuinely exceed the budget, agents must prioritize by severity and explicitly note that lower-severity items were omitted. Identical wording to A1's code-review addition.
- **F-17 (#99):** Verified — ciso-reviewer skip clause already present and in good shape. No changes made; omitted from this PR.

## Test plan

- [ ] Read the updated Step 1 and confirm the `Explore`-vs-`general-purpose` note is discoverable at the point where a practitioner selects an agent for codebase research
- [ ] Read the schema routing callout and confirm change-type rows cover the full spectrum (additive, new table, destructive/structural)
- [ ] Read the Reconciliation section and confirm the dedupe sentence appears as the first sentence after the opening paragraph, before the "two readings" list
- [ ] Read the Reviewer roles section and confirm the output budget sentence appears after the dispatch table and before `## Reconciliation`, with the safety-valve sentence for over-budget findings
- [ ] Confirm the "repeated because skills load on demand" duplication notes remain intact (deliberate, not removed)
- [ ] Confirm `ciso-reviewer` skip clause at line 192 is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)