### PR TITLE
code-review: schema fan-out routing, dedup findings, ciso skip path, specialist budget (F-15, F-16, F-17, F-21)

### DIFF
--- a/claude/.claude/hooks/require-code-review.sh
+++ b/claude/.claude/hooks/require-code-review.sh
@@ -72,18 +72,6 @@ if [ -z "$(git diff --cached 2>/dev/null)" ]; then
   exit 0
 fi
 
-# WIP opt-out: commits prefixed with `wip:`, `fixup!`, or `[skip-review]`
-# skip the per-commit review pass. The cumulative /ready-for-review gate
-# still runs before PR handoff and catches everything.
-# Extract the first word of the commit message from the -m/--message flag.
-COMMIT_MSG_FIRST_WORD=$(printf '%s' "$COMMAND" \
-  | grep -oE '(-m |--message[= ])[[:space:]]*['"'"'"]?[^[:space:]'"'"'"]+' \
-  | head -1 \
-  | sed 's/^-m[[:space:]]*//;s/^--message[=[:space:]]//;s/^['"'"'"]//;s/['"'"'"]$//')
-if printf '%s' "$COMMIT_MSG_FIRST_WORD" | grep -qE '^(wip:|fixup!|\[skip-review\])'; then
-  exit 0
-fi
-
 REPO_HASH=$(printf '%s' "$REPO_ROOT" | sha256sum | awk '{print $1}')
 SESSION_ID=$(printf '%s\n' "$INPUT" | jq -r '.session_id // empty')
 CURRENT_HASH=$(git diff --cached | sha256sum | awk '{print $1}')

--- a/claude/.claude/hooks/require-code-review.sh
+++ b/claude/.claude/hooks/require-code-review.sh
@@ -72,6 +72,18 @@ if [ -z "$(git diff --cached 2>/dev/null)" ]; then
   exit 0
 fi
 
+# WIP opt-out: commits prefixed with `wip:`, `fixup!`, or `[skip-review]`
+# skip the per-commit review pass. The cumulative /ready-for-review gate
+# still runs before PR handoff and catches everything.
+# Extract the first word of the commit message from the -m/--message flag.
+COMMIT_MSG_FIRST_WORD=$(printf '%s' "$COMMAND" \
+  | grep -oE '(-m |--message[= ])[[:space:]]*['"'"'"]?[^[:space:]'"'"'"]+' \
+  | head -1 \
+  | sed 's/^-m[[:space:]]*//;s/^--message[=[:space:]]//;s/^['"'"'"]//;s/['"'"'"]$//')
+if printf '%s' "$COMMIT_MSG_FIRST_WORD" | grep -qE '^(wip:|fixup!|\[skip-review\])'; then
+  exit 0
+fi
+
 REPO_HASH=$(printf '%s' "$REPO_ROOT" | sha256sum | awk '{print $1}')
 SESSION_ID=$(printf '%s\n' "$INPUT" | jq -r '.session_id // empty')
 CURRENT_HASH=$(git diff --cached | sha256sum | awk '{print $1}')

--- a/claude/.claude/hooks/tests/test_hooks.py
+++ b/claude/.claude/hooks/tests/test_hooks.py
@@ -477,6 +477,53 @@ class TestRequireCodeReview:
         assert reason is not None
         assert "PreToolUse hooks evaluate" in reason
 
+    # -- WIP opt-out (F-10) ------------------------------------------------
+    # Commits whose message starts with `wip:`, `fixup!`, or `[skip-review]`
+    # bypass the per-commit review gate. The cumulative /ready-for-review pass
+    # still fires before PR handoff — the per-commit gate is the only thing
+    # skipped. Case-sensitive: `WIP:` is NOT an opt-out prefix.
+
+    @pytest.mark.parametrize(
+        "commit_msg",
+        [
+            "wip: incomplete feature",
+            "fixup! previous commit",
+            "[skip-review] trivial typo fix",
+        ],
+    )
+    def test_wip_prefix_allows_without_marker(self, isolated_home, git_repo, commit_msg):
+        """WIP-prefixed commits are allowed through even without a review marker."""
+        assert (
+            run_hook(
+                CODE_REVIEW_HOOK,
+                bash_input(f'git commit -m "{commit_msg}"', session_id=DEFAULT_TEST_SESSION_ID),
+                cwd=git_repo,
+            )
+            == "allow"
+        )
+
+    def test_non_wip_commit_still_blocked_without_marker(self, isolated_home, git_repo):
+        """A non-WIP commit with the same staged diff is blocked without a review marker."""
+        assert (
+            run_hook(
+                CODE_REVIEW_HOOK,
+                bash_input('git commit -m "feat: add new feature"', session_id=DEFAULT_TEST_SESSION_ID),
+                cwd=git_repo,
+            )
+            == "deny"
+        )
+
+    def test_wip_prefix_case_sensitive_uppercase_blocked(self, isolated_home, git_repo):
+        """WIP opt-out is case-sensitive; `WIP:` (uppercase) is not an opt-out prefix."""
+        assert (
+            run_hook(
+                CODE_REVIEW_HOOK,
+                bash_input('git commit -m "WIP: not an opt-out"', session_id=DEFAULT_TEST_SESSION_ID),
+                cwd=git_repo,
+            )
+            == "deny"
+        )
+
 
 # ---------------------------------------------------------------------------
 # require-respond-pr.sh

--- a/claude/.claude/hooks/tests/test_hooks.py
+++ b/claude/.claude/hooks/tests/test_hooks.py
@@ -477,52 +477,6 @@ class TestRequireCodeReview:
         assert reason is not None
         assert "PreToolUse hooks evaluate" in reason
 
-    # -- WIP opt-out (F-10) ------------------------------------------------
-    # Commits whose message starts with `wip:`, `fixup!`, or `[skip-review]`
-    # bypass the per-commit review gate. The cumulative /ready-for-review pass
-    # still fires before PR handoff — the per-commit gate is the only thing
-    # skipped. Case-sensitive: `WIP:` is NOT an opt-out prefix.
-
-    @pytest.mark.parametrize(
-        "commit_msg",
-        [
-            "wip: incomplete feature",
-            "fixup! previous commit",
-            "[skip-review] trivial typo fix",
-        ],
-    )
-    def test_wip_prefix_allows_without_marker(self, isolated_home, git_repo, commit_msg):
-        """WIP-prefixed commits are allowed through even without a review marker."""
-        assert (
-            run_hook(
-                CODE_REVIEW_HOOK,
-                bash_input(f'git commit -m "{commit_msg}"', session_id=DEFAULT_TEST_SESSION_ID),
-                cwd=git_repo,
-            )
-            == "allow"
-        )
-
-    def test_non_wip_commit_still_blocked_without_marker(self, isolated_home, git_repo):
-        """A non-WIP commit with the same staged diff is blocked without a review marker."""
-        assert (
-            run_hook(
-                CODE_REVIEW_HOOK,
-                bash_input('git commit -m "feat: add new feature"', session_id=DEFAULT_TEST_SESSION_ID),
-                cwd=git_repo,
-            )
-            == "deny"
-        )
-
-    def test_wip_prefix_case_sensitive_uppercase_blocked(self, isolated_home, git_repo):
-        """WIP opt-out is case-sensitive; `WIP:` (uppercase) is not an opt-out prefix."""
-        assert (
-            run_hook(
-                CODE_REVIEW_HOOK,
-                bash_input('git commit -m "WIP: not an opt-out"', session_id=DEFAULT_TEST_SESSION_ID),
-                cwd=git_repo,
-            )
-            == "deny"
-        )
 
 
 # ---------------------------------------------------------------------------

--- a/claude/.claude/skills/code-review/SKILL.md
+++ b/claude/.claude/skills/code-review/SKILL.md
@@ -10,10 +10,6 @@ Review the code that was just written or modified. Act as a principal engineer r
 
 ## Step 0 — Detect changed domains
 
-**WIP opt-out:** When the staged commit message starts with `wip:`, `fixup!`, or `[skip-review]` (case-sensitive), skip the per-commit code-review pass. The cumulative pass at `/ready-for-review` still runs before PR handoff and catches everything.
-
-**Small-diff fast-path:** When the diff is <50 lines AND touches only one file, run only items 1–10 of the Base checklist (Correctness items 1–5, Hygiene items 6–8, Clarity items 9–10). Skip all domain checklists and ripple-effect triage. The threshold is 50 diff lines; the reduced item set is items 1–10 only — nothing else from the Base checklist, no domain checklists, no ripple-effect step.
-
 Before reviewing, determine which files were changed (from context, git diff, or the conversation). Classify each changed file into one or more domains:
 
 - **Infrastructure**: `.github/`, `*.tf`, `Dockerfile`, `docker-compose*`, CI/CD configs

--- a/claude/.claude/skills/code-review/SKILL.md
+++ b/claude/.claude/skills/code-review/SKILL.md
@@ -209,7 +209,7 @@ The Change type column keys on what the change *does* for an operator or consume
 
 When you do spawn a specialist, be specific. "Spawn `ciso-reviewer`" is useless; "Spawn `ciso-reviewer` and ask it to verify the checkout flow in CheckoutPage.tsx still enforces ownership after the new validation" is actionable.
 
-Specialist agents must return ≤2K tokens of structured findings (checklist-item-keyed bullets), not narrative prose. When spawning, include this constraint in the agent prompt.
+Specialist agents must return ≤2K tokens of structured findings (checklist-item-keyed bullets), not narrative prose. If findings genuinely exceed the budget, the agent must prioritize by severity and explicitly note that lower-severity items were omitted. When spawning, include this constraint in the agent prompt.
 
 ## Reconciliation
 

--- a/claude/.claude/skills/code-review/SKILL.md
+++ b/claude/.claude/skills/code-review/SKILL.md
@@ -10,6 +10,10 @@ Review the code that was just written or modified. Act as a principal engineer r
 
 ## Step 0 — Detect changed domains
 
+**WIP opt-out:** When the staged commit message starts with `wip:`, `fixup!`, or `[skip-review]` (case-sensitive), skip the per-commit code-review pass. The cumulative pass at `/ready-for-review` still runs before PR handoff and catches everything.
+
+**Small-diff fast-path:** When the diff is <50 lines AND touches only one file, run only items 1–10 of the Base checklist (Correctness items 1–5, Hygiene items 6–8, Clarity items 9–10). Skip all domain checklists and ripple-effect triage. The threshold is 50 diff lines; the reduced item set is items 1–10 only — nothing else from the Base checklist, no domain checklists, no ripple-effect step.
+
 Before reviewing, determine which files were changed (from context, git diff, or the conversation). Classify each changed file into one or more domains:
 
 - **Infrastructure**: `.github/`, `*.tf`, `Dockerfile`, `docker-compose*`, CI/CD configs
@@ -179,7 +183,7 @@ This is the last gate before ship — a specialist miss here ships as a regressi
 - **Convergence-as-design-tell** from a prior round (see Reconciliation).
 - **Explicit user request.**
 
-Always spawn `ciso-reviewer` when the change touches auth/authz, secrets, tokens, data exposure, sensitive-data logging, third-party data sharing, or infra permissions — high-stakes-boundary case is non-optional. Always spawn `staff-product-engineer` when the change alters user-facing behavior.
+Always spawn `ciso-reviewer` when the change touches auth/authz, secrets, tokens, data exposure, sensitive-data logging, third-party data sharing, or infra permissions — high-stakes-boundary case is non-optional, **unless** the change is declared dev-only or internal-only (no privilege boundary crossed) (e.g., a dev-only flow with no production reachability, or an internal-only path where engineers themselves are the only callers and the change crosses no privilege boundary they shouldn't cross). When skipping on those grounds, name the surface in the review output — never silently skip. Always spawn `staff-product-engineer` when the change alters user-facing behavior.
 
 Spawn per question (not per file-path domain) — "change touches `.github/`" isn't enough; the question needs a specific shape.
 
@@ -194,7 +198,7 @@ The Change type column keys on what the change *does* for an operator or consume
 | Adds/modifies security controls | `staff-sdet` + `ciso-reviewer` — verify test pyramid, coverage, and threat model |
 | Changes auth model (JWT, roles, permissions) | `ciso-reviewer` + `staff-backend-engineer` — trace all auth paths including token refresh, session expiry, and error fallbacks |
 | Modifies shared utilities (helpers, hooks, contexts) | `staff-backend-engineer` + `staff-frontend-engineer` — verify all call sites and check for behavioral assumptions |
-| Changes data model (columns, types, defaults, migrations) | `staff-backend-engineer` + `staff-data-engineer` + `staff-analytics-engineer` (three-way schema review — backend designs, data reviews pipeline / DDL impact, analytics reviews ELT-readiness); add `staff-product-engineer` if user-visible. Apply trigger discipline (see Item ownership) to avoid three-persona fire on trivial additive diffs. |
+| Changes data model (columns, types, defaults, migrations) | Route by change type: new nullable column, index, or view → `staff-backend-engineer` only; new table → `staff-backend-engineer` + `staff-analytics-engineer`; rename, drop, type change, NOT NULL constraint added, partition key, or RLS policy → `staff-backend-engineer` + `staff-data-engineer` + `staff-analytics-engineer`. Add `staff-product-engineer` if user-visible. |
 | Adds or changes warehouse models / dbt transformations / semantic-layer files | `staff-analytics-engineer` (modeling, transformation correctness, materialization, test coverage) |
 | Adds or changes CDC / change-stream / ETL/ELT pipeline / warehouse ingestion connector | `staff-data-engineer` (transport, schema-drift, observability) + `staff-platform-engineer` (operational footprint) |
 | Modifies CI/CD pipelines or deploy config | `staff-platform-engineer` + `staff-backend-engineer` — verify pipelines and environment consistency |
@@ -205,11 +209,13 @@ The Change type column keys on what the change *does* for an operator or consume
 
 When you do spawn a specialist, be specific. "Spawn `ciso-reviewer`" is useless; "Spawn `ciso-reviewer` and ask it to verify the checkout flow in CheckoutPage.tsx still enforces ownership after the new validation" is actionable.
 
+Specialist agents must return ≤2K tokens of structured findings (checklist-item-keyed bullets), not narrative prose. When spawning, include this constraint in the agent prompt.
+
 ## Reconciliation
 
 Same logic as plan-review's Reconciliation — repeated because skills load on demand.
 
-After spawned reviewers return findings, pause if findings concentrate on a single surface — the same feature, implementation detail, or design choice attracting multiple gaps. Two readings:
+After spawned reviewers return findings, pause if findings concentrate on a single surface — the same feature, implementation detail, or design choice attracting multiple gaps. If two specialists flag the same `file:line` with the same root cause, present the finding once with both reviewer attributions rather than as duplicate findings. Two readings:
 
 - **Implementation-wrong-shape.** The surface is the wrong abstraction; gaps will keep multiplying as you patch. Replace, don't patch-by-patch.
 - **Prompt-overlap artifact.** Reviewers given similar prompts produce N voices of the same observation. Convergence looks like signal but is framing-induced.


### PR DESCRIPTION
## Summary

- **F-15** — Schema fan-out rule: replaces the flat three-way data-model spawn row with tiered routing by change type (nullable column/index/view → backend only; new table → backend+analytics; rename/drop/type-change/NOT NULL/partition/RLS → three-way).
- **F-16** — Dedupe overlapping findings: adds sentence to Reconciliation section specifying that two specialists flagging the same `file:line` with the same root cause are presented once with both attributions.
- **F-17** — Mirror plan-review ciso skip path: `ciso-reviewer` spawn is non-optional unless the change is declared dev-only or internal-only with no privilege boundary crossed; skip must be named in review output.
- **F-21** — Specialist output budget: paragraph added after spawn table requiring specialists to return ≤2K tokens of structured findings; constraint must be included in agent prompt. Safety valve: when findings genuinely exceed the budget, the agent must prioritize by severity and explicitly note that lower-severity items were omitted (mirrors plan-review/SKILL.md).

## Test plan

- [x] `pytest claude/.claude/hooks/tests/` — 368 passed
- [x] `ruff check claude/.claude/hooks/tests/` — clean
- [x] Existing `TestRequireCodeReview` tests unchanged and passing

Refs #96
Refs #97
Closes #99
Refs #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)