### PR TITLE
review-permissions: move TRIGGER into frontmatter description, add DO NOT TRIGGER (F-04 Phase 1)

### DIFF
--- a/claude/.claude/skills/review-permissions/SKILL.md
+++ b/claude/.claude/skills/review-permissions/SKILL.md
@@ -1,9 +1,17 @@
 ---
 name: review-permissions
-description: Security review of permissions.allow rules in Claude Code settings.json
+description: >
+  Security review of permissions.allow rules in Claude Code settings.json.
+  TRIGGER when: `permissions.allow` rules are added or modified in any
+  `.claude/settings.json`, or the user asks to review permission rules
+  or allowed commands.
+  DO NOT TRIGGER when: reviewing hook entries in settings.json (use
+  `claude-hook-review`); reviewing other settings.json fields — env,
+  model, theme (use `update-config`); reviewing Bash command behavior
+  that is unrelated to permissions scoping.
+allowed-tools: Read, Grep, Glob, Bash
+user-invocable: false
 ---
-
-TRIGGER when: `permissions.allow` rules are added or modified in any `.claude/settings.json`, the code-review skill detects permission scope changes, or the user asks to review permission rules or allowed commands.
 
 Review each `permissions.allow` entry against the security checklist below. The goal is to ensure allowed commands cannot be exploited for code execution, data exfiltration, secret exposure, or privilege escalation.
 


### PR DESCRIPTION
## Summary

- Move `TRIGGER when:` / `DO NOT TRIGGER when:` blocks from the skill body into the frontmatter `description` field, where the harness reads them at startup for auto-trigger matching
- Add `DO NOT TRIGGER when:` block (was entirely absent — adjacent skills `claude-hook-review` and `update-config` weren't named)
- Add `allowed-tools: Read, Grep, Glob, Bash` and `user-invocable: false` (missing frontmatter for a specialist skill)
- Remove consequence clause from TRIGGER: "the code-review skill detects permission scope changes" describes when another skill invokes this one, not an independent trigger condition

Part of F-04 Phase 1 (TRIGGER hygiene audit). All other specialist skills (`claude-hook-review`, `skill-review`, `test-conventions`, `test-evaluation`) had clean TRIGGERs already.

## Test plan

- [ ] Invoke `/review-permissions` on a `settings.json` diff that adds a `permissions.allow` rule — should fire
- [ ] Verify `claude-hook-review` fires on a hook-entry `settings.json` change and `review-permissions` does not co-fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)