### PR TITLE
docs: auto mode activation, hard-floor deny rules, settings.local.json template

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Schema-change diffs nominally route three ways — `staff-backend-engineer` (des
 ### Other
 
 - **`CLAUDE.md`** — baseline engineering instructions (judgment heuristics, working style, safety rules).
-- **`settings.json`** — global settings wiring up the hooks and statusline. Configured with **opusplan** as the default model (cost-effective and [recommended by Anthropic](https://support.claude.com/en/articles/14552983-models-usage-and-limits-in-claude-code)). Session-only overrides (model, effortLevel) are intentionally not tracked — use the `ANTHROPIC_MODEL` and `CLAUDE_CODE_EFFORT_LEVEL` env vars, or `/effort max` mid-session.
+- **`settings.json`** — global settings wiring up the hooks, statusline, and a `permissions.deny` hard floor for `sudo` and secret-file reads (see [Auto mode](#auto-mode)). Configured with **opusplan** as the default model (cost-effective and [recommended by Anthropic](https://support.claude.com/en/articles/14552983-models-usage-and-limits-in-claude-code)). Session-only overrides (model, effortLevel) are intentionally not tracked — use the `ANTHROPIC_MODEL` and `CLAUDE_CODE_EFFORT_LEVEL` env vars, or `/effort max` mid-session.
 - **`statusline-command.sh`** — status bar showing model, context usage, session cost, working directory, and git branch.
 
 ## Worktree enforcement
@@ -275,6 +275,88 @@ If a project's review pattern consistently surfaces gaps in these areas — and 
 ## Machine-specific overrides
 
 Machine-local Claude Code permissions belong in `~/.claude/settings.local.json` (not tracked).
+
+## Auto mode
+
+Auto mode replaces per-action permission prompts with a background classifier that evaluates each tool call before it runs, blocking anything irreversible, destructive, or targeted outside your environment. See the [engineering deep dive](https://www.anthropic.com/engineering/claude-code-auto-mode) and the [permission modes reference](https://code.claude.com/docs/en/permission-modes) for how the two-layer pipeline works.
+
+### Requirements
+
+- **Plan:** Max, Team, Enterprise, or Anthropic API. Not available on Pro, or on Bedrock, Vertex, or Foundry.
+- **Model:** Claude Sonnet 4.6, Opus 4.6, or Opus 4.7 (Team/Enterprise/API); Opus 4.7 only on Max. Verify that any custom model alias in your `settings.json` ultimately resolves to one of these.
+- **Claude Code:** v2.1.83 or later.
+
+### Activating
+
+Press **Shift+Tab** in the CLI to cycle through modes until `auto` appears, then accept the one-time opt-in prompt. To start directly in auto mode:
+
+```bash
+claude --permission-mode auto
+```
+
+To make it the default, add to `~/.claude/settings.json`:
+
+```json
+{
+  "permissions": {
+    "defaultMode": "auto"
+  }
+}
+```
+
+### Hard-floor deny rules
+
+`settings.json` in this repo ships a `permissions.deny` list that runs *before* the classifier and cannot be overridden by any `autoMode.allow` entry. These close gaps the classifier's default block list doesn't cover:
+
+| Rule | What it closes |
+|---|---|
+| `Bash(sudo *)`, `Bash(sudo)` | Privilege escalation — turns the `sudo` prohibition in `CLAUDE.md` into a hard block |
+| `Read(**/.env)`, `Read(**/.env.*)` | Local secret reads — the classifier won't flag in-working-directory reads as exfiltration |
+| `Read(**/credentials.json)` | Cloud provider credential files (AWS CLI, GCP service accounts, etc.) |
+
+These rules apply in all permission modes, not only auto mode.
+
+### What to put in `settings.local.json`
+
+The classifier trusts only the working repo and its configured remotes by default. Add `autoMode.environment` to `~/.claude/settings.local.json` (gitignored) to declare which infrastructure is yours, reducing false positives on routine operations:
+
+```json
+{
+  "autoMode": {
+    "environment": [
+      "$defaults",
+      "Organization: <org name>. Primary use: <use case, e.g. software development, security consulting>.",
+      "Source control: github.com — only repos this developer is a collaborator on. Do not push to other organizations.",
+      "Trusted domains: <domains your work regularly reaches, e.g. supabase.com, vercel.com, api.example.com>",
+      "Additional context: <regulated industry, multi-tenant infrastructure, compliance constraints if any>"
+    ]
+  }
+}
+```
+
+`"$defaults"` splices in the built-in trust list at that position. Omit it only if you intend to replace the defaults entirely — doing so silently drops all built-in block rules including force-push and `curl | bash` protection. See the [danger note in the config reference](https://code.claude.com/docs/en/auto-mode-config#override-the-block-and-allow-rules).
+
+Keep project names, internal hostnames, and private domain names in `settings.local.json`. Do not put them in the committed `settings.json`.
+
+Start minimal and expand reactively: run `claude auto-mode config` to see your effective config, and check `/permissions → Recently denied` after the first few sessions to find legitimate operations the classifier is blocking.
+
+### Broad allow rules drop in auto mode
+
+When auto mode activates, Claude Code silently drops `permissions.allow` rules that grant arbitrary code execution:
+
+- Blanket wildcards: `Bash(*)`, `PowerShell(*)`
+- Wildcarded interpreters: `Bash(python3:*)`, `Bash(node:*)`, and similar
+- Package-manager run commands
+
+Check your `settings.local.json` for entries matching these patterns — those operations will route to the classifier instead of auto-approving. Narrow rules like `Bash(npm test)` carry over unchanged. Dropped rules are restored when you leave auto mode.
+
+### Inspection and tuning
+
+```bash
+claude auto-mode defaults   # print built-in environment, allow, and soft_deny rules
+claude auto-mode config     # print effective config with your settings applied
+claude auto-mode critique   # get AI feedback on your custom rules
+```
 
 ## Output preferences
 

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -135,5 +135,14 @@
       }
     }
   },
-  "model": "opusplan"
+  "model": "opusplan",
+  "permissions": {
+    "deny": [
+      "Bash(sudo *)",
+      "Bash(sudo)",
+      "Read(**/.env)",
+      "Read(**/.env.*)",
+      "Read(**/credentials.json)"
+    ]
+  }
 }


### PR DESCRIPTION
## Summary

- Adds a full **Auto mode** section to README covering requirements, activation, the two-layer classifier pipeline, and tuning commands
- Documents the `permissions.deny` hard-floor rules (sudo, .env, credentials.json) shipped in `settings.json` and why they complement the classifier
- Provides a `settings.local.json` `autoMode.environment` template with a `"$defaults"` retention warning and the broad-allow-rules-drop gotcha
- Updates the `settings.json` bullet in the "Other" config table to reflect the new deny block

`settings.json` change: adds the `permissions.deny` block. These rules run before the classifier and cannot be overridden by `autoMode.allow` — they harden the sudo and secret-read gaps that were previously advisory-only in `CLAUDE.md`.

## Test plan

- [ ] Verify `Read(**/.env)` and `Bash(sudo *)` entries in `claude/.claude/settings.json` match the documented table
- [ ] Confirm `"$defaults"` warning in the template is accurate against the [auto-mode-config reference](https://code.claude.com/docs/en/auto-mode-config#override-the-block-and-allow-rules)
- [ ] Confirm activation instructions (Shift+Tab, `--permission-mode auto`, `defaultMode` setting) are current
- [ ] Spot-check `claude auto-mode defaults/config/critique` command names against CLI help

🤖 Generated with [Claude Code](https://claude.com/claude-code)