### PR TITLE
fix: add backtick hygiene note to ready-for-review section 4

### DIFF
--- a/claude/.claude/skills/ready-for-review/SKILL.md
+++ b/claude/.claude/skills/ready-for-review/SKILL.md
@@ -145,6 +145,15 @@ Propose an updated body and apply with `gh pr edit <n> --body`. Keep
 the project's template structure intact — refresh content inside
 existing sections, don't restructure.
 
+**Backtick hygiene.** When constructing the new body via
+`gh pr edit <n> --body "$(cat <<'EOF' … EOF )"`, write backticks
+literally inside the heredoc. Do NOT write `\``. The single-quoted
+delimiter (`'EOF'`) tells bash to preserve every character verbatim —
+no expansion, no escape processing — so `\`` survives into the body and
+breaks GitHub markdown code-span rendering. Backslash-escape backticks
+only inside double-quoted strings or unquoted (`<<EOF`) heredocs where
+they would otherwise trigger command substitution.
+
 ## 5. CI status (warn only; skip if no PR)
 
 Run `gh pr checks <n>`.


### PR DESCRIPTION
## Summary

- Adds a **Backtick hygiene** paragraph to section 4 of `ready-for-review/SKILL.md`, immediately after the `gh pr edit` instruction block
- Explains that inside single-quoted heredocs (`<<'EOF'`), backticks must be written literally — not as `\`` — because single-quoting disables all bash escape processing
- Includes the contrast case: backslash-escaping is correct inside double-quoted strings or unquoted `<<EOF` heredocs where backticks would otherwise trigger command substitution

## Test plan

- [ ] Read the updated section 4 and verify the new paragraph appears between the `gh pr edit` block and the `## 5. CI status` header
- [ ] Confirm HOOK_TEST_FIXTURE anchor blocks (lines ~40, ~178, ~185) are unchanged — run the hook-alignment test suite if available

🤖 Generated with [Claude Code](https://claude.com/claude-code)