### PR TITLE
Process improvements from PR #145 meta-analysis (items a, b, d, f, i, j)

### DIFF
--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -43,6 +43,14 @@
 - Never commit secrets, credentials, API keys, or large binary assets to repositories.
 - Never use the Read tool on files likely to contain secrets (`.env`, `.claude.json`, `credentials.json`, similar). Reading pulls the secret into the conversation context. When you need to inspect such a file, give the user a shell command (`cat`, `grep`, `jq`) to run via `!` instead.
 
+## Code Comments
+
+Comments must be readable by a future coder who has not read the PR description, commit message, or planning document. In particular:
+
+- **No PR-defined terminology** in code comments (e.g., "Defense A", "Action 6", "Pattern C"). If a label is meaningful it must be defined in code (constant name, function name, type name) — not in a comment that depends on context outside the file.
+- **No "used to be X" / "was Y before"** framing. The rationale-vs-prior-version belongs in the commit message or PR body.
+- **Self-test:** if you can't write the comment such that it survives the PR being merged and the description being lost, don't write the comment. Move the rationale to the commit message instead.
+
 ## Output Preferences
 
 If `~/.claude/output-preferences.md` exists, read it at session start and apply those preferences for response tone and formatting. Cap at 50 lines.

--- a/claude/.claude/hooks/require-plan-review.sh
+++ b/claude/.claude/hooks/require-plan-review.sh
@@ -29,10 +29,11 @@
 INPUT=$(cat)
 TOOL_NAME=$(printf '%s\n' "$INPUT" | jq -r '.tool_name // empty')
 
-# Only gate Write and Edit tool calls.
-if [ "$TOOL_NAME" != "Write" ] && [ "$TOOL_NAME" != "Edit" ]; then
-  exit 0
-fi
+# Only gate Write, Edit, and MultiEdit tool calls.
+case "$TOOL_NAME" in
+  Write|Edit|MultiEdit) ;;
+  *) exit 0 ;;
+esac
 
 # Not in a git repo — can't check for plan files or key the marker.
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)

--- a/claude/.claude/hooks/require-plan-review.sh
+++ b/claude/.claude/hooks/require-plan-review.sh
@@ -7,10 +7,16 @@
 # Projects without a .claude/plans/ directory or with no plan files pass
 # through silently — the plan-existence check is the built-in filter.
 #
-# Marker layout:
-#   ~/.claude/plan-review-markers/<repo-hash>.<session_id>
-# Written by the /plan-review skill when a clean review completes.
-# The marker is keyed per-session (not a singleton) to prevent parallel
+# Two-marker pattern:
+# - Active marker (~/.claude/.plan-review-active.d/<session_id>):
+#   presence-only, fresh mtime <60 min. Written by /plan-review at step 0;
+#   removed at the deactivation step. Bypasses the gate so the skill's own
+#   Write/Edit calls during review don't self-deny. mtime refreshed on each
+#   bypass to handle long reviews.
+# - Completion marker (~/.claude/plan-review-markers/<repo-hash>.<session_id>):
+#   written by /plan-review when the review is clean. Existence-checked;
+#   allows Write/Edit until the next session.
+# The markers are keyed per-session (not singletons) to prevent parallel
 # sessions from overwriting each other's markers.
 #
 # Defense-in-depth: the hook filters its own input by tool name; do not
@@ -50,6 +56,14 @@ SESSION_ID=$(printf '%s\n' "$INPUT" | jq -r '.session_id // empty')
 
 # Without session_id, we cannot key a per-session marker — block.
 if [ -n "$SESSION_ID" ]; then
+  # Active-marker bypass: the /plan-review skill is currently running.
+  ACTIVE_MARKER="$HOME/.claude/.plan-review-active.d/$SESSION_ID"
+  if [ -f "$ACTIVE_MARKER" ] && [ -n "$(find "$ACTIVE_MARKER" -mmin -60 2>/dev/null)" ]; then
+    touch "$ACTIVE_MARKER" 2>/dev/null
+    exit 0
+  fi
+
+  # Completion-marker check.
   REPO_HASH=$(printf '%s' "$REPO_ROOT" | sha256sum | awk '{print $1}')
   MARKER="$HOME/.claude/plan-review-markers/$REPO_HASH.$SESSION_ID"
   if [ -f "$MARKER" ]; then

--- a/claude/.claude/hooks/session-marker-dashboard.sh
+++ b/claude/.claude/hooks/session-marker-dashboard.sh
@@ -1,16 +1,20 @@
 #!/bin/bash
-# SessionStart hook: display active-marker state so post-compaction sessions
-# can see which gate-bypass markers are already present on disk.
+# SessionStart hook: surface active gate-bypass marker state to the resuming
+# Claude session.
 #
-# Output goes to stdout as plain text, which the harness injects into
-# Claude's conversation context at session start. Only emits when at least
-# one active marker is present or stale — all-absent (the normal fresh-session
-# state) produces no output so routine session starts stay noise-free.
+# Audience: Claude (the agent), not humans. The harness injects plain-text
+# stdout from SessionStart hooks directly into the agent's conversation context
+# at session start. This lets a new session — after compaction or restart —
+# see which review-skill gates are already bypassed without having to rediscover
+# the on-disk state itself.
 #
-# Active markers are session-scoped (keyed by session_id, not repo hash) so
-# they can always be checked here regardless of which git repo the session
-# opens in. Completion markers are repo-scoped and checked lazily by the
-# PreToolUse hooks instead.
+# Emits output only when at least one active marker is present or stale.
+# All-absent (normal fresh-session state) produces no output, keeping routine
+# session starts noise-free.
+#
+# Active markers are session-scoped (keyed by session_id) so they can be
+# checked here regardless of which git repo the session opens in. Completion
+# markers are repo-scoped and checked lazily by the PreToolUse hooks.
 #
 # Exit 0 always — this hook must not block session startup.
 
@@ -51,7 +55,7 @@ if [ "$PLAN_REVIEW_STATUS" = "absent" ] \
   exit 0
 fi
 
-printf "Session marker state (active review markers from a prior session or interrupted review):\n"
+printf "Active review-skill gate markers detected for this session. Each line below shows one skill's bypass state — \"present\" means the gate is bypassed (skill is mid-run or was interrupted); \"stale\" (>60 min old) means the bypass has expired and the gate is back in force.\n"
 printf "  plan-review-active: %s\n" "$PLAN_REVIEW_STATUS"
 printf "  ready-for-review-active: %s\n" "$READY_FOR_REVIEW_STATUS"
 printf "  respond-pr-active: %s\n" "$RESPOND_PR_STATUS"

--- a/claude/.claude/hooks/session-marker-dashboard.sh
+++ b/claude/.claude/hooks/session-marker-dashboard.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# SessionStart hook: display active-marker state so post-compaction sessions
+# can see which gate-bypass markers are already present on disk.
+#
+# Output goes to stdout as plain text, which the harness injects into
+# Claude's conversation context at session start. Only emits when at least
+# one active marker is present or stale — all-absent (the normal fresh-session
+# state) produces no output so routine session starts stay noise-free.
+#
+# Active markers are session-scoped (keyed by session_id, not repo hash) so
+# they can always be checked here regardless of which git repo the session
+# opens in. Completion markers are repo-scoped and checked lazily by the
+# PreToolUse hooks instead.
+#
+# Exit 0 always — this hook must not block session startup.
+
+INPUT=$(cat 2>/dev/null)
+SESSION_ID=$(printf '%s\n' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null)
+if [ -z "$SESSION_ID" ]; then
+  exit 0
+fi
+
+marker_status() {
+  local marker="$1"
+  if [ ! -f "$marker" ]; then
+    printf "absent"
+    return
+  fi
+  local now_s mtime_s age_min
+  now_s=$(date +%s 2>/dev/null)
+  mtime_s=$(date -r "$marker" +%s 2>/dev/null)  # -r <file> works on GNU date (Linux) and BSD date (macOS)
+  if [ -z "$mtime_s" ] || [ -z "$now_s" ]; then
+    printf "present (mtime unknown)"
+    return
+  fi
+  age_min=$(( (now_s - mtime_s) / 60 ))
+  if [ "$age_min" -ge 60 ]; then
+    printf "stale (%dm ago)" "$age_min"
+  else
+    printf "present (%dm ago)" "$age_min"
+  fi
+}
+
+PLAN_REVIEW_STATUS=$(marker_status "$HOME/.claude/.plan-review-active.d/$SESSION_ID")
+READY_FOR_REVIEW_STATUS=$(marker_status "$HOME/.claude/.ready-for-review-active.d/$SESSION_ID")
+RESPOND_PR_STATUS=$(marker_status "$HOME/.claude/.respond-pr-active.d/$SESSION_ID")
+
+if [ "$PLAN_REVIEW_STATUS" = "absent" ] \
+   && [ "$READY_FOR_REVIEW_STATUS" = "absent" ] \
+   && [ "$RESPOND_PR_STATUS" = "absent" ]; then
+  exit 0
+fi
+
+printf "Session marker state (active review markers from a prior session or interrupted review):\n"
+printf "  plan-review-active: %s\n" "$PLAN_REVIEW_STATUS"
+printf "  ready-for-review-active: %s\n" "$READY_FOR_REVIEW_STATUS"
+printf "  respond-pr-active: %s\n" "$RESPOND_PR_STATUS"

--- a/claude/.claude/hooks/tests/test_require_plan_review.py
+++ b/claude/.claude/hooks/tests/test_require_plan_review.py
@@ -1,18 +1,26 @@
 """Tests for require-plan-review.sh."""
 from __future__ import annotations
 
+import os
 import subprocess
+import time
 
 import pytest
 from helpers import (
     HOOKS_DIR,
+    SKILLS_DIR,
     bash_input,
     edit_input,
+    extract_skill_command,
+    plan_review_marker_path,
     run_hook,
     run_hook_reason,
+    run_skill_command,
     write_input,
     write_plan_review_marker,
 )
+
+PLAN_REVIEW_SKILL = SKILLS_DIR / "plan-review" / "SKILL.md"
 
 REQUIRE_PLAN_REVIEW_HOOK = HOOKS_DIR / "require-plan-review.sh"
 
@@ -184,3 +192,215 @@ class TestRequirePlanReview:
         assert reason is not None
         assert "/plan-review" in reason
         assert "plan-review-markers" in reason
+
+    # -- Active-marker bypass -----------------------------------------------
+    # Marker layout: ~/.claude/.plan-review-active.d/<session_id>.
+    # The /plan-review skill writes one file per session at Step 0 and
+    # removes it at the deactivation step. While fresh (<60 min), the hook
+    # bypasses the gate so the skill's own Write/Edit calls don't self-deny.
+
+    def test_fresh_active_marker_allows_write(self, plan_review_repo, plan_review_home):
+        """Active marker created by /plan-review Step 0 bypasses the gate."""
+        sid = "session-active-write"
+        marker_dir = plan_review_home / ".claude" / ".plan-review-active.d"
+        marker_dir.mkdir(parents=True)
+        (marker_dir / sid).touch()
+        assert (
+            run_hook(
+                REQUIRE_PLAN_REVIEW_HOOK,
+                {**write_input("/tmp/foo.py"), "session_id": sid},
+                cwd=plan_review_repo,
+            )
+            == "allow"
+        )
+
+    def test_fresh_active_marker_allows_edit(self, plan_review_repo, plan_review_home):
+        sid = "session-active-edit"
+        marker_dir = plan_review_home / ".claude" / ".plan-review-active.d"
+        marker_dir.mkdir(parents=True)
+        (marker_dir / sid).touch()
+        assert (
+            run_hook(
+                REQUIRE_PLAN_REVIEW_HOOK,
+                {**edit_input("/tmp/foo.py"), "session_id": sid},
+                cwd=plan_review_repo,
+            )
+            == "allow"
+        )
+
+    def test_stale_active_marker_falls_through_to_deny(
+        self, plan_review_repo, plan_review_home
+    ):
+        """>60min old active marker doesn't bypass; no completion marker → deny."""
+        sid = "session-stale-active"
+        marker_dir = plan_review_home / ".claude" / ".plan-review-active.d"
+        marker_dir.mkdir(parents=True)
+        marker = marker_dir / sid
+        marker.touch()
+        ninety_min_ago = time.time() - 90 * 60
+        os.utime(marker, (ninety_min_ago, ninety_min_ago))
+        assert (
+            run_hook(
+                REQUIRE_PLAN_REVIEW_HOOK,
+                {**write_input("/tmp/foo.py"), "session_id": sid},
+                cwd=plan_review_repo,
+            )
+            == "deny"
+        )
+
+    def test_other_sessions_active_marker_does_not_bypass(
+        self, plan_review_repo, plan_review_home
+    ):
+        """Per-session keying: session A's active marker must NOT bypass session B."""
+        marker_dir = plan_review_home / ".claude" / ".plan-review-active.d"
+        marker_dir.mkdir(parents=True)
+        (marker_dir / "session-A").touch()
+        assert (
+            run_hook(
+                REQUIRE_PLAN_REVIEW_HOOK,
+                {**write_input("/tmp/foo.py"), "session_id": "session-B"},
+                cwd=plan_review_repo,
+            )
+            == "deny"
+        )
+
+    def test_active_marker_mtime_refreshed_on_bypass(
+        self, plan_review_repo, plan_review_home
+    ):
+        """Long-running review mitigation: hook touches the active marker on each
+        bypass so a session approaching the 60-min cutoff doesn't get blocked."""
+        sid = "session-long-review"
+        marker_dir = plan_review_home / ".claude" / ".plan-review-active.d"
+        marker_dir.mkdir(parents=True)
+        marker = marker_dir / sid
+        marker.touch()
+        fifty_min_ago = time.time() - 50 * 60
+        os.utime(marker, (fifty_min_ago, fifty_min_ago))
+        pre_mtime = marker.stat().st_mtime
+        assert (
+            run_hook(
+                REQUIRE_PLAN_REVIEW_HOOK,
+                {**write_input("/tmp/foo.py"), "session_id": sid},
+                cwd=plan_review_repo,
+            )
+            == "allow"
+        )
+        assert marker.stat().st_mtime > pre_mtime, (
+            "active marker mtime must be refreshed on bypass to keep long reviews alive"
+        )
+
+    # -- SKILL.md fixture alignment -----------------------------------------
+
+    def test_skill_activate_command_creates_bypass_marker(
+        self, plan_review_repo, plan_review_home
+    ):
+        """Run the SKILL.md activate-gate recipe; verify the resulting marker
+        authorizes a previously-gated Write."""
+        sid = "session-skill-activate"
+        sessions_dir = plan_review_home / ".claude" / "sessions"
+        sessions_dir.mkdir(parents=True)
+        (sessions_dir / str(os.getpid())).write_text(sid)
+
+        assert (
+            run_hook(
+                REQUIRE_PLAN_REVIEW_HOOK,
+                {**write_input("/tmp/foo.py"), "session_id": sid},
+                cwd=plan_review_repo,
+            )
+            == "deny"
+        ), "precondition: Write must be gated before activation"
+
+        run_skill_command(
+            extract_skill_command(PLAN_REVIEW_SKILL, "activate-gate"),
+            cwd=plan_review_repo,
+            isolated_home=plan_review_home,
+        )
+
+        marker = plan_review_home / ".claude" / ".plan-review-active.d" / sid
+        assert marker.exists(), (
+            "SKILL.md activate-gate recipe ran but no marker landed at the path "
+            "the hook checks — skill and hook disagree on layout."
+        )
+        assert (
+            run_hook(
+                REQUIRE_PLAN_REVIEW_HOOK,
+                {**write_input("/tmp/foo.py"), "session_id": sid},
+                cwd=plan_review_repo,
+            )
+            == "allow"
+        )
+
+    def test_skill_deactivate_command_removes_bypass_marker(
+        self, plan_review_repo, plan_review_home
+    ):
+        """Run activate then deactivate from SKILL.md; verify deactivate removes
+        the marker and the hook re-gates."""
+        sid = "session-skill-deactivate"
+        sessions_dir = plan_review_home / ".claude" / "sessions"
+        sessions_dir.mkdir(parents=True)
+        (sessions_dir / str(os.getpid())).write_text(sid)
+
+        run_skill_command(
+            extract_skill_command(PLAN_REVIEW_SKILL, "activate-gate"),
+            cwd=plan_review_repo,
+            isolated_home=plan_review_home,
+        )
+        marker = plan_review_home / ".claude" / ".plan-review-active.d" / sid
+        assert marker.exists(), "activate-gate setup did not create the marker"
+
+        run_skill_command(
+            extract_skill_command(PLAN_REVIEW_SKILL, "deactivate-gate"),
+            cwd=plan_review_repo,
+            isolated_home=plan_review_home,
+        )
+        assert not marker.exists(), (
+            "SKILL.md deactivate-gate recipe ran but marker is still present — "
+            "skill and hook disagree on the marker path."
+        )
+        assert (
+            run_hook(
+                REQUIRE_PLAN_REVIEW_HOOK,
+                {**write_input("/tmp/foo.py"), "session_id": sid},
+                cwd=plan_review_repo,
+            )
+            == "deny"
+        )
+
+    def test_skill_completion_command_writes_completion_marker(
+        self, plan_review_repo, plan_review_home
+    ):
+        """Run the SKILL.md record-completion recipe; verify the resulting marker
+        authorizes a previously-gated Write via the completion path."""
+        sid = "session-skill-completion"
+        sessions_dir = plan_review_home / ".claude" / "sessions"
+        sessions_dir.mkdir(parents=True)
+        (sessions_dir / str(os.getpid())).write_text(sid)
+
+        assert (
+            run_hook(
+                REQUIRE_PLAN_REVIEW_HOOK,
+                {**write_input("/tmp/foo.py"), "session_id": sid},
+                cwd=plan_review_repo,
+            )
+            == "deny"
+        ), "precondition: Write must be gated before completion marker is written"
+
+        run_skill_command(
+            extract_skill_command(PLAN_REVIEW_SKILL, "record-completion"),
+            cwd=plan_review_repo,
+            isolated_home=plan_review_home,
+        )
+
+        expected_marker = plan_review_marker_path(plan_review_home, plan_review_repo, sid)
+        assert expected_marker.exists(), (
+            "SKILL.md record-completion recipe ran but no marker landed at the path "
+            "the hook checks — skill and hook disagree on layout."
+        )
+        assert (
+            run_hook(
+                REQUIRE_PLAN_REVIEW_HOOK,
+                {**write_input("/tmp/foo.py"), "session_id": sid},
+                cwd=plan_review_repo,
+            )
+            == "allow"
+        )

--- a/claude/.claude/hooks/tests/test_require_plan_review.py
+++ b/claude/.claude/hooks/tests/test_require_plan_review.py
@@ -12,6 +12,7 @@ from helpers import (
     bash_input,
     edit_input,
     extract_skill_command,
+    multiedit_input,
     plan_review_marker_path,
     run_hook,
     run_hook_reason,
@@ -226,6 +227,32 @@ class TestRequirePlanReview:
                 cwd=plan_review_repo,
             )
             == "allow"
+        )
+
+    def test_fresh_active_marker_allows_multiedit(self, plan_review_repo, plan_review_home):
+        sid = "session-active-multiedit"
+        marker_dir = plan_review_home / ".claude" / ".plan-review-active.d"
+        marker_dir.mkdir(parents=True)
+        (marker_dir / sid).touch()
+        assert (
+            run_hook(
+                REQUIRE_PLAN_REVIEW_HOOK,
+                {**multiedit_input("/tmp/foo.py"), "session_id": sid},
+                cwd=plan_review_repo,
+            )
+            == "allow"
+        )
+
+    def test_plan_exists_no_marker_denies_multiedit(
+        self, plan_review_repo, plan_review_home
+    ):
+        assert (
+            run_hook(
+                REQUIRE_PLAN_REVIEW_HOOK,
+                {**multiedit_input("/tmp/foo.py"), "session_id": "test-session-prt"},
+                cwd=plan_review_repo,
+            )
+            == "deny"
         )
 
     def test_stale_active_marker_falls_through_to_deny(

--- a/claude/.claude/hooks/tests/test_session_marker_dashboard.py
+++ b/claude/.claude/hooks/tests/test_session_marker_dashboard.py
@@ -1,0 +1,122 @@
+"""Tests for session-marker-dashboard.sh.
+
+The hook is a SessionStart hook whose stdout is injected by the harness
+into the Claude session's conversation context. It surfaces existing
+active-marker state so Claude can see which review-skill gates are
+currently bypassed when resuming after compaction.
+
+Output is emitted only when at least one active marker is present or
+stale — an all-absent state (normal fresh session) produces no output.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+from helpers import HOOKS_DIR
+
+SESSION_MARKER_DASHBOARD_HOOK = HOOKS_DIR / "session-marker-dashboard.sh"
+
+
+def _run_dashboard(payload: dict, isolated_home: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [str(SESSION_MARKER_DASHBOARD_HOOK)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env={**os.environ, "HOME": str(isolated_home)},
+        check=False,
+    )
+
+
+class TestSessionMarkerDashboard:
+    def test_all_absent_produces_no_output(self, isolated_home):
+        """When no active markers exist, the hook exits silently."""
+        result = _run_dashboard({"session_id": "sess-absent"}, isolated_home)
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+    def test_fresh_plan_review_marker_prints_dashboard(self, isolated_home):
+        """A fresh plan-review-active marker triggers dashboard output."""
+        sid = "sess-pr-active"
+        marker_dir = isolated_home / ".claude" / ".plan-review-active.d"
+        marker_dir.mkdir(parents=True)
+        (marker_dir / sid).touch()
+        result = _run_dashboard({"session_id": sid}, isolated_home)
+        assert result.returncode == 0
+        assert "plan-review-active" in result.stdout
+        assert "present" in result.stdout
+
+    def test_stale_plan_review_marker_shows_stale(self, isolated_home):
+        """A >60-min-old active marker is labelled 'stale'."""
+        sid = "sess-pr-stale"
+        marker_dir = isolated_home / ".claude" / ".plan-review-active.d"
+        marker_dir.mkdir(parents=True)
+        marker = marker_dir / sid
+        marker.touch()
+        ninety_min_ago = time.time() - 90 * 60
+        os.utime(marker, (ninety_min_ago, ninety_min_ago))
+        result = _run_dashboard({"session_id": sid}, isolated_home)
+        assert result.returncode == 0
+        assert "stale" in result.stdout
+        assert "plan-review-active" in result.stdout
+
+    def test_respond_pr_marker_triggers_output(self, isolated_home):
+        """A respond-pr-active marker also triggers the dashboard."""
+        sid = "sess-rpr-active"
+        marker_dir = isolated_home / ".claude" / ".respond-pr-active.d"
+        marker_dir.mkdir(parents=True)
+        (marker_dir / sid).touch()
+        result = _run_dashboard({"session_id": sid}, isolated_home)
+        assert result.returncode == 0
+        assert "respond-pr-active" in result.stdout
+        assert "present" in result.stdout
+
+    def test_ready_for_review_marker_triggers_output(self, isolated_home):
+        """A ready-for-review-active marker triggers the dashboard."""
+        sid = "sess-rfr-active"
+        marker_dir = isolated_home / ".claude" / ".ready-for-review-active.d"
+        marker_dir.mkdir(parents=True)
+        (marker_dir / sid).touch()
+        result = _run_dashboard({"session_id": sid}, isolated_home)
+        assert result.returncode == 0
+        assert "ready-for-review-active" in result.stdout
+        assert "present" in result.stdout
+
+    def test_other_sessions_marker_does_not_trigger(self, isolated_home):
+        """Session A's active marker must not appear in session B's dashboard."""
+        marker_dir = isolated_home / ".claude" / ".plan-review-active.d"
+        marker_dir.mkdir(parents=True)
+        (marker_dir / "session-A").touch()
+        result = _run_dashboard({"session_id": "session-B"}, isolated_home)
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+    def test_no_session_id_produces_no_output(self, isolated_home):
+        """Missing session_id in the payload → hook exits silently."""
+        result = _run_dashboard({}, isolated_home)
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+    def test_all_three_markers_all_shown(self, isolated_home):
+        """When all three skills have active markers, all three appear."""
+        sid = "sess-all-active"
+        for skill in ("plan-review", "ready-for-review", "respond-pr"):
+            marker_dir = isolated_home / ".claude" / f".{skill}-active.d"
+            marker_dir.mkdir(parents=True)
+            (marker_dir / sid).touch()
+        result = _run_dashboard({"session_id": sid}, isolated_home)
+        assert result.returncode == 0
+        assert "plan-review-active" in result.stdout
+        assert "ready-for-review-active" in result.stdout
+        assert "respond-pr-active" in result.stdout
+        assert result.stdout.count("present") == 3
+
+    def test_exit_0_always(self, isolated_home):
+        """Hook must always exit 0 to avoid blocking session startup."""
+        result = _run_dashboard({"session_id": "sess-exit-check"}, isolated_home)
+        assert result.returncode == 0

--- a/claude/.claude/hooks/tests/test_session_marker_dashboard.py
+++ b/claude/.claude/hooks/tests/test_session_marker_dashboard.py
@@ -110,10 +110,9 @@ class TestSessionMarkerDashboard:
             (marker_dir / sid).touch()
         result = _run_dashboard({"session_id": sid}, isolated_home)
         assert result.returncode == 0
-        assert "plan-review-active" in result.stdout
-        assert "ready-for-review-active" in result.stdout
-        assert "respond-pr-active" in result.stdout
-        assert result.stdout.count("present") == 3
+        assert "plan-review-active: present" in result.stdout
+        assert "ready-for-review-active: present" in result.stdout
+        assert "respond-pr-active: present" in result.stdout
 
     def test_exit_0_always(self, isolated_home):
         """Hook must always exit 0 to avoid blocking session startup."""

--- a/claude/.claude/hooks/tests/test_session_marker_dashboard.py
+++ b/claude/.claude/hooks/tests/test_session_marker_dashboard.py
@@ -16,7 +16,6 @@ import subprocess
 import time
 from pathlib import Path
 
-import pytest
 from helpers import HOOKS_DIR
 
 SESSION_MARKER_DASHBOARD_HOOK = HOOKS_DIR / "session-marker-dashboard.sh"

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -6,6 +6,10 @@
           {
             "type": "command",
             "command": "~/.claude/hooks/capture-session-id.sh"
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/session-marker-dashboard.sh"
           }
         ]
       }

--- a/claude/.claude/skills/plan-review/SKILL.md
+++ b/claude/.claude/skills/plan-review/SKILL.md
@@ -13,14 +13,25 @@ user-invocable: true
 
 Review an implementation plan. Act as a review board evaluating a proposal before engineering effort is committed. Be thorough but practical — flag real risks, not hypothetical ones.
 
-## Step 0 — Identify the plan
+## Step 0 — Activate gate session
+
+Write the active-session marker so this skill's own Write/Edit operations are not blocked by the `require-plan-review.sh` hook while the review is in progress:
+
+<!-- HOOK_TEST_FIXTURE: activate-gate — the hook-alignment test suite reads this exact fenced block from this file (claude/.claude/skills/plan-review/SKILL.md) to verify it matches require-plan-review.sh's active-marker layout. Do not duplicate the recipe elsewhere; the test re-reads it from here. -->
+```
+SESSION_ID=$(cat "$HOME/.claude/sessions/$PPID") && [ -n "$SESSION_ID" ] && mkdir -p "$HOME/.claude/.plan-review-active.d" && touch "$HOME/.claude/.plan-review-active.d/$SESSION_ID"
+```
+
+If the chain fails (empty `SESSION_ID`, etc.), the `capture-session-id.sh` SessionStart hook didn't run — abort and report; do not proceed without the marker, since the hook would block any Write/Edit during the review.
+
+## Step 1 — Identify the plan
 
 Find the plan to review. Check, in order:
 1. If a plan file path was provided as an argument, read it
 2. If a plan was just written in `.claude/plans/`, read the most recent one
 3. If a plan exists in the current conversation context, use that
 
-## Step 1 — Detect domains
+## Step 2 — Detect domains
 
 Read the plan and classify which domains it touches. When using an agent to explore the codebase for plan context, use `general-purpose` — not `Explore`. The `Explore` agent reads excerpts and is not suitable for design-doc auditing or cross-file consistency checks; it misses content past its read window.
 
@@ -34,7 +45,7 @@ Read the plan and classify which domains it touches. When using an agent to expl
 
 **Schema change routing:** Route schema changes by change type: new nullable column, index, or view → `staff-backend-engineer` only; new table → `staff-backend-engineer` + `staff-analytics-engineer`; rename, drop, type change, NOT NULL constraint added, partition key, or RLS policy → `staff-backend-engineer` + `staff-data-engineer` + `staff-analytics-engineer`. Add `staff-product-engineer` if user-visible.
 
-## Step 2 — Design-fitness gate
+## Step 3 — Design-fitness gate
 
 Before evaluating gaps, answer two questions in order:
 
@@ -51,11 +62,11 @@ Markers of over-elaboration:
 - Captured outputs / fields with no reader downstream.
 - "Could be done in N lines" stays a valid challenge even after persona reviewers have shaped the plan — persona-shaped is not persona-locked.
 
-If over-elaborated: stop. Surface the simpler design as the primary review output before any checklist findings. Otherwise proceed to Step 3 — gap-finding will surface what's missing.
+If over-elaborated: stop. Surface the simpler design as the primary review output before any checklist findings. Otherwise proceed to Step 4 — gap-finding will surface what's missing.
 
 Question implementation choices, not feature scope — the ticket itself isn't reviewed here, that goes back to the author.
 
-## Step 3 — Evaluate
+## Step 4 — Evaluate
 
 Evaluate the plan against the **Base checklist** first, then each detected **Domain checklist**. For multi-phase plans, evaluate each phase against the relevant checklists. Reference the specific phase/section when reporting findings.
 
@@ -79,7 +90,7 @@ B5. **Evidence** — Does the plan cite a source for each finding/assertion (fil
 
 ### Scope
 
-B6. **Proportionality** — Whole-design proportionality belongs to Step 2's gate. At checklist time, flag local issues only: a helper overkill for one caller, an abstraction at a single call site.
+B6. **Proportionality** — Whole-design proportionality belongs to Step 3's gate. At checklist time, flag local issues only: a helper overkill for one caller, an abstraction at a single call site.
 
 B7. **Scope creep** — Does the plan include work not required to solve the stated problem (adjacent improvements, premature optimization, "while we're here" refactors)? Capture these in **Out of Scope** — don't lose the observation, don't plan for it either.
 
@@ -196,7 +207,7 @@ This is the design-stage gate. Specialist misses here are recoverable in code-re
 - **Convergence-as-design-tell** from a prior round (see Reconciliation).
 - **Explicit user request.**
 
-Always spawn `ciso-reviewer` when the plan touches auth/authz, secrets, tokens, data exposure, sensitive-data logging, third-party data sharing, or infra permissions — high-stakes-boundary case is non-optional, **unless** the Step 2 user-surface declaration puts the change outside `ciso-reviewer`'s threat model (e.g., a dev-only flow with no production reachability, or an internal-only path where engineers themselves are the only callers and the change crosses no privilege boundary they shouldn't cross). When skipping on those grounds, name the surface in the review output — never silently skip. Always spawn `staff-product-engineer` when the plan changes user-facing behavior.
+Always spawn `ciso-reviewer` when the plan touches auth/authz, secrets, tokens, data exposure, sensitive-data logging, third-party data sharing, or infra permissions — high-stakes-boundary case is non-optional, **unless** the Step 3 user-surface declaration puts the change outside `ciso-reviewer`'s threat model (e.g., a dev-only flow with no production reachability, or an internal-only path where engineers themselves are the only callers and the change crosses no privilege boundary they shouldn't cross). When skipping on those grounds, name the surface in the review output — never silently skip. Always spawn `staff-product-engineer` when the plan changes user-facing behavior.
 
 Spawn per question (not per file-path domain) — "plan touches backend" isn't enough; the question needs a specific shape.
 
@@ -226,7 +237,7 @@ After spawned reviewers return findings, pause if findings concentrate on a sing
 - **Design-wrong-shape.** The surface is the wrong abstraction; gaps will keep multiplying as you patch. Replace, don't patch-by-patch.
 - **Prompt-overlap artifact.** Reviewers given similar prompts produce N voices of the same observation. Convergence looks like signal but is framing-induced.
 
-You judge which applies. Don't treat convergence as automatic authority for "patch each gap." If design-wrong-shape, replace the surface and re-run Step 2. If prompt-overlap, apply the underlying finding once, skip duplicates, and note the overlap so the next spawn uses tighter prompts.
+You judge which applies. Don't treat convergence as automatic authority for "patch each gap." If design-wrong-shape, replace the surface and re-run Step 3. If prompt-overlap, apply the underlying finding once, skip duplicates, and note the overlap so the next spawn uses tighter prompts.
 
 ## Item ownership
 
@@ -279,3 +290,23 @@ For each finding, state:
 If any items were flagged by B7 (scope creep), include an **Out of Scope** section listing them. The reviewer can decide whether to bring them into scope or create follow-up tickets.
 
 End with a verdict: **Approve**, **Approve with changes** (list what), or **Request changes** (list blockers).
+
+## Record review completion + deactivate
+
+After delivering the verdict, write the completion marker and remove the active-session marker.
+
+Write the completion marker only when the verdict is **Approve** or **Approve with changes** and all required changes have been applied to the plan. Do not write it on **Request changes** — write it only after the plan author revises the plan and a clean re-review completes.
+
+<!-- HOOK_TEST_FIXTURE: record-completion — the hook-alignment test suite reads this exact fenced block from this file (claude/.claude/skills/plan-review/SKILL.md) to verify it matches require-plan-review.sh's completion-marker layout. Do not duplicate the recipe elsewhere; the test re-reads it from here. -->
+```
+SESSION_ID=$(cat "$HOME/.claude/sessions/$PPID") && [ -n "$SESSION_ID" ] && mkdir -p "$HOME/.claude/plan-review-markers" && REPO_HASH=$(git rev-parse --show-toplevel | tr -d '\n' | sha256sum | awk '{print $1}') && printf 'reviewed\n' > "$HOME/.claude/plan-review-markers/$REPO_HASH.$SESSION_ID"
+```
+
+Then remove the active-session marker:
+
+<!-- HOOK_TEST_FIXTURE: deactivate-gate — the hook-alignment test suite reads this exact fenced block from this file (claude/.claude/skills/plan-review/SKILL.md) to verify it matches require-plan-review.sh's active-marker cleanup. Do not duplicate the recipe elsewhere; the test re-reads it from here. -->
+```
+SESSION_ID=$(cat "$HOME/.claude/sessions/$PPID" 2>/dev/null) && [ -n "$SESSION_ID" ] && rm -f "$HOME/.claude/.plan-review-active.d/$SESSION_ID"
+```
+
+Removes only this session's file. If the skill errors out before reaching this step, don't manually clean up — the hook's 60-minute staleness cutoff handles the orphan automatically.

--- a/claude/.claude/skills/plan-review/SKILL.md
+++ b/claude/.claude/skills/plan-review/SKILL.md
@@ -103,6 +103,13 @@ B14. **Missing decision rationale** — Are design choices explained? "Use appro
 
 B15. **Effort section reality** — If the plan has an "Estimated Effort" section, does it describe **review surface** (file count, domain complexity, risk concentration) rather than **implementation hours**? Hour-based estimates anchored in human coding speed mislead when Claude writes the code. Flag any effort section citing hours/days; rewrite in review-surface terms.
 
+B16. **Tech-debt intersection** — Does the plan touch, expand, or work around an existing tech-debt mechanism (grandfathered-violations list, legacy shim, `// TODO: refactor` marker, dual code path that exists for migration reasons)? If yes, the plan must explicitly choose between:
+
+- **(a) Expand the workaround for now** — with rationale (typically "the surgical fix is out-of-scope and would dilate the PR").
+- **(b) Include a surgical fix in this PR** — and adjust scope accordingly.
+
+Don't silently expand. The choice between (a) and (b) is calibrated to team size and PR-scope discipline — surface the intersection here, not after the fact in code-review. Flag as **missing scope (B8)** if the plan touches a tech-debt mechanism without acknowledging it.
+
 ## Domain: Infrastructure
 
 Apply when the plan touches CI/CD, workflows, deployment, or config.
@@ -240,6 +247,7 @@ The dispatcher fires reviewers per touched domain. Each agent self-scopes agains
 | **B11. Rollback strategy** | `staff-data-engineer`, `staff-platform-engineer`, `staff-backend-engineer` | `staff-sdet` (testability of rollback) |
 | **B12. Dependency risk** | `staff-backend-engineer` (runtime deps), `staff-platform-engineer` (CI / build deps) | — |
 | **B14. Missing decision rationale** | `staff-product-engineer` (user-impact decisions) | judgment (others) |
+| **B16. Tech-debt intersection** | `staff-product-engineer` (scope decision: fix now vs. defer) | domain reviewer for the affected area — whichever of `staff-backend-engineer`, `staff-frontend-engineer`, `staff-data-engineer`, or `staff-platform-engineer` owns the subsystem the tech debt lives in (surgical-fix feasibility) |
 | **I1–I4. Infrastructure** (env parity, idempotency, deployment ordering, secret/config provisioning) | `staff-platform-engineer` | `staff-data-engineer` (I2 migration-level idempotency); `ciso-reviewer` (I4 secret threat framing) |
 | **D1. Migration safety** | `staff-data-engineer` (pipeline impact, DDL form) | `staff-backend-engineer` (correctness), `staff-platform-engineer` (deploy-window, lock-budget) |
 | **D2. Migration reversibility** | `staff-data-engineer` | `staff-backend-engineer` |

--- a/claude/.claude/skills/respond-pr/SKILL.md
+++ b/claude/.claude/skills/respond-pr/SKILL.md
@@ -17,18 +17,39 @@ Fetch all review comments on the current branch's open pull request and address 
    ```
    The `require-respond-pr.sh` PreToolUse hook bypasses while THIS session's marker is fresh (<60 min) and refreshes its mtime on each bypass so long runs don't hit the staleness cutoff. Per-session keying prevents parallel respond-pr sessions from thrashing on cleanup or leaking bypass to unrelated sessions. If the chain fails (empty `SESSION_ID`, etc.), the `capture-session-id.sh` SessionStart hook didn't run — abort and report; do not proceed without the marker, since every gated `gh` call below will be blocked.
 
-   **Marker lifecycle:** this marker must stay active for the entire skill session — step 6 is the only step that removes it. If you run other skills as intermediate steps (e.g., `/ready-for-review` before pushing in step 5), their cleanup must not touch this marker. If the marker is accidentally removed mid-session, restore it in a standalone Bash call before any subsequent `gh` command — the hook fires before the shell executes, so you cannot create the marker and use it atomically in the same call.
+   **Marker lifecycle:** this marker must stay active for the entire skill session — step 7 is the only step that removes it. If you run other skills as intermediate steps (e.g., `/ready-for-review` before pushing in step 6), their cleanup must not touch this marker. If the marker is accidentally removed mid-session, restore it in a standalone Bash call before any subsequent `gh` command — the hook fires before the shell executes, so you cannot create the marker and use it atomically in the same call.
 1. Identify the PR number for the current branch: `gh pr view --json number -q '.number'`
 2. Fetch **all three** types of comments. Two failure modes Claude commonly hits: (a) fetching only the first type and missing the other two; (b) fetching without `--paginate` and silently truncating at 30 results per type. Both produce reviews that look complete but miss real feedback.
    - **Inline file comments:** `gh api repos/{owner}/{repo}/pulls/{number}/comments --paginate`
    - **Top-level review comments:** `gh api repos/{owner}/{repo}/pulls/{number}/reviews --paginate --jq '.[] | select(.body != "")'`
    - **Issue-level comments:** `gh api repos/{owner}/{repo}/issues/{number}/comments --paginate`
-3. For each unresolved comment:
+3. **Classify, then batch.** Before drafting any reply, assign each unresolved comment to one of the five types below. All code changes across the batch go into a single commit (step 6); all replies are posted after that commit. Required fields are not optional — if a field's value is non-obvious, that is exactly when it earns its keep.
+
+   - **`FIXED`** — a code change was made.
+     Required fields: `disposition` (one of `fixed-as-requested` | `fixed-with-modification` | `fixed-differently`), `rationale` (REQUIRED when disposition ≠ `fixed-as-requested` — explain what was changed and why), `commit_sha` (filled in after the commit in step 6).
+   - **`EXPLAIN-DESIGN`** — the existing code is correct; the comment misreads intent.
+     Required fields: `decision` (what the code does), `why` (the reason it does that), `why-not-alternative` (why the reviewer's apparent alternative was not taken), `where-documented` (file:line or "inline below").
+   - **`OUT-OF-SCOPE`** — the comment identifies a real issue but it belongs in a separate PR.
+     Required fields: `acknowledgment` (confirm the issue is real), `where-tracked` (ticket or backlog), `link-or-ticket` (URL or "will create").
+   - **`DEFERRED`** — the change is valid but intentionally left for a follow-up.
+     Required fields: `acknowledgment`, `deferral-reason`, `follow-up-ticket`.
+   - **`AGREE-NO-CHANGE`** — the reviewer is right but the code already handles it, or the suggestion is a matter of preference and no change is warranted.
+     Required fields: `acknowledgment`, `rationale`.
+
+   **Worked examples** (illustrating required-field depth, not wording to copy verbatim):
+
+   *`FIXED` with `fixed-with-modification`:*
+   > **[Claude Code]** Fixed. Applied the reviewer's intent (validate before writing) but checked at the handler level rather than inline at the call site — the call site is shared by three paths and an inline check would need to be duplicated. `disposition: fixed-with-modification` | `rationale: moved check to handler boundary to avoid three-way duplication` | `commit_sha: <sha>`
+
+   *`EXPLAIN-DESIGN`:*
+   > **[Claude Code]** The early return is intentional — when the session token is absent we want a fast 401 with no DB round-trip. The alternative (falling through to a null-check deeper in the stack) would silently succeed for unauthenticated callers in contexts where the token field is optional. `where-documented: auth/middleware.ts:42`
+
+4. For each unresolved comment:
    - Read the referenced file and line to understand the context
-   - Determine if it requires a code change, a reply, or both
-   - If a code change is needed, make the change and note it in the reply
-   - If it's a question or discussion point, draft a clear response
-4. Post replies using the appropriate endpoint for each comment type — do **not** use `gh api .../pulls/comments/{id}` with `-F body=...`; that endpoint PATCHes the target comment in place and silently overwrites the author's text.
+   - Apply the classification from step 3
+   - If a code change is needed, make it; note it in the reply using the `FIXED` field template
+   - If it's design explanation, draft using the `EXPLAIN-DESIGN` template
+5. Post replies using the appropriate endpoint for each comment type — do **not** use `gh api .../pulls/comments/{id}` with `-F body=...`; that endpoint PATCHes the target comment in place and silently overwrites the author's text.
 
    - **Inline file comments** (fetched from `pulls/{n}/comments`) — reply via the `/replies` sub-resource:
      ```
@@ -47,8 +68,8 @@ Fetch all review comments on the current branch's open pull request and address 
      gh api repos/{owner}/{repo}/issues/{number}/comments \
        -F body='**[Claude Code]** ...reply text...'
      ```
-5. Commit and push any code changes in a single commit
-6. **Remove this session's hook bypass marker:**
+6. Commit and push any code changes in a single commit
+7. **Remove this session's hook bypass marker:**
    <!-- HOOK_TEST_FIXTURE: disable-bypass — the hook-alignment test suite reads this exact fenced block to verify it removes the marker the enable step created. Do not duplicate elsewhere; the test re-reads it from here. -->
    ```
    SESSION_ID=$(cat "$HOME/.claude/sessions/$PPID" 2>/dev/null) && [ -n "$SESSION_ID" ] && rm -f "$HOME/.claude/.respond-pr-active.d/$SESSION_ID"
@@ -71,7 +92,7 @@ gh api repos/owner/repo/pulls/4/comments/12345678/replies \
 - Be concise in replies — state what was done, not lengthy explanations
 - If you disagree with a comment, explain why clearly but defer to the reviewer's judgment
 - Do not resolve review threads — let the reviewer verify and resolve them
-- PR comments are editable after posting. If a reply **you authored** in this session has a typo or factual error, edit it in place rather than posting a correction. **Use PATCH only against comments you authored — confusing the target ID with the user's comment ID overwrites their text irrecoverably and cannot be undone.** A `user.login` check is insufficient — Claude posts under the user's own token, so PATCH against the user's own comment will succeed. The reliable check is the attribution prefix: every reply Claude posts starts with `**[Claude Code]**`, and the user's comments do not. Before any PATCH, fetch the target body and verify it starts with that prefix; abort to the `/replies` form (Step 4) on any mismatch:
+- PR comments are editable after posting. If a reply **you authored** in this session has a typo or factual error, edit it in place rather than posting a correction. **Use PATCH only against comments you authored — confusing the target ID with the user's comment ID overwrites their text irrecoverably and cannot be undone.** A `user.login` check is insufficient — Claude posts under the user's own token, so PATCH against the user's own comment will succeed. The reliable check is the attribution prefix: every reply Claude posts starts with `**[Claude Code]**`, and the user's comments do not. Before any PATCH, fetch the target body and verify it starts with that prefix; abort to the `/replies` form (Step 5) on any mismatch:
   ```
   TARGET_BODY=$(gh api repos/{owner}/{repo}/pulls/comments/{id} --jq '.body')
   case "$TARGET_BODY" in

--- a/claude/.claude/skills/respond-pr/SKILL.md
+++ b/claude/.claude/skills/respond-pr/SKILL.md
@@ -32,7 +32,7 @@ Fetch all review comments on the current branch's open pull request and address 
    - **`OUT-OF-SCOPE`** — the comment identifies a real issue but it belongs in a separate PR.
      Required fields: `acknowledgment` (confirm the issue is real), `where-tracked` (ticket or backlog), `link-or-ticket` (URL or "will create").
    - **`DEFERRED`** — the change is valid but intentionally left for a follow-up.
-     Required fields: `acknowledgment`, `deferral-reason`, `follow-up-ticket`.
+     Required fields: `acknowledgment`, `deferral-reason`, `follow-up-ticket` (URL to an existing ticket, or `"will create: <one-line summary>"` if none exists yet — but the ticket must be created before the skill session ends).
    - **`AGREE-NO-CHANGE`** — the reviewer is right but the code already handles it, or the suggestion is a matter of preference and no change is warranted.
      Required fields: `acknowledgment`, `rationale`.
 


### PR DESCRIPTION
## Summary

- **(i)** `claude/.claude/CLAUDE.md` — Added `## Code Comments` section with PR-terminology ban, no-used-to-be framing, and self-test rule
- **(j)** `plan-review/SKILL.md` — Added B16 tech-debt-intersection check to Base checklist + Item ownership table (domain-aware co-owner for surgical-fix feasibility)
- **(f)** `respond-pr/SKILL.md` — Added classify-then-batch Step 3 with five reply types (FIXED, EXPLAIN-DESIGN, OUT-OF-SCOPE, DEFERRED, AGREE-NO-CHANGE) and required-fields enforcement; DEFERRED type now accepts `follow-up-ticket: "will create: <summary>"` when no ticket exists yet
- **(a)/(b)** `require-plan-review.sh` + `plan-review/SKILL.md` — Active-marker bypass (Write|Edit|MultiEdit) so in-progress plan reviews don't self-deny their own calls; mtime-refresh on each bypass for long reviews; new tests in `test_require_plan_review.py`
- **(d)** `session-marker-dashboard.sh` (new) + `settings.json` — SessionStart hook that surfaces orphaned active markers post-compaction into Claude's conversation context (audience: Claude, not humans); silent when all-absent; tests in `test_session_marker_dashboard.py`

Tests are now in the per-hook file layout introduced by PR #124 — the monolithic `test_hooks.py` is gone.

## Items not in scope

- **(c), (e), (g), (h)** — Deferred or dropped per plan scope table
- **(j) project-specific supplement** — Applied separately in a companion PR

## Test plan

- `pytest claude/.claude/hooks/tests/` — 398 tests, all pass
- `ruff check claude/.claude/hooks/tests/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)