### PR TITLE
plan-review B5: require verification of cited code shapes

### DIFF
--- a/claude/.claude/skills/plan-review/SKILL.md
+++ b/claude/.claude/skills/plan-review/SKILL.md
@@ -86,7 +86,7 @@ B3. **Breaking intermediate states** — During phased migrations, is there a wi
 
 B4. **Unresolved external dependencies** — Does the plan depend on external services, APIs, or tools whose availability, rate limits, or behavior the author hasn't verified?
 
-B5. **Evidence** — Does the plan cite a source for each finding/assertion (file:line, tool that flagged it, or how it was discovered)? Conclusions without evidence force reviewers to re-derive them.
+B5. **Evidence and verification** — Does the plan cite a source for each finding/assertion (file:line, tool that flagged it, or how it was discovered)? When the plan asserts a specific code shape (function signature, exact line number, type field, import path), verify the cited source actually matches — citation alone is insufficient if the assertion misquotes it. Conclusions without evidence force reviewers to re-derive them; misquoted citations produce phantom code-review findings when the implementer correctly diverges.
 
 ### Scope
 
@@ -251,7 +251,7 @@ The dispatcher fires reviewers per touched domain. Each agent self-scopes agains
 | **B2. Missing consumer analysis** | `staff-backend-engineer` (API consumers) | `staff-frontend-engineer`, `staff-product-engineer`, `staff-data-engineer` (per consumer type), `staff-analytics-engineer` (warehouse-consumer fitness — source shape suits modeling) |
 | **B3. Breaking intermediate states** | `staff-backend-engineer`, `staff-data-engineer` | `staff-platform-engineer` (deploy-window) |
 | **B4. Unresolved external dependencies** | `staff-backend-engineer` | — |
-| **B5, B6, B7, B13, B15. Judgment items** (evidence, proportionality, scope creep, ambiguous instructions, effort section) | judgment (any reviewer) | — |
+| **B5, B6, B7, B13, B15. Judgment items** (evidence and verification, proportionality, scope creep, ambiguous instructions, effort section) | judgment (any reviewer) | — |
 | **B8. Missing scope** | `staff-product-engineer` (user-facing gaps), `staff-sdet` (test gaps) | `staff-data-engineer`, `staff-platform-engineer` (ops gaps) |
 | **B9. Phase independence** | `staff-platform-engineer` | `staff-backend-engineer` |
 | **B10. Test realism** | `staff-sdet` | `staff-product-engineer` (user-flow realism) |


### PR DESCRIPTION
## Summary

- Strengthens `B5. Evidence` → `B5. Evidence and verification` in `plan-review/SKILL.md`
- Adds explicit requirement: when a plan asserts a specific code shape (function signature, exact line number, type field, import path), the reviewer must verify the cited source actually matches — citation alone is insufficient
- Aligns the Item ownership table shorthand with the renamed check

## Why

Plans that assert unverified code shapes — invented signatures, wrong line numbers, invalid type fields — produce phantom code-review findings when implementers correctly diverge from the bad assertion. The evidence check already required citations; it now also requires that citations be verified against the assertion.

B1 (unstated assumptions) was scoped to SDK/library behavior. B13 (ambiguous instructions) was about misinterpretability, not factual correctness. Neither caught the "clear but wrong" case. B5 is the right home.

## Test plan

- [ ] `pytest claude/.claude/` — all expected to pass
- [ ] `ruff check claude/.claude/` — no issues
- [ ] Diff: only two lines change (B5 body, shorthand in Item ownership table)

_Note: `claude/.claude/scripts/` was introduced in a prior merge; no new top-level stow entries in this PR. If merging onto a fresh clone, run `./install.sh` to link all top-level entries._

🤖 Generated with [Claude Code](https://claude.com/claude-code)