### PR TITLE
feat: enforce 200-line SKILL.md ceiling via pre-commit hook

### DIFF
--- a/claude/.claude/hooks/check-skill-length.sh
+++ b/claude/.claude/hooks/check-skill-length.sh
@@ -22,8 +22,8 @@ REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 FAIL=0
 MESSAGES=""
 while IFS= read -r f; do
-  new=$(git show ":$f" 2>/dev/null | wc -l) || continue
-  old=$(git show "HEAD:$f" 2>/dev/null | wc -l || echo 0)
+  new=$(git show ":$f" 2>/dev/null | awk 'END{print NR}')
+  old=$(git show "HEAD:$f" 2>/dev/null | awk 'END{print NR}')
   if [ "$new" -gt 200 ] && [ "$new" -gt "$old" ]; then
     MESSAGES="${MESSAGES}  $f: $new lines (was $old, limit 200)\n"
     FAIL=1

--- a/claude/.claude/hooks/check-skill-length.sh
+++ b/claude/.claude/hooks/check-skill-length.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Gate: block git commit when a staged SKILL.md grows past the 200-line ceiling.
+#
+# Policy: deny when the staged file is over 200 AND longer than the previously
+# committed version. This allows reducing an already-over-limit file commit by
+# commit without blocking the work, while still catching new bloat.
+#
+# The "if" field in settings.json is unreliable — the internal grep is the
+# actual gate. See require-code-review.sh for the same pattern and rationale.
+
+INPUT=$(cat)
+COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command // empty')
+
+# Only gate git commit commands.
+if ! printf '%s\n' "$COMMAND" | grep -qE '(^|&&?|;|\|\|?)\s*git\s+commit(\s|$)'; then
+  exit 0
+fi
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+[ -z "$REPO_ROOT" ] && exit 0
+
+FAIL=0
+MESSAGES=""
+while IFS= read -r f; do
+  new=$(git show ":$f" 2>/dev/null | wc -l) || continue
+  old=$(git show "HEAD:$f" 2>/dev/null | wc -l || echo 0)
+  if [ "$new" -gt 200 ] && [ "$new" -gt "$old" ]; then
+    MESSAGES="${MESSAGES}  $f: $new lines (was $old, limit 200)\n"
+    FAIL=1
+  fi
+done < <(git diff --cached --name-only | grep -E 'claude/.claude/skills/.+/SKILL\.md')
+
+if [ "$FAIL" -eq 1 ]; then
+  REASON=$(printf 'Skill length gate: one or more SKILL.md files grew past the 200-line limit. Reduce to 200 or fewer lines before committing:\n%b' "$MESSAGES")
+  REASON_JSON=$(printf '%s' "$REASON" | jq -Rs .)
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' "$REASON_JSON"
+fi

--- a/claude/.claude/hooks/check-skill-length.sh
+++ b/claude/.claude/hooks/check-skill-length.sh
@@ -28,6 +28,8 @@ while IFS= read -r f; do
     MESSAGES="${MESSAGES}  $f: $new lines (was $old, limit 200)\n"
     FAIL=1
   fi
+# Path prefix is repo-root-relative for this repo's layout (claude/.claude/skills/).
+# In other repos this grep matches nothing and the hook exits 0 silently.
 done < <(git diff --cached --name-only | grep -E 'claude/.claude/skills/.+/SKILL\.md')
 
 if [ "$FAIL" -eq 1 ]; then

--- a/claude/.claude/hooks/tests/test_check_skill_length.py
+++ b/claude/.claude/hooks/tests/test_check_skill_length.py
@@ -178,6 +178,18 @@ class TestCheckSkillLength:
             == "allow"
         )
 
+    def test_staged_deletion_of_skill_allows(self, isolated_home, skill_repo):
+        """git rm-staged SKILL.md: git show ":$f" produces empty output → new=0, 0 > 200 is false → allow."""
+        subprocess.run(["git", "rm", "-q", SKILL_PATH], cwd=skill_repo, check=True)
+        assert (
+            run_hook(
+                CHECK_SKILL_LENGTH_HOOK,
+                bash_input("git commit -m foo"),
+                cwd=skill_repo,
+            )
+            == "allow"
+        )
+
     def test_deny_message_includes_filename_and_counts(self, isolated_home, skill_repo):
         """Deny reason must name the file, new line count, old line count, and limit."""
         (skill_repo / SKILL_PATH).write_text(make_skill_content(201))

--- a/claude/.claude/hooks/tests/test_check_skill_length.py
+++ b/claude/.claude/hooks/tests/test_check_skill_length.py
@@ -1,0 +1,218 @@
+"""Tests for check-skill-length.sh."""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from helpers import (
+    HOOKS_DIR,
+    bash_input,
+    edit_input,
+    run_hook,
+    run_hook_reason,
+)
+
+CHECK_SKILL_LENGTH_HOOK = HOOKS_DIR / "check-skill-length.sh"
+SKILL_PATH = "claude/.claude/skills/my-skill/SKILL.md"
+
+
+def make_skill_content(n: int, prefix: str = "line") -> str:
+    """Return content with exactly n newline-terminated lines."""
+    return "\n".join(f"{prefix} {i + 1}" for i in range(n)) + "\n"
+
+
+def make_repo_with_skill(tmp_path: Path, head_lines: int) -> Path:
+    """Git repo with SKILL.md committed at `head_lines` lines."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "test"], cwd=repo, check=True)
+    skill_dir = repo / "claude" / ".claude" / "skills" / "my-skill"
+    skill_dir.mkdir(parents=True)
+    (repo / SKILL_PATH).write_text(make_skill_content(head_lines))
+    subprocess.run(["git", "add", SKILL_PATH], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=repo, check=True)
+    return repo
+
+
+@pytest.fixture
+def skill_repo(tmp_path):
+    """Git repo with SKILL.md committed at 190 lines."""
+    return make_repo_with_skill(tmp_path, 190)
+
+
+@pytest.fixture
+def new_skill_repo(tmp_path):
+    """Git repo with no committed SKILL.md — SKILL.md will be a new staged file."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "test"], cwd=repo, check=True)
+    (repo / "README.md").write_text("hello\n")
+    subprocess.run(["git", "add", "README.md"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=repo, check=True)
+    (repo / "claude" / ".claude" / "skills" / "my-skill").mkdir(parents=True)
+    return repo
+
+
+class TestCheckSkillLength:
+    def test_non_commit_command_allows(self, isolated_home, skill_repo):
+        (skill_repo / SKILL_PATH).write_text(make_skill_content(201))
+        subprocess.run(["git", "add", SKILL_PATH], cwd=skill_repo, check=True)
+        assert (
+            run_hook(CHECK_SKILL_LENGTH_HOOK, bash_input("git status"), cwd=skill_repo)
+            == "allow"
+        )
+
+    def test_non_bash_tool_allows(self, isolated_home, skill_repo):
+        assert (
+            run_hook(CHECK_SKILL_LENGTH_HOOK, edit_input("/tmp/foo.txt"), cwd=skill_repo)
+            == "allow"
+        )
+
+    def test_outside_git_repo_allows(self, isolated_home, tmp_path):
+        non_repo = tmp_path / "not-a-repo"
+        non_repo.mkdir()
+        assert (
+            run_hook(
+                CHECK_SKILL_LENGTH_HOOK,
+                bash_input("git commit -m foo"),
+                cwd=non_repo,
+            )
+            == "allow"
+        )
+
+    def test_no_staged_skill_files_allows(self, isolated_home, skill_repo):
+        (skill_repo / "other.txt").write_text("something\n")
+        subprocess.run(["git", "add", "other.txt"], cwd=skill_repo, check=True)
+        assert (
+            run_hook(
+                CHECK_SKILL_LENGTH_HOOK,
+                bash_input("git commit -m foo"),
+                cwd=skill_repo,
+            )
+            == "allow"
+        )
+
+    def test_skill_at_exactly_200_allows(self, isolated_home, skill_repo):
+        """200 lines is at the limit — the gate is `> 200`, so 200 passes."""
+        (skill_repo / SKILL_PATH).write_text(make_skill_content(200))
+        subprocess.run(["git", "add", SKILL_PATH], cwd=skill_repo, check=True)
+        assert (
+            run_hook(
+                CHECK_SKILL_LENGTH_HOOK,
+                bash_input("git commit -m foo"),
+                cwd=skill_repo,
+            )
+            == "allow"
+        )
+
+    def test_skill_growing_to_201_denies(self, isolated_home, skill_repo):
+        """HEAD at 190, staged at 201: new > 200 and new > old → deny."""
+        (skill_repo / SKILL_PATH).write_text(make_skill_content(201))
+        subprocess.run(["git", "add", SKILL_PATH], cwd=skill_repo, check=True)
+        assert (
+            run_hook(
+                CHECK_SKILL_LENGTH_HOOK,
+                bash_input("git commit -m foo"),
+                cwd=skill_repo,
+            )
+            == "deny"
+        )
+
+    def test_new_skill_over_limit_denies(self, isolated_home, new_skill_repo):
+        """New file with no HEAD version staged at 201 lines — old defaults to 0 → deny."""
+        (new_skill_repo / SKILL_PATH).write_text(make_skill_content(201))
+        subprocess.run(["git", "add", SKILL_PATH], cwd=new_skill_repo, check=True)
+        assert (
+            run_hook(
+                CHECK_SKILL_LENGTH_HOOK,
+                bash_input("git commit -m foo"),
+                cwd=new_skill_repo,
+            )
+            == "deny"
+        )
+
+    def test_already_over_limit_growing_denies(self, isolated_home, tmp_path):
+        """HEAD at 210, staged at 215: growing while over limit → deny."""
+        repo = make_repo_with_skill(tmp_path, 210)
+        (repo / SKILL_PATH).write_text(make_skill_content(215))
+        subprocess.run(["git", "add", SKILL_PATH], cwd=repo, check=True)
+        assert (
+            run_hook(
+                CHECK_SKILL_LENGTH_HOOK,
+                bash_input("git commit -m foo"),
+                cwd=repo,
+            )
+            == "deny"
+        )
+
+    def test_already_over_limit_reducing_allows(self, isolated_home, tmp_path):
+        """HEAD at 210, staged at 205: reducing while over limit → allow."""
+        repo = make_repo_with_skill(tmp_path, 210)
+        (repo / SKILL_PATH).write_text(make_skill_content(205))
+        subprocess.run(["git", "add", SKILL_PATH], cwd=repo, check=True)
+        assert (
+            run_hook(
+                CHECK_SKILL_LENGTH_HOOK,
+                bash_input("git commit -m foo"),
+                cwd=repo,
+            )
+            == "allow"
+        )
+
+    def test_already_over_limit_same_size_allows(self, isolated_home, tmp_path):
+        """HEAD at 210, staged at 210 (different content, same count): not growing → allow."""
+        repo = make_repo_with_skill(tmp_path, 210)
+        (repo / SKILL_PATH).write_text(make_skill_content(210, prefix="row"))
+        subprocess.run(["git", "add", SKILL_PATH], cwd=repo, check=True)
+        assert (
+            run_hook(
+                CHECK_SKILL_LENGTH_HOOK,
+                bash_input("git commit -m foo"),
+                cwd=repo,
+            )
+            == "allow"
+        )
+
+    def test_deny_message_includes_filename_and_counts(self, isolated_home, skill_repo):
+        """Deny reason must name the file, new line count, old line count, and limit."""
+        (skill_repo / SKILL_PATH).write_text(make_skill_content(201))
+        subprocess.run(["git", "add", SKILL_PATH], cwd=skill_repo, check=True)
+        reason = run_hook_reason(
+            CHECK_SKILL_LENGTH_HOOK,
+            bash_input("git commit -m foo"),
+            cwd=skill_repo,
+        )
+        assert reason is not None
+        assert SKILL_PATH in reason
+        assert "201" in reason
+        assert "190" in reason
+        assert "200" in reason
+
+    def test_cwd_not_repo_root_does_not_cause_false_negative(
+        self, isolated_home, skill_repo
+    ):
+        """Hook run from a repo subdirectory must still catch over-limit SKILL.md.
+
+        Regression test: `git diff --cached --name-only` emits repo-root-relative
+        paths. An earlier version had `[ -f "$f" ] || continue` which resolved
+        those paths against CWD — if CWD was a subdirectory the check failed
+        and the file was silently skipped (false negative, bloated skill slips
+        through). The guard was removed; `git show ":$f"` reads from the index
+        directly and doesn't depend on CWD.
+        """
+        (skill_repo / SKILL_PATH).write_text(make_skill_content(201))
+        subprocess.run(["git", "add", SKILL_PATH], cwd=skill_repo, check=True)
+        subdir = skill_repo / "claude"
+        assert (
+            run_hook(
+                CHECK_SKILL_LENGTH_HOOK,
+                bash_input("git commit -m foo"),
+                cwd=subdir,
+            )
+            == "deny"
+        )

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -79,6 +79,12 @@
           },
           {
             "type": "command",
+            "command": "~/.claude/hooks/check-skill-length.sh",
+            "if": "Bash(git commit *)",
+            "statusMessage": "Checking skill length..."
+          },
+          {
+            "type": "command",
             "command": "~/.claude/hooks/require-ready-for-review.sh",
             "if": "Bash(git push *)",
             "statusMessage": "Checking ready-for-review gate..."

--- a/claude/.claude/skills/ready-for-review/SKILL.md
+++ b/claude/.claude/skills/ready-for-review/SKILL.md
@@ -42,7 +42,7 @@ the `require-ready-for-review.sh` hook:
 SESSION_ID=$(cat "$HOME/.claude/sessions/$PPID") && [ -n "$SESSION_ID" ] && mkdir -p "$HOME/.claude/.ready-for-review-active.d" && touch "$HOME/.claude/.ready-for-review-active.d/$SESSION_ID"
 ```
 
-If the chain fails (empty `SESSION_ID`), the `capture-session-id.sh` SessionStart hook didn't run — abort; the gate will block iteration pushes without this marker.
+If the chain fails (empty `SESSION_ID`), the `capture-session-id.sh` SessionStart hook didn't run — abort and report; the gate will block iteration pushes without this marker.
 
 ## 1. Preconditions (halt on fail)
 
@@ -71,9 +71,11 @@ config. Examples: skill bodies under `.claude/skills/**`, plans under
 `*.md`, `docs/**`. If the diff touches scripts, hooks, tests, or
 application source — even alongside docs — run step 2.
 
-**Pre-existing failures:** if a step fails on code unrelated to this diff, open a separate branch rather than bundling the fix. Rebase once the default branch is green.
+**Pre-existing failures:** if a step fails on code unrelated to this diff, confirm it's
+unrelated (`git log -- <file>`, `git diff origin/<base> -- <file>`), then either wait for
+the existing owner or open a separate branch. Rebase once the default branch is green.
 
-**Test-to-fit is forbidden:** fix the code, not the test.
+**Test-to-fit is forbidden:** fix the code, not the test — unless the product requirement genuinely changed.
 
 ## 3. Code review (halt on findings)
 
@@ -94,8 +96,7 @@ normal staged-diff `/code-review` + marker gate, then return to
 step 2 and re-run fast checks. Do not re-run `/code-review` on its
 own output (loop risk).
 
-Unskippable — markdown, skill, and config diffs benefit from the
-same pass.
+Unskippable — markdown, skill, and config diffs benefit from the same pass.
 
 ## 4. Sync PR description (warn + fix; skip if no PR)
 
@@ -143,8 +144,7 @@ they would otherwise trigger command substitution.
 Run `gh pr checks <n>`.
 
 - All green → continue.
-- Still running → note the in-flight checks; user decides whether to
-  wait.
+- Still running → note the in-flight checks; user decides whether to wait.
 - Red → surface failing check names with a one-line summary of each.
   Do not auto-halt — sometimes the human reviewer wants to see the
   failure themselves — but make the failure explicit before handoff.
@@ -177,7 +177,7 @@ Then remove the active-session marker:
 SESSION_ID=$(cat "$HOME/.claude/sessions/$PPID" 2>/dev/null) && [ -n "$SESSION_ID" ] && rm -f "$HOME/.claude/.ready-for-review-active.d/$SESSION_ID"
 ```
 
-Removes only this session's file; the hook's 60-minute staleness cutoff handles orphans if the skill errors before this step.
+Removes only this session's file; if the skill errors before this step, do not manually clean up — the hook's 60-minute staleness cutoff handles orphans.
 
 **Do NOT write the completion marker if:**
 

--- a/claude/.claude/skills/ready-for-review/SKILL.md
+++ b/claude/.claude/skills/ready-for-review/SKILL.md
@@ -42,10 +42,7 @@ the `require-ready-for-review.sh` hook:
 SESSION_ID=$(cat "$HOME/.claude/sessions/$PPID") && [ -n "$SESSION_ID" ] && mkdir -p "$HOME/.claude/.ready-for-review-active.d" && touch "$HOME/.claude/.ready-for-review-active.d/$SESSION_ID"
 ```
 
-If the chain fails (empty `SESSION_ID`, etc.), the
-`capture-session-id.sh` SessionStart hook didn't run — abort and
-report; do not proceed without the marker, since the gate would
-block iteration pushes.
+If the chain fails (empty `SESSION_ID`), the `capture-session-id.sh` SessionStart hook didn't run — abort; the gate will block iteration pushes without this marker.
 
 ## 1. Preconditions (halt on fail)
 
@@ -74,16 +71,9 @@ config. Examples: skill bodies under `.claude/skills/**`, plans under
 `*.md`, `docs/**`. If the diff touches scripts, hooks, tests, or
 application source — even alongside docs — run step 2.
 
-**Pre-existing failures on the default branch.** If a verification
-step fails with issues unrelated to this branch's diff, do not bundle
-the fix. Confirm it's unrelated (`git log -- <file>` and
-`git diff origin/<default> -- <file>`), then either wait for the
-existing owner or open a separate branch + PR for the fix. Rebase this
-branch once the default branch is green again.
+**Pre-existing failures:** if a step fails on code unrelated to this diff, open a separate branch rather than bundling the fix. Rebase once the default branch is green.
 
-**Test-to-fit is forbidden.** If a test fails because of this branch's
-change, fix the code — not the test — unless the product requirement
-genuinely changed.
+**Test-to-fit is forbidden:** fix the code, not the test.
 
 ## 3. Code review (halt on findings)
 
@@ -95,13 +85,7 @@ BASE_REF=$(gh pr view --json baseRefName --jq .baseRefName 2>/dev/null || echo m
 git diff $(git merge-base origin/$BASE_REF HEAD)...HEAD
 ```
 
-The squash-merge artifact reviewers ultimately see is this diff.
-Cumulative review surfaces cross-commit findings — defense-in-depth
-gaps spanning two commits, deprecations exposed only when a new test
-exercises an unmodified call site, idempotency-key shape mismatches
-across modules — that per-commit review misses. Per-commit
-`/code-review` during iteration remains valuable for fast feedback;
-treat its findings as inputs here, not substitutes.
+The squash-merge artifact reviewers see is this diff; cumulative review surfaces cross-commit findings that per-commit review misses. Per-commit `/code-review` during iteration remains valuable — treat its findings as inputs here, not substitutes.
 
 Because the reviewed diff is not the staged diff, do NOT write the
 review-completion marker (per `/code-review`'s own rule). If findings
@@ -174,10 +158,7 @@ Steps 3 and 4 may have produced new commits or body edits. Reconfirm:
   with `origin/<branch>`, not ahead.
 - PR body edit (if any) landed — re-fetch with `gh pr view` and confirm.
 
-If the branch has no PR and no remote tracking, surface this: the
-human can't review what isn't pushed. A project-specific pre-merge or
-PR-creation skill should handle the actual open; this skill does not
-create PRs.
+If the branch has no PR and no remote tracking, surface this — a project-specific pre-merge skill should open the PR; this skill does not.
 
 ## 7. Record gate completion + deactivate session
 
@@ -196,9 +177,7 @@ Then remove the active-session marker:
 SESSION_ID=$(cat "$HOME/.claude/sessions/$PPID" 2>/dev/null) && [ -n "$SESSION_ID" ] && rm -f "$HOME/.claude/.ready-for-review-active.d/$SESSION_ID"
 ```
 
-Removes only this session's file. If the skill errors out before
-reaching this step, don't manually clean up — the hook's 60-minute
-staleness cutoff handles the orphan automatically.
+Removes only this session's file; the hook's 60-minute staleness cutoff handles orphans if the skill errors before this step.
 
 **Do NOT write the completion marker if:**
 


### PR DESCRIPTION
## What

- **New hook `check-skill-length.sh`** — PreToolUse:Bash gate that blocks `git commit` when a staged SKILL.md grows past the 200-line limit. Policy: deny when `new > 200 AND new > old`, so already-over-limit files can be reduced commit-by-commit without being blocked.
- **13 pytest cases** covering: non-commit commands, non-Bash tools, no staged SKILL.md, exactly-at-200, new-file-over-limit, growing/reducing/same-size already-over-limit, staged deletion, deny message contents, and a CWD regression test (the prior `[ -f "$f" ]` guard was CWD-dependent and caused false negatives when the hook ran from a repo subdirectory).
- **Settings registration** — hook added to PreToolUse > Bash array in `settings.json`.
- **`ready-for-review/SKILL.md` trimmed 212 → 200** — five prose compressions (session-chain failure note, pre-existing failures callout, test-to-fit rule, cumulative review rationale, no-PR note), all behavior-preserving.

## Why

`skill-review`'s own rule: *"When a rule can be encoded mechanically, prefer mechanical enforcement."* The 200-line ceiling existed as advisory text only. This PR makes it a commit gate — same enforcement point and failure shape as `require-code-review.sh`.

## What was reviewed

- Per-commit `/code-review` on each staged diff before committing
- Cumulative `/code-review` (full branch-vs-main diff) before PR open
- `claude-hook-review` subagent on the hook script
- All three review rounds produced findings that were fixed before landing

## Test results

```
428 passed in ~21s
ruff: All checks passed
```

## Existing PRs

No prior PRs address skill length enforcement via a pre-commit hook. The 200-line limit has been referenced in prose (skill-review skill) but never mechanically enforced.