### PR TITLE
fix: deny chained `cd ... && git` regardless of session cwd

### DIFF
--- a/claude/.claude/hooks/require-worktree-for-git-writes.sh
+++ b/claude/.claude/hooks/require-worktree-for-git-writes.sh
@@ -31,19 +31,23 @@ emit_deny() {
     "$reason_json"
 }
 
+# Returns success when the command chains `cd ... <op> ... git ...`. The
+# hook reads cwd from Claude Code's session-persisted bash state (set by
+# prior Bash calls), not from the inline cd in the current command, because
+# the hook fires before the subshell runs. When this shape is detected the
+# effective cwd at the time git runs cannot be determined from the tool-input
+# JSON alone. Pattern requires `cd` as a word, then a chain operator, then
+# `git` somewhere later — avoids false positives on paths containing `cd`.
+command_chains_cd_then_git() {
+  printf '%s' "$1" | grep -qE '(^|[[:space:]])cd[[:space:]].*(&&|\|\||;).*git'
+}
+
 # When the command chains `cd ... <op> ... git ...`, the agent likely
-# expected the inline `cd` to land inside a worktree. This hook reads
-# CWD from the JSON tool_input — which reflects Claude Code's bash
-# tool's *persisted* cwd from prior calls, not the cwd produced by the
-# inline `cd` in the current command. The hook fires before the
-# subshell runs, so the inline `cd` hasn't taken effect yet. Returns a
+# expected the inline `cd` to land inside a worktree. Returns a
 # self-correction note for the agent when this pattern is detected;
-# empty otherwise. Pattern requires `cd` as a word, then a chain
-# operator, then `git` somewhere later — this targets the precise
-# failure mode (`cd /worktree && git ...`) and avoids false positives
-# on path strings containing `cd` as a substring.
+# empty otherwise.
 cwd_anchor_note_if_chained() {
-  if printf '%s' "$1" | grep -qE '(^|[[:space:]])cd[[:space:]].*(&&|\|\||;).*git'; then
+  if command_chains_cd_then_git "$1"; then
     printf '%s' " If you just chained 'cd /path/to/worktree && git ...' and expected the inline cd to land you in the worktree: this hook reads cwd from Claude Code's session-persisted bash state (set by prior Bash calls), not from your inline cd, because the hook fires before the subshell runs. Anchor cwd by running 'cd /path/to/worktree' as its own Bash call first, then retry the git op in a follow-up call."
   fi
 }
@@ -120,6 +124,17 @@ fi
 
 # Per-repo opt-in: only enforce if the repo has committed the sentinel.
 if [ ! -f "$REPO_ROOT/.claude/worktree-required" ]; then
+  exit 0
+fi
+
+# A chained `cd ... && git ...` makes the effective cwd at the time git
+# runs unknowable from the tool-input JSON alone — the hook reads the
+# session-persisted cwd from prior Bash calls, not the cwd the inline cd
+# would produce. Deny regardless of the persisted cwd so that the hook's
+# decision is never based on stale state. The agent fix is to anchor cwd
+# with a standalone Bash call before the git op.
+if command_chains_cd_then_git "$COMMAND"; then
+  emit_deny "Blocked by worktree-enforcement hook: the command chains 'cd ... && git ...' and this hook cannot determine the effective cwd at the time git runs — it reads the session-persisted cwd (from prior Bash calls), not the cwd produced by the inline cd, because the hook fires before the subshell runs. This repo has opted into worktree discipline (.claude/worktree-required is committed). Anchor cwd by running 'cd /path/to/worktree' as its own Bash call first, then retry the git op in a follow-up call."
   exit 0
 fi
 

--- a/claude/.claude/hooks/tests/test_require_worktree_for_git_writes.py
+++ b/claude/.claude/hooks/tests/test_require_worktree_for_git_writes.py
@@ -478,13 +478,110 @@ class TestRequireWorktreeForGitWrites:
         assert reason is not None
         assert "-C path" not in reason
 
-    def test_chained_cd_and_git_C_appends_both_notes(self, opted_in_repo):
-        """Command with both patterns → both notes appended independently."""
+    def test_chained_cd_and_git_C_only_cd_chain_deny(self, opted_in_repo):
+        """Command with both cd chain and -C: the cd-chain deny fires before
+        the fragment loop, so the -C note is never appended."""
         reason = run_hook_reason(
             WORKTREE_HOOK,
             bash_input("cd /tmp && git -C /tmp commit -m foo"),
             cwd=opted_in_repo,
         )
         assert reason is not None
-        assert "chained 'cd" in reason   # chained-cd note
-        assert "-C path" in reason        # -C note
+        assert "chains 'cd" in reason    # cd-chain deny fires first
+        assert "-C path" not in reason   # -C note never reached
+
+    # -- Worktree-cwd bypass: chained cd to main tree from worktree session --
+    # Regression: a session whose persisted cwd is a linked worktree could run
+    # `cd /main-repo && git merge ...` and bypass the hook — the hook read the
+    # persisted cwd (worktree shape → exit 0) before ever inspecting the
+    # fragments. The fix denies all chained `cd ... && git ...` commands
+    # regardless of the persisted cwd, since the effective cwd at the time
+    # git runs cannot be determined from the tool-input JSON alone.
+
+    def test_worktree_cwd_chained_cd_to_main_merge_denied(self, opted_in_with_worktree):
+        """Bug regression: persisted cwd = worktree, `cd /main && git merge`
+        must be denied — the hook cannot tell the git op runs on the main tree."""
+        opted_in_repo, worktree = opted_in_with_worktree
+        assert (
+            run_hook(
+                WORKTREE_HOOK,
+                bash_input(f"cd {str(opted_in_repo)} && git merge feature"),
+                cwd=worktree,
+            )
+            == "deny"
+        )
+
+    def test_worktree_cwd_chained_cd_to_main_push_denied(self, opted_in_with_worktree):
+        """Persisted cwd = worktree, `cd /main && git push` → denied."""
+        opted_in_repo, worktree = opted_in_with_worktree
+        assert (
+            run_hook(
+                WORKTREE_HOOK,
+                bash_input(f"cd {str(opted_in_repo)} && git push origin main"),
+                cwd=worktree,
+            )
+            == "deny"
+        )
+
+    def test_worktree_cwd_chained_cd_semicolon_denied(self, opted_in_with_worktree):
+        """`;` chain operator — same bypass shape, same denial."""
+        opted_in_repo, worktree = opted_in_with_worktree
+        assert (
+            run_hook(
+                WORKTREE_HOOK,
+                bash_input(f"cd {str(opted_in_repo)}; git merge feature"),
+                cwd=worktree,
+            )
+            == "deny"
+        )
+
+    def test_worktree_cwd_chained_cd_or_denied(self, opted_in_with_worktree):
+        """`||` chain operator — same bypass shape, same denial."""
+        opted_in_repo, worktree = opted_in_with_worktree
+        assert (
+            run_hook(
+                WORKTREE_HOOK,
+                bash_input(f"cd {str(opted_in_repo)} || git merge feature"),
+                cwd=worktree,
+            )
+            == "deny"
+        )
+
+    def test_worktree_cwd_chained_cd_readonly_also_denied(self, opted_in_with_worktree):
+        """Chained cd+git is denied regardless of subcommand — the hook
+        cannot determine which cwd the git op runs against, so it refuses
+        to evaluate rather than guess."""
+        opted_in_repo, worktree = opted_in_with_worktree
+        assert (
+            run_hook(
+                WORKTREE_HOOK,
+                bash_input(f"cd {str(opted_in_repo)} && git status"),
+                cwd=worktree,
+            )
+            == "deny"
+        )
+
+    def test_worktree_cwd_plain_git_still_allowed(self, opted_in_with_worktree):
+        """No inline cd — hook reads the worktree-persisted cwd and allows."""
+        _, worktree = opted_in_with_worktree
+        assert (
+            run_hook(
+                WORKTREE_HOOK,
+                bash_input("git merge feature"),
+                cwd=worktree,
+            )
+            == "allow"
+        )
+
+    def test_worktree_cwd_chain_without_cd_still_allowed(self, opted_in_with_worktree):
+        """Non-cd chain from worktree — no inline cd, so hook reads persisted
+        cwd (worktree) and allows."""
+        _, worktree = opted_in_with_worktree
+        assert (
+            run_hook(
+                WORKTREE_HOOK,
+                bash_input("git status && git log --oneline"),
+                cwd=worktree,
+            )
+            == "allow"
+        )


### PR DESCRIPTION
## Summary

- **Bug:** A session whose persisted cwd was a linked worktree could run `cd /main-repo && git merge ... && git push ...` and bypass the worktree enforcement hook. The hook read the session-persisted cwd (worktree shape → exit 0) before ever reaching the fragment loop. The merge landed on local main unblocked.
- **Root cause:** `require-worktree-for-git-writes.sh` short-circuits at the worktree-shape check (line 134) when the persisted cwd is a linked worktree. An inline `cd /main-tree` in the same command runs in the subshell *after* the hook exits — the hook never sees it.
- **Fix:** Extract `command_chains_cd_then_git()` predicate (reuses the existing regex from `cwd_anchor_note_if_chained`) and call it **before** the worktree-shape early-exit. Deny unconditionally when the pattern matches — the effective cwd at the time git runs cannot be determined from the tool-input JSON alone.

## Why not parse the `cd` target path?

The handoff doc proposed extracting the cd target and re-running the worktree check against it. That approach has hidden parsing complexity: tilde/env-var/quote/relative/command-substitution/multiple-`cd` cases all require shell expansion the hook can't safely replicate. Failing-open on parse failure would preserve the bypass for those cases. The refuse-to-evaluate approach is simpler, closes both directions of the bypass (worktree→main and main→worktree), and matches the advice the hook already gives in its self-correction note.

**Trade-off:** A benign `cd /sibling-worktree && git commit` from a worktree-persisted session is also denied. Fix is one standalone `cd` Bash call — same advice the hook already emits.

## Test plan

- [x] 7 new regression tests: merge and push from worktree-cwd chained cd → deny; `;` and `||` operators → deny; readonly subcommand chained cd → deny (shape-based, not subcmd-based); plain git from worktree → allow; non-cd chain from worktree → allow
- [x] Updated `test_chained_cd_and_git_C_appends_both_notes` → `test_chained_cd_and_git_C_only_cd_chain_deny`: early-deny fires before fragment loop, so -C note is never appended
- [x] `pytest claude/.claude/` — 454 passed (up from 415)
- [x] `ruff check claude/.claude/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)