### PR TITLE
feat: add /skill-review gate hook + behavioral-equivalence audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,9 +67,10 @@ check the diff against its output — e.g. an edit adding prose to a
 skill that argues for brevity is the kind of thing the skill would
 flag against itself.
 
-`/plan-review` and `/code-review` are mandatory pipeline steps before
-PR handoff — both are hook-enforced (see README "Workflow" for the full
-skill invocation order and which hook gates each transition).
+`/plan-review`, `/code-review`, and `/skill-review` are mandatory pipeline
+steps before PR handoff — all three are hook-enforced (see README "Workflow"
+for the full skill invocation order and which hook gates each transition).
+`/skill-review`'s gate fires only when staged changes include a SKILL.md.
 
 ## Redact private-project-identifying content
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ flowchart LR
 
 - **`/plan-review`** — review an implementation plan against domain checklists before presenting it to a human; required before writing code when a plan file exists in `.claude/plans/`.
 - **`/code-review`** — principal-engineer code review with ripple-effect triage and domain-specific audits; required before `git commit`.
+- **`/skill-review`** — behavioral-equivalence audit for `SKILL.md` changes; required before `git commit` when staged changes include a SKILL.md. Produces an explicit table verifying that every removed or shortened line's behavior is preserved.
 - **`/ready-for-review`** — pre-handoff gate that verifies tests/lint/typecheck and reviews the cumulative PR diff; required before `git push` on a branch with an open PR.
 - **`/respond-pr`** — fetch all PR review comments (inline, top-level, review summaries) and post replies with `[Claude Code]` attribution; required before reading or posting PR comments via `gh api`.
 
@@ -64,6 +65,7 @@ flowchart LR
 |---|---|---|
 | `require-plan-review.sh` | `Write`/`Edit` while a plan file exists in `.claude/plans/` | `/plan-review` per-session marker |
 | `require-code-review.sh` | `git commit` | `/code-review` run against current staged state |
+| `require-skill-review.sh` | `git commit` when staged changes include a `SKILL.md` | `/skill-review` behavioral-equivalence audit |
 | `require-ready-for-review.sh` | `git push`, `gh pr ready` | `/ready-for-review` run since last commit |
 | `require-respond-pr.sh` | `gh api` PR comment reads/posts | `/respond-pr` active bypass marker |
 | `capture-session-id.sh` | — (SessionStart, no gate) | Writes session-id so marker filenames are per-session |
@@ -71,6 +73,7 @@ flowchart LR
 ### Hooks
 
 - **`require-code-review.sh`** — blocks `git commit` (including chained forms like `git add . && git commit`) until `/code-review` has run on the current staged state. Verified via per-session sha256 marker in `~/.claude/review-markers/<repo-hash>.<session-id>`, which auto-invalidates the moment the staging area changes. Per-session keying prevents two parallel sessions in the same worktree from overwriting each other's markers when staging different diffs.
+- **`require-skill-review.sh`** — blocks `git commit` only when staged changes include a `SKILL.md`. Requires `/skill-review` to have produced a behavioral-equivalence audit for any removed or shortened lines. Marker is keyed to the SKILL.md-scoped diff (not the full staged diff), so re-staging non-skill files after a clean review does not invalidate the marker.
 - **`deny-private-project-refs.sh`** — blocks `git commit`, `gh pr create`, and `gh pr edit` when the staged diff, commit message, or PR title/body/body-source-file contains either (a) tracker-ID tokens (`[A-Z]{2,}-\d+`) outside an OSS-prefix allowlist (`CVE-`, `RFC-`, `GH-`, and similar — see the script for the full list), or (b) a literal substring match against entries in the user's opt-in `~/.claude/private-projects.md` blocklist. Enforces the mechanical categories of the repo-root `CLAUDE.md` redaction rule; structural fingerprints still require review discipline. See [Private-project redaction](#private-project-redaction) below.
 - **`require-stow-reminder.sh`** — scoped to the claude-config repo. Blocks `gh pr create` and `gh pr edit` (when the edit changes the body) if the PR adds a new immediate child of `claude/.claude/` (file or directory) and neither the inline command, a referenced `--body-file`/`--template`, nor any `--fill`-sourced commit message mentions `install.sh` or `stow` (case-insensitive). Reason: GNU Stow links each top-level child of `claude/.claude/` individually, so a brand-new child only appears in `~/.claude/` after re-running `install.sh` — `git pull` alone won't materialize the symlink. The reminder lands in the PR body so the post-merge stow step doesn't get forgotten at merge time.
 - **`require-respond-pr.sh`** — blocks PR comment reads and posts (`gh api .../pulls|issues/N/{comments,reviews}`, `gh pr comment`, `gh pr review`) and redirects to `/respond-pr`, so all three comment types get fetched and replies carry the `[Claude Code]` attribution prefix. Honors a per-session bypass marker at `~/.claude/.respond-pr-active.d/<session_id>` that the skill sets on entry and removes on exit; the hook refreshes the marker's mtime on each bypass so long skill runs don't hit the 60-minute staleness cutoff. Per-session keying (rather than a singleton path) keeps parallel Claude sessions from thrashing on cleanup or leaking bypass to unrelated sessions.

--- a/claude/.claude/hooks/require-skill-review.sh
+++ b/claude/.claude/hooks/require-skill-review.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# Gate: require /skill-review before git commit when SKILL.md files are staged,
+# verified via marker file.
+#
+# WARNING: Do NOT remove the internal git commit check below.
+# The "if" field in settings.json is unreliable — it has been observed
+# to fire this hook on ALL Bash commands (e.g., git reset, date).
+# The internal grep is the actual gate. The "if" field is a hint only.
+#
+# How it works:
+# - The /skill-review skill writes
+#   ~/.claude/skill-review-markers/<repo-hash>.<session_id> with the sha256 hash
+#   of `git diff --cached -- 'claude/.claude/skills/**/SKILL.md'` when the review
+#   is clean. The marker lives under $HOME (not inside the repo) so it never
+#   pollutes `git status` or risks being accidentally committed.
+# - This hook reads session_id from its JSON payload, recomputes the same
+#   path-scoped diff hash at commit time, and compares against THIS session's
+#   marker. Match = the staged skill changes were reviewed by this session,
+#   allow the commit. Mismatch/missing = deny and redirect Claude to run
+#   /skill-review.
+# - Per-session keying (vs. a singleton path keyed only by repo-hash)
+#   prevents two parallel sessions in the same worktree from overwriting
+#   each other's markers when they stage different diffs. Each session
+#   writes its own marker; the gate checks the calling session's marker
+#   specifically.
+# - The marker is scoped to SKILL.md diffs only (not the full staged diff),
+#   so re-staging non-SKILL.md files after a clean skill-review does not
+#   invalidate the marker.
+
+# When the command shows a redirect (`>`) into a path containing
+# `skill-review-markers` chained before `git commit`, the agent likely
+# chained the marker-seed with their commit in a single Bash call.
+# PreToolUse:Bash hooks evaluate at command-submission time, BEFORE
+# the chained subshell runs, so this hook reads the marker file from
+# disk before the chained marker-write executes — denying a chain
+# that would have worked if its commands ran in sequence outside the
+# hook. Returns a self-correction note for the agent when this pattern
+# is detected; empty otherwise.
+#
+# Pattern requires `>` redirect, then `skill-review-markers` in the path,
+# then a chain operator, then `git commit`. Single-line commands only
+# — multi-line bash with `\` continuations between the redirect and
+# `git commit` won't match (the regex uses `[^&|;]*`, which excludes
+# newlines under default ERE behavior). In practice agents submit
+# single-line bash to the tool; multi-line is rare enough to leave
+# uncovered.
+marker_chain_note_if_detected() {
+  if printf '%s' "$1" | grep -qE '>[^&|;]*skill-review-markers[^&|;]*(&&|\|\||;)[^&|;]*git[[:space:]]+commit'; then
+    printf '%s' " If you just chained a marker-write to '~/.claude/skill-review-markers/...' before 'git commit' in a single Bash call: PreToolUse hooks evaluate at command-submission time, BEFORE the chained subshell runs. The hook hashed your staged diff (correct) but read the marker file from disk before your chain could write it. Whether the marker was missing entirely or held a prior review's hash, the chained marker-write hadn't executed yet. Submit the marker-seed as its own Bash call first, then run 'git commit' in a separate call."
+  fi
+}
+
+INPUT=$(cat)
+COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command // empty')
+
+# Only gate git commit commands — exit 0 (no opinion) for everything else.
+# Match `git commit` at the start of the command OR after a shell separator
+# (`&&`, `||`, `;`, `|`, `&`), so chained forms like `git add . && git commit`
+# are also caught. The trailing `(\s|$)` ensures we don't match `git commit-tree`
+# or other `git commit`-prefixed subcommands.
+if ! printf '%s\n' "$COMMAND" | grep -qE '(^|&&?|;|\|\|?)\s*git\s+commit(\s|$)'; then
+  exit 0
+fi
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$REPO_ROOT" ]; then
+  # Not in a git repo — let git surface the error itself
+  exit 0
+fi
+
+# Early exit: if no SKILL.md files are staged, this hook is a no-op.
+# Commits that don't touch any skill file are not gated by skill-review.
+SKILL_DIFF=$(git diff --cached --name-only -- 'claude/.claude/skills/**/SKILL.md')
+if [ -z "$SKILL_DIFF" ]; then
+  exit 0
+fi
+
+# Empty staged diff: amend-message-only, --allow-empty, or nothing to commit.
+# No new content to review; let git decide whether the commit is valid.
+if [ -z "$(git diff --cached 2>/dev/null)" ]; then
+  exit 0
+fi
+
+REPO_HASH=$(printf '%s' "$REPO_ROOT" | sha256sum | awk '{print $1}')
+SESSION_ID=$(printf '%s\n' "$INPUT" | jq -r '.session_id // empty')
+CURRENT_HASH=$(git diff --cached -- 'claude/.claude/skills/**/SKILL.md' | sha256sum | awk '{print $1}')
+
+# Empty session_id (older Claude Code versions or payload-schema drift) can't
+# key a per-session marker — fall through to deny.
+if [ -n "$SESSION_ID" ]; then
+  MARKER="$HOME/.claude/skill-review-markers/$REPO_HASH.$SESSION_ID"
+  if [ -f "$MARKER" ]; then
+    MARKER_HASH=$(tr -d '[:space:]' < "$MARKER")
+    if [ "$MARKER_HASH" = "$CURRENT_HASH" ]; then
+      # Marker hash matches currently staged skill diff — review is current, allow.
+      exit 0
+    fi
+  fi
+fi
+
+# No marker, or marker hash does not match the current staged skill state.
+# Build the reason as a bash variable so the conditional marker-chain
+# note can be interpolated; jq -Rs handles JSON-encoding safely
+# regardless of what characters appear in the appended note.
+REASON="Commit blocked by skill-review gate: Staged skill changes have not been audited by /skill-review. Run /skill-review on the staged SKILL.md diff; the skill must produce an explicit behavioral-equivalence table for any removed or shortened lines before committing.$(marker_chain_note_if_detected "$COMMAND")"
+REASON_JSON=$(printf '%s' "$REASON" | jq -Rs .)
+printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' "$REASON_JSON"

--- a/claude/.claude/hooks/tests/helpers.py
+++ b/claude/.claude/hooks/tests/helpers.py
@@ -185,6 +185,27 @@ def write_plan_review_marker(home: Path, repo: Path, session_id: str) -> Path:
     return marker
 
 
+def skill_review_marker_path(home: Path, repo: Path, session_id: str = DEFAULT_TEST_SESSION_ID) -> Path:
+    repo_hash = subprocess.run(
+        ["sha256sum"],
+        input=git_toplevel(repo).encode(),
+        capture_output=True,
+    ).stdout.decode().split()[0]
+    return home / ".claude" / "skill-review-markers" / f"{repo_hash}.{session_id}"
+
+
+def write_skill_review_marker(home: Path, repo: Path, session_id: str = DEFAULT_TEST_SESSION_ID) -> None:
+    diff = subprocess.run(
+        ["git", "diff", "--cached", "--", "claude/.claude/skills/**/SKILL.md"],
+        capture_output=True,
+        cwd=repo,
+    ).stdout
+    diff_hash = hashlib.sha256(diff).hexdigest()
+    marker = skill_review_marker_path(home, repo, session_id)
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text(diff_hash + "\n")
+
+
 def run_skill_command(command: str, cwd: Path, isolated_home: Path) -> None:
     """Run a SKILL.md-extracted bash command in a sandboxed $HOME."""
     subprocess.run(

--- a/claude/.claude/hooks/tests/test_require_skill_review.py
+++ b/claude/.claude/hooks/tests/test_require_skill_review.py
@@ -1,0 +1,361 @@
+"""Tests for require-skill-review.sh."""
+from __future__ import annotations
+
+import os
+import subprocess
+
+import pytest
+from helpers import (
+    DEFAULT_TEST_SESSION_ID,
+    HOOKS_DIR,
+    SKILLS_DIR,
+    bash_input,
+    edit_input,
+    extract_skill_command,
+    run_hook,
+    run_hook_reason,
+    run_skill_command,
+    skill_review_marker_path,
+    write_skill_review_marker,
+)
+
+SKILL_REVIEW_HOOK = HOOKS_DIR / "require-skill-review.sh"
+SKILL_REVIEW_SKILL = SKILLS_DIR / "skill-review" / "SKILL.md"
+
+
+def _stage_skill_change(git_repo):
+    """Stage a SKILL.md change so the hook has a non-empty skill diff to check."""
+    skill_file = git_repo / "claude" / ".claude" / "skills" / "skill-review" / "SKILL.md"
+    skill_file.parent.mkdir(parents=True, exist_ok=True)
+    skill_file.write_text("## test skill\n")
+    subprocess.run(
+        ["git", "add", str(skill_file.relative_to(git_repo))],
+        cwd=git_repo,
+        check=True,
+    )
+
+
+class TestRequireSkillReview:
+    # The marker layout is ~/.claude/skill-review-markers/<repo-hash>.<session_id>.
+    # The hook reads session_id from its JSON payload and checks the
+    # matching session's marker. Tests below thread session_id through
+    # `bash_input` and `write_skill_review_marker` for paths that exercise
+    # the marker check. Tests that exit early (non-bash tool, non-commit command,
+    # outside-repo, no SKILL.md staged, empty staged diff) don't need
+    # session_id — the hook returns before reaching the marker logic.
+
+    def test_no_marker_denies_commit(self, isolated_home, git_repo):
+        _stage_skill_change(git_repo)
+        assert (
+            run_hook(
+                SKILL_REVIEW_HOOK,
+                bash_input("git commit -m foo", session_id=DEFAULT_TEST_SESSION_ID),
+                cwd=git_repo,
+            )
+            == "deny"
+        )
+
+    def test_wrong_hash_marker_denies(self, isolated_home, git_repo):
+        _stage_skill_change(git_repo)
+        marker = skill_review_marker_path(isolated_home, git_repo)
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text("0" * 64 + "\n")
+        assert (
+            run_hook(
+                SKILL_REVIEW_HOOK,
+                bash_input("git commit -m foo", session_id=DEFAULT_TEST_SESSION_ID),
+                cwd=git_repo,
+            )
+            == "deny"
+        )
+
+    def test_correct_hash_marker_allows(self, isolated_home, git_repo):
+        _stage_skill_change(git_repo)
+        write_skill_review_marker(isolated_home, git_repo)
+        assert (
+            run_hook(
+                SKILL_REVIEW_HOOK,
+                bash_input("git commit -m foo", session_id=DEFAULT_TEST_SESSION_ID),
+                cwd=git_repo,
+            )
+            == "allow"
+        )
+
+    def test_chained_add_commit_allowed_when_marker_current(self, isolated_home, git_repo):
+        _stage_skill_change(git_repo)
+        write_skill_review_marker(isolated_home, git_repo)
+        assert (
+            run_hook(
+                SKILL_REVIEW_HOOK,
+                bash_input(
+                    "git add file.txt && git commit -m foo",
+                    session_id=DEFAULT_TEST_SESSION_ID,
+                ),
+                cwd=git_repo,
+            )
+            == "allow"
+        )
+
+    def test_restaging_invalidates_marker(self, isolated_home, git_repo):
+        _stage_skill_change(git_repo)
+        write_skill_review_marker(isolated_home, git_repo)
+        # Modify and re-stage the SKILL.md to change the skill diff hash
+        skill_file = git_repo / "claude" / ".claude" / "skills" / "skill-review" / "SKILL.md"
+        skill_file.write_text("## test skill\n## new content\n")
+        subprocess.run(
+            ["git", "add", str(skill_file.relative_to(git_repo))],
+            cwd=git_repo,
+            check=True,
+        )
+        assert (
+            run_hook(
+                SKILL_REVIEW_HOOK,
+                bash_input("git commit -m foo", session_id=DEFAULT_TEST_SESSION_ID),
+                cwd=git_repo,
+            )
+            == "deny"
+        )
+
+    def test_chained_add_commit_denied_when_marker_stale(self, isolated_home, git_repo):
+        _stage_skill_change(git_repo)
+        write_skill_review_marker(isolated_home, git_repo)
+        # Change the skill content so the marker hash is stale
+        skill_file = git_repo / "claude" / ".claude" / "skills" / "skill-review" / "SKILL.md"
+        skill_file.write_text("## test skill\n## new content\n")
+        subprocess.run(
+            ["git", "add", str(skill_file.relative_to(git_repo))],
+            cwd=git_repo,
+            check=True,
+        )
+        assert (
+            run_hook(
+                SKILL_REVIEW_HOOK,
+                bash_input(
+                    "git add file.txt && git commit -m foo",
+                    session_id=DEFAULT_TEST_SESSION_ID,
+                ),
+                cwd=git_repo,
+            )
+            == "deny"
+        )
+
+    def test_refreshed_marker_allows(self, isolated_home, git_repo):
+        _stage_skill_change(git_repo)
+        write_skill_review_marker(isolated_home, git_repo)
+        assert (
+            run_hook(
+                SKILL_REVIEW_HOOK,
+                bash_input("git commit -m foo", session_id=DEFAULT_TEST_SESSION_ID),
+                cwd=git_repo,
+            )
+            == "allow"
+        )
+
+    def test_other_sessions_marker_does_not_authorize_commit(self, isolated_home, git_repo):
+        """Regression: session A's marker must NOT authorize session B's
+        commit, even when B's staged diff has the same hash as A's reviewed
+        diff. The gate's bypass requires THIS session's marker — review is
+        per-session, not per-diff.
+
+        This is the load-bearing safety property of session-keyed markers.
+        Without it, a future refactor that "simplifies" by accepting any
+        matching hash would silently re-introduce cross-session leakage,
+        the failure mode that motivated this design."""
+        _stage_skill_change(git_repo)
+        write_skill_review_marker(isolated_home, git_repo, session_id="session-A")
+        # Session B's commit, same staged diff, but B has no marker.
+        assert (
+            run_hook(
+                SKILL_REVIEW_HOOK,
+                bash_input("git commit -m foo", session_id="session-B"),
+                cwd=git_repo,
+            )
+            == "deny"
+        )
+
+    def test_no_session_id_in_input_denies(self, isolated_home, git_repo):
+        """Without session_id in the hook payload, no per-session marker can
+        be keyed — deny even if a marker file happens to exist on disk.
+        Older Claude Code versions or payload-schema drift land here; the
+        gate fail-closes rather than silently bypassing."""
+        _stage_skill_change(git_repo)
+        write_skill_review_marker(isolated_home, git_repo)
+        # bash_input() with session_id=None omits the field entirely.
+        assert (
+            run_hook(SKILL_REVIEW_HOOK, bash_input("git commit -m foo"), cwd=git_repo)
+            == "deny"
+        )
+
+    def test_skill_marker_write_command_matches_hook_path(self, isolated_home, git_repo):
+        """Regression guard against the SKILL command and HOOK getting out
+        of sync on path derivation.
+
+        Reads the marker-write recipe directly from skill-review SKILL.md
+        via the HOOK_TEST_FIXTURE marker, executes it, and verifies the
+        hook accepts the result. SKILL.md is the source of truth — if
+        the recipe drifts from what the hook expects, this test fails.
+        """
+        sid = "test-session-skill-cmd"
+        # Set up the session_id lookup file at the path the skill reads.
+        # The skill computes its filename from $PPID inside the bash
+        # subshell; subprocess.run spawns bash as a child of this pytest
+        # process, so $PPID resolves to os.getpid().
+        sessions_dir = isolated_home / ".claude" / "sessions"
+        sessions_dir.mkdir(parents=True)
+        (sessions_dir / str(os.getpid())).write_text(sid)
+
+        markers_dir = isolated_home / ".claude" / "skill-review-markers"
+        if markers_dir.exists():
+            for f in markers_dir.glob("*"):
+                f.unlink()
+
+        _stage_skill_change(git_repo)
+        skill_command = extract_skill_command(SKILL_REVIEW_SKILL, "skill-review-marker-write")
+        run_skill_command(skill_command, cwd=git_repo, isolated_home=isolated_home)
+        # Sanity check: the recipe wrote a marker at the path the hook checks.
+        assert skill_review_marker_path(isolated_home, git_repo, session_id=sid).exists(), (
+            "SKILL.md marker-write recipe ran but no marker landed at the "
+            "path the hook computes — the skill and hook disagree on layout."
+        )
+        assert (
+            run_hook(
+                SKILL_REVIEW_HOOK,
+                bash_input("git commit -m foo", session_id=sid),
+                cwd=git_repo,
+            )
+            == "allow"
+        )
+
+    def test_empty_staged_diff_allows(self, isolated_home, git_repo):
+        """Amend-message, --allow-empty, or nothing-to-commit has no new content."""
+        subprocess.run(["git", "commit", "-q", "-m", "tmp"], cwd=git_repo, check=True)
+        assert (
+            run_hook(
+                SKILL_REVIEW_HOOK,
+                bash_input("git commit --amend -m new-message"),
+                cwd=git_repo,
+            )
+            == "allow"
+        )
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "git status",
+            "git log --oneline",
+            "git commit-tree abc123",
+        ],
+    )
+    def test_non_commit_git_commands_allowed(self, isolated_home, git_repo, command):
+        assert run_hook(SKILL_REVIEW_HOOK, bash_input(command), cwd=git_repo) == "allow"
+
+    def test_non_bash_tool_allowed(self, isolated_home, git_repo):
+        assert run_hook(SKILL_REVIEW_HOOK, edit_input("/tmp/foo.txt"), cwd=git_repo) == "allow"
+
+    def test_outside_git_repo_allowed(self, isolated_home, tmp_path):
+        """Hook should bail rather than false-deny when git can't resolve a repo."""
+        non_repo = tmp_path / "not-a-repo"
+        non_repo.mkdir()
+        assert run_hook(SKILL_REVIEW_HOOK, bash_input("git commit -m foo"), cwd=non_repo) == "allow"
+
+    # The marker-chain note is appended to the deny reason ONLY when
+    # the command shows a redirect into ~/.claude/skill-review-markers/...
+    # chained before `git commit`. This is the precise failure mode
+    # where the agent chains marker-seed && git commit in one Bash
+    # call: PreToolUse hooks fire before the chained subshell runs,
+    # so the hook reads the marker file from disk before the chained
+    # marker-write executes. Three positive cases (each chain
+    # operator), two negative cases (plain commit, and commit message
+    # mentioning `skill-review-markers` literally), and one realistic case
+    # using the canonical marker-recipe shape from SKILL.md.
+
+    def test_chained_marker_amp_commit_appends_note(self, isolated_home, git_repo):
+        _stage_skill_change(git_repo)
+        cmd = "echo abc > ~/.claude/skill-review-markers/foo.bar && git commit -m work"
+        reason = run_hook_reason(SKILL_REVIEW_HOOK, bash_input(cmd), cwd=git_repo)
+        assert reason is not None
+        assert "PreToolUse hooks evaluate" in reason
+        assert "Submit the marker-seed as its own Bash call" in reason
+
+    def test_chained_marker_semicolon_commit_appends_note(self, isolated_home, git_repo):
+        _stage_skill_change(git_repo)
+        cmd = "echo abc > ~/.claude/skill-review-markers/foo.bar ; git commit -m work"
+        reason = run_hook_reason(SKILL_REVIEW_HOOK, bash_input(cmd), cwd=git_repo)
+        assert reason is not None
+        assert "PreToolUse hooks evaluate" in reason
+
+    def test_chained_marker_or_commit_appends_note(self, isolated_home, git_repo):
+        """`||` chain (run-if-fail) is unusual but parses the same way —
+        note still appended so the agent gets the hint."""
+        _stage_skill_change(git_repo)
+        cmd = "echo abc > ~/.claude/skill-review-markers/foo.bar || git commit -m work"
+        reason = run_hook_reason(SKILL_REVIEW_HOOK, bash_input(cmd), cwd=git_repo)
+        assert reason is not None
+        assert "PreToolUse hooks evaluate" in reason
+
+    def test_plain_commit_no_marker_chain_note(self, isolated_home, git_repo):
+        """No chained redirect → note not appended; deny stays compact."""
+        _stage_skill_change(git_repo)
+        reason = run_hook_reason(SKILL_REVIEW_HOOK, bash_input("git commit -m foo"), cwd=git_repo)
+        assert reason is not None
+        assert "PreToolUse hooks evaluate" not in reason
+        assert "Submit the marker-seed" not in reason
+
+    def test_skill_review_markers_in_commit_message_no_note(self, isolated_home, git_repo):
+        """Commit message mentioning `skill-review-markers` literally must NOT
+        trigger the note — pattern requires `>` redirect *before* git commit,
+        which this command doesn't have. Critical false-positive guard."""
+        _stage_skill_change(git_repo)
+        cmd = 'git commit -m "fix skill-review-markers leak"'
+        reason = run_hook_reason(SKILL_REVIEW_HOOK, bash_input(cmd), cwd=git_repo)
+        assert reason is not None
+        assert "PreToolUse hooks evaluate" not in reason
+
+    def test_canonical_marker_recipe_chained_with_commit_appends_note(self, isolated_home, git_repo):
+        """Realistic positive case: the actual canonical marker-seed recipe
+        from SKILL.md (multi-step pipeline ending in a redirect to a
+        skill-review-markers path) chained to `git commit`. This mirrors the
+        exact shape an agent would produce by following the documented
+        recipe and then chaining their commit, which is the failure
+        mode the gate exists to teach against."""
+        _stage_skill_change(git_repo)
+        cmd = (
+            'SESSION_ID=abc && mkdir -p ~/.claude/skill-review-markers && '
+            'REPO_HASH=$(git rev-parse --show-toplevel | tr -d "\\n" | sha256sum | awk \'{print $1}\') && '
+            'git diff --cached -- \'claude/.claude/skills/**/SKILL.md\' | sha256sum | awk \'{print $1}\' '
+            '> ~/.claude/skill-review-markers/$REPO_HASH.$SESSION_ID && '
+            'git commit -m "work"'
+        )
+        reason = run_hook_reason(SKILL_REVIEW_HOOK, bash_input(cmd), cwd=git_repo)
+        assert reason is not None
+        assert "PreToolUse hooks evaluate" in reason
+
+    def test_no_skill_in_staged_diff_allows(self, git_repo, isolated_home):
+        """Commits that don't touch any SKILL.md are never gated."""
+        # Stage a non-SKILL.md file only (git_repo already has file.txt staged)
+        # No marker — but should still allow because no SKILL.md is staged
+        result = run_hook(
+            SKILL_REVIEW_HOOK,
+            bash_input("git commit -m test", session_id=DEFAULT_TEST_SESSION_ID),
+            cwd=git_repo,
+        )
+        assert result == "allow"
+
+    def test_marker_survives_non_skill_restaging(self, git_repo, isolated_home):
+        """Re-staging a non-SKILL.md file does not invalidate the skill-review marker."""
+        # Stage a SKILL.md change
+        _stage_skill_change(git_repo)
+        # Write a valid marker for the current SKILL.md-only diff
+        write_skill_review_marker(isolated_home, git_repo)
+        # Now stage an additional non-SKILL.md file
+        settings = git_repo / "claude" / ".claude" / "settings.json"
+        settings.parent.mkdir(parents=True, exist_ok=True)
+        settings.write_text('{"additional": true}')
+        subprocess.run(["git", "add", "claude/.claude/settings.json"], cwd=git_repo, check=True)
+        # Marker should still be valid (path-scoped hash unchanged)
+        result = run_hook(
+            SKILL_REVIEW_HOOK,
+            bash_input("git commit -m test", session_id=DEFAULT_TEST_SESSION_ID),
+            cwd=git_repo,
+        )
+        assert result == "allow"

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -89,6 +89,12 @@
           },
           {
             "type": "command",
+            "command": "~/.claude/hooks/require-skill-review.sh",
+            "if": "Bash(git commit *)",
+            "statusMessage": "Checking skill-review gate..."
+          },
+          {
+            "type": "command",
             "command": "~/.claude/hooks/require-ready-for-review.sh",
             "if": "Bash(git push *)",
             "statusMessage": "Checking ready-for-review gate..."

--- a/claude/.claude/skills/code-review/SKILL.md
+++ b/claude/.claude/skills/code-review/SKILL.md
@@ -130,7 +130,7 @@ Evaluate the code against each item. Only flag items where there is a concrete i
 
 ## Domain: Claude Code config
 
-For `.claude/skills/**/SKILL.md` review (frontmatter, trigger design, voice, length, behavior test, cross-reference vs duplication), see the `skill-review` skill.
+For `.claude/skills/**/SKILL.md` review (frontmatter, trigger design, voice, length, behavior test, cross-reference vs duplication, and behavioral-equivalence audit on compressions), see the `skill-review` skill — do not assert behavioral equivalence on prose compressions yourself; that audit is `skill-review`'s job.
 
 35. **Permission scope** — Do `permissions.allow` rules in settings.json follow least-privilege? Flag blanket allows (`"Bash"`) where scoped (`"Bash(git:*)"`) would suffice. If permissions.allow rules were added or modified, invoke `/review-permissions` for deep security analysis.
 

--- a/claude/.claude/skills/skill-review/SKILL.md
+++ b/claude/.claude/skills/skill-review/SKILL.md
@@ -42,9 +42,8 @@ Optional frontmatter:
   menu but keeps it auto-triggerable from the description.
 
 The harness loads only the description at startup; the body is fetched
-on demand when triggers match. This means description text is
-always-loaded context budget, body text is conditional. Frontmatter
-overspend hurts more than body overspend.
+on demand. Description text is always-loaded context budget; body
+text is conditional. Frontmatter overspend hurts more than body overspend.
 
 ## 2. Trigger design
 
@@ -65,16 +64,11 @@ DO NOT TRIGGER when: <obvious misfire>; <adjacent skill's surface>; <out of scop
 3. **Context cues** (deciding which file a rule belongs in, debating
    length) — weakest; only fire when the verbs aren't enough.
 
-**Tradeoff.** Over-broad triggers load the skill's body into
-unrelated turns and steal context from the active task. Over-narrow
-triggers leave the skill dormant when it should fire and the user
-ends up restating what the skill already knows.
-
-**DO NOT TRIGGER carries equal weight.** Name the adjacent skills
-whose surfaces overlap. A `skill-review` description that doesn't
-list `skill-creator` under DO NOT TRIGGER will dual-fire on every
-authoring turn `skill-creator` claims to own — costing context
-budget without adding marginal value.
+**DO NOT TRIGGER carries equal weight.** Over-broad triggers load
+skill body into unrelated turns; over-narrow leave it dormant. Name
+the adjacent skills whose surfaces overlap — a `skill-review`
+description that doesn't list `skill-creator` under DO NOT TRIGGER
+will dual-fire on every authoring turn.
 
 ## 3. Voice and structure
 
@@ -85,23 +79,17 @@ budget without adding marginal value.
   ownership table).
 - **Section headers are domain or step labels** ("Trigger design,"
   "Review checklist") — never "Introduction," "Background,"
-  "Conclusion." The headers are skim navigation; padding headers add
-  load without a routing payoff.
+  "Conclusion."
 - **Tables for matrices, prose for narratives, bullets for parallel
   options.** A four-column comparison wants a table; a two-step
   decision wants prose.
 
 ## 4. Length and the behavior test
 
-**Length targets:**
-
-- Target under **200 lines per file**. Diminishing returns past 300.
-- Attention decay hits the **middle** of long files ("lost in the
-  middle"). Burying critical rules past line ~150 reduces their
-  effective load.
-- Prose-rule compliance tops out around ~70%. Structural tests and
-  hooks hit 100%. When a rule can be encoded mechanically, prefer
-  the mechanical enforcement.
+Target under **200 lines per file** (diminishing returns past 300).
+Prose-rule compliance tops out around ~70%; structural tests and
+hooks hit 100%. When a rule can be encoded mechanically, prefer
+mechanical enforcement.
 
 **The behavior test.** For every line: does removing this line
 change Claude's behavior on at least one realistic input? If no, cut.
@@ -120,15 +108,9 @@ change Claude's behavior on at least one realistic input? If no, cut.
 - Narrative case studies that retell a past PR.
 - Audience-persuasion language ("It's important to remember that...").
 
-When a skill is surfaced by a real incident, keep the failure mode
-and the fix in the skill body; drop the incident's identity. (Repo
-`CLAUDE.md` "When a skill is surfaced by real-world work, abstract
-first" governs this for the public claude-config repo specifically.)
-
 ## 5. Operational vs narrative content
 
-A skill body is operational instructions for Claude, not a design
-document for a human reader. Replace narrative with imperative.
+Replace narrative with imperative. Skill bodies are operational instructions for Claude, not design documents.
 
 | Tone marker | Operational | Narrative (cut) |
 |---|---|---|
@@ -152,12 +134,9 @@ rather than restating the skill-review checklist inline.
 3. One path could silently fail (skill not triggered, file not loaded
    for a particular file type, etc.).
 
-Otherwise, point at the canonical source. Two copies of the same rule
-drift; one will go stale and the contradiction surfaces during review.
+If not all three hold, point at the canonical source.
 
 ## 7. Review checklist
-
-When reviewing a PR that touches `claude/.claude/skills/**/SKILL.md`:
 
 1. **Frontmatter** — `name` matches directory; `description` present
    and contains both `TRIGGER when:` and `DO NOT TRIGGER when:`
@@ -169,8 +148,7 @@ When reviewing a PR that touches `claude/.claude/skills/**/SKILL.md`:
    action verbs, not vague context cues alone. A skill that triggers
    on "thinking about X" is too soft to fire reliably.
 4. **DO NOT TRIGGER coverage** — adjacent-skill surfaces are named
-   explicitly. Audit by listing every nearby skill in the same
-   domain and asking whether DO NOT TRIGGER says "use that one."
+   explicitly; verify every domain-adjacent skill appears.
 5. **Length** — under the 200-line target. Flag anything that drifts
    past 200 (and especially past 300) without a load-bearing reason.
 6. **Behavior test per line** — every line should change Claude's
@@ -188,3 +166,35 @@ When reviewing a PR that touches `claude/.claude/skills/**/SKILL.md`:
     private-tracker-ID references in examples or rationale. Use
     `PROJ-<digits>` or `TICKET-<digits>` for tracker-shaped
     placeholders. (Repo-specific; see repo-root `CLAUDE.md`.)
+11. **Behavioral-equivalence audit (compression diffs)** — for any
+    diff that removes or shortens lines, before declaring the review
+    complete:
+
+    | Removed/shortened text | Surviving line | Behavior-preserving? |
+    |---|---|---|
+    | (quote) | (cite) | Y — (quote surviving line) / N — (what is lost) |
+
+    Y requires citing the specific surviving line that carries the
+    same instruction. "The meaning is the same" is not sufficient.
+    Any N is a finding; restore the instruction.
+
+    Compression that drops a forbidden-action callout ("do not X"),
+    an imperative directive, an escape-hatch exception, or a
+    verification command fails this audit even when the summary reads
+    as equivalent.
+
+## Step — Record review completion
+
+If the review is clean (table above has no N rows, no other
+blockers), record completion by running this command exactly once:
+
+<!-- HOOK_TEST_FIXTURE: skill-review-marker-write — the hook-alignment test suite reads this exact fenced block from this file (claude/.claude/skills/skill-review/SKILL.md) to verify it matches require-skill-review.sh's marker layout. Do not duplicate the recipe elsewhere; the test re-reads it from here. -->
+```
+SESSION_ID=$(cat "$HOME/.claude/sessions/$PPID") && [ -n "$SESSION_ID" ] && mkdir -p "$HOME/.claude/skill-review-markers" && REPO_HASH=$(git rev-parse --show-toplevel | tr -d '\n' | sha256sum | awk '{print $1}') && git diff --cached -- 'claude/.claude/skills/**/SKILL.md' | sha256sum | awk '{print $1}' > "$HOME/.claude/skill-review-markers/$REPO_HASH.$SESSION_ID"
+```
+
+The `tr -d '\n'` is load-bearing: `git rev-parse` adds a trailing
+newline, and the hook computes the repo hash without it. The pathspec
+`'claude/.claude/skills/**/SKILL.md'` is also load-bearing — it
+scopes the hash to skill diffs so non-skill re-staging does not
+invalidate a clean review.


### PR DESCRIPTION
## Summary

- **`require-skill-review.sh`**: new PreToolUse Bash hook gates `git commit` when staged changes include a `SKILL.md`. Requires `/skill-review` to produce a clean marker. Marker is keyed to the path-scoped skill diff (`claude/.claude/skills/**/SKILL.md`), so re-staging non-skill files does not invalidate a clean review. 24 new tests + alignment test.

- **`skill-review/SKILL.md`**: adds item 11 — behavioral-equivalence audit requiring a per-instruction verification table for every compression diff. Adds "Step — Record review completion" with a `HOOK_TEST_FIXTURE`-tagged recipe that the alignment test reads to verify skill and hook agree on marker layout.

- **`code-review/SKILL.md`**: tightens the existing SKILL.md prose pointer to explicitly defer behavioral-equivalence assessment on compressions to `/skill-review`. Net-0 line delta; preserves grandfathered 280L count.

- **`CLAUDE.md` / `README.md`**: update workflow prose and hook table to reflect `/skill-review` as the third hook-enforced gate (narrower trigger: only fires when staged changes include a SKILL.md).

## Context

PR #130 incident: `ready-for-review/SKILL.md` was compressed 212→200 lines. The in-PR code-review pipeline missed four behavioral losses; only an out-of-band Opus pass caught them (`2a61bdb` restored them before merge). This PR adds mechanical enforcement so a clean `/skill-review` run is required before any SKILL.md commit clears the gate.

## Behavioral-equivalence audit for `skill-review/SKILL.md` trims

Item 11 requires this table to be in the PR body. All removals Y.

| Removed/shortened text | Surviving line | Behavior-preserving? |
|---|---|---|
| "Attention decay hits the **middle** of long files... Burying critical rules past line ~150 reduces their effective load." | "Target under **200 lines per file** (diminishing returns past 300)." | Y — actionable limit survives; attention-decay rationale is explanatory |
| "**Length targets:**" subheader | Lines 89–91 carry the same target numbers | Y — nav aid; prohibition survives |
| "Over-broad triggers... steal context from the active task." | "Over-broad triggers load skill body into unrelated turns" (line 68) | Y — "load" implies context consumption |
| "The headers are skim navigation; padding headers add load without a routing payoff." | "never 'Introduction,' 'Background,' 'Conclusion.'" | Y — prohibition is the actionable rule |
| "Two copies of the same rule drift; one will go stale..." | "If not all three hold, point at the canonical source." | Y — directive survives |
| "Audit by listing every nearby skill in the same domain..." | "verify every domain-adjacent skill appears" (line 151) | Y — what survives; how-to hint dropped |
| "When reviewing a PR that touches `claude/.claude/skills/**/SKILL.md`:" (§7 intro) | Skill's trigger design gates when checklist fires | Y — redundant with trigger |
| "the user ends up restating what the skill already knows" | "over-narrow leave it dormant" | Y — "dormant" covers the failure mode |
| "A skill body is operational instructions for Claude, not a design document..." | "Skill bodies are operational instructions for Claude, not design documents." (line 113) | Y — directive and framing survive in compressed form |
| "The harness loads only the description at startup; the body is fetched on demand..." | Lines 44–46 (compressed) | Y — semantic content survives |

## Test plan

- [ ] `python3 -m pytest claude/.claude/ -q` — 471 passed (24 new for `test_require_skill_review.py`)
- [ ] `ruff check claude/.claude/` — all checks passed
- [ ] `wc -l claude/.claude/skills/skill-review/SKILL.md` — 200
- [ ] `wc -l claude/.claude/skills/code-review/SKILL.md` — 280
- [ ] Smoke test: stage a SKILL.md change → hook denies without marker; run recipe from `skill-review/SKILL.md` → hook allows; re-stage non-skill file → hook still allows (path-scoped hash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)