### PR TITLE
feat: add test-first invariant to test-conventions skill

### DIFF
--- a/claude/.claude/skills/test-conventions/REFERENCES.md
+++ b/claude/.claude/skills/test-conventions/REFERENCES.md
@@ -1,0 +1,20 @@
+# References — test-conventions
+
+Reference material that informed this skill. Not loaded during skill execution — consult when editing the skill to verify a rule still holds or to add new guidance.
+
+## Test-first discipline and its recognized exceptions
+
+The test-first invariant is most strongly stated in:
+
+- **Kent Beck, *Test-Driven Development: By Example*** (Addison-Wesley, 2002) — canonical statement. Beck's later [Stack Overflow answer "How deep are your unit tests?"](https://stackoverflow.com/questions/153234/how-deep-are-your-unit-tests) frames the burden-of-proof clause: *"I get paid for code that works, not for tests, so my philosophy is to test as little as possible to reach a given level of confidence."*
+- **Gerard Meszaros, *xUnit Test Patterns*** (Addison-Wesley, 2007) — operationalized test-first into mainstream xUnit practice. Defines the [Humble Object](http://xunitpatterns.com/Humble%20Object.html) pattern that the SKILL section names for the UI/view-layer exception.
+
+Recognized exception categories are attested across:
+
+- **Spike solutions** — Kent Beck, [Spike Solution](https://wiki.c2.com/?SpikeSolution=) and *TDD by Example* Part III; James Shore, [Spike Solutions](https://www.jamesshore.com/v2/books/aoad1/spike_solutions); Ron Jeffries on the c2 wiki. Definition: knowledge-limited exploratory code, thrown away and re-done test-first.
+- **UI / view-layer code** — Meszaros, [Hard to Test Code](http://xunitpatterns.com/Hard%20to%20Test%20Code.html); Robert C. Martin, [When TDD doesn't work](https://blog.cleancoder.com/uncle-bob/2014/04/30/When-tdd-does-not-work.html); David Heinemeier Hansson, [Test-induced design damage](https://dhh.dk/2014/test-induced-design-damage.html); Google, [*Software Engineering at Google* ch. 14](https://abseil.io/resources/swe-book/html/ch14.html) — *"UI tests are notoriously unreliable and costly."*
+- **Configuration and wiring** — Uncle Bob, *When TDD doesn't work*; Google, [*SWE at Google* ch. 11](https://abseil.io/resources/swe-book/html/ch11.html) — large tests are *"more about validating configuration than pieces of code."*
+- **Physical / hardware boundaries** — Uncle Bob, *When TDD doesn't work*; Bissi et al., [*On the use of TDD for Embedded Systems*](https://www.sciencedirect.com/science/article/pii/S0950584925001181) (Sci. of Computer Programming, 2025).
+- **Test infrastructure** — Meszaros, *Hard to Test Code*; Uncle Bob, *When TDD doesn't work*.
+
+The 2014 [*Is TDD Dead?*](https://martinfowler.com/articles/is-tdd-dead/) conversation (Beck, Fowler, DHH) and Ian Cooper's [*TDD: Where Did It All Go Wrong?*](https://www.infoq.com/presentations/tdd-original/) (DevTernity 2017) frame the modern consensus: test at the module's public API rather than per-class, and treat TDD as context-dependent rather than universal. Beck's [Test Desiderata](https://medium.com/@kentbeck_7670/test-desiderata-94150638a4b3) (2019) reframes testing as a property tradeoff space.

--- a/claude/.claude/skills/test-conventions/SKILL.md
+++ b/claude/.claude/skills/test-conventions/SKILL.md
@@ -2,8 +2,8 @@
 name: test-conventions
 description: >
   Testing conventions for writing tests in any codebase: test pyramid layers,
-  design for testability, test isolation, naming, test data, coverage judgment,
-  and mock design.
+  test-first discipline, design for testability, test isolation, naming, test
+  data, coverage judgment, and mock design.
   TRIGGER when: planning tests for new code, writing test infrastructure
   (mocks, helpers, fixtures), or discussing test strategy for new features.
   DO NOT TRIGGER when: a project-level test skill is already loaded, the task
@@ -28,7 +28,15 @@ user-invocable: false
 **E2E tests** verify complete user journeys across the full stack. 
 **Smoke tests** are lightweight post-deploy checks that verify critical paths are functional — they answer "is it up?" not "does every flow work?"
 
-## 2. Design for testability
+## 2. Test-first invariant
+
+**PRODUCTION CODE REQUIRES A FAILING TEST FIRST.**
+
+Writing the test first catches regressions, forces interface design before implementation, and prevents tests shaped to pass after the fact. "First" means the test must run and fail before the production change is made — if you wrote production code first, delete it, write the test, watch it fail, then re-add the production code.
+
+Recognized exceptions: refactoring code already covered by tests; **spike solutions** — throwaway exploratory code meant to learn an unfamiliar API or shape, discarded and redone test-first afterward; **UI / view-layer code** that's hard to assert against (apply the **Humble Object** pattern: push logic into a tested presentation layer, leave the thin shell exempt); **configuration and wiring** with no branching logic; **physical-boundary code** (hardware integrations, device drivers); and **test infrastructure** itself (fixtures, helpers, doubles). For each exception, state the substitute verification — manual smoke, integration coverage at the next layer up, or why none is needed. The burden of proof is on the exception, not the rule.
+
+## 3. Design for testability
 
 ### Dependency injection over internal construction
 Functions should accept their dependencies as parameters, not create them internally. A function that constructs its own client internally cannot be tested without hitting the real service. Accepting the client as a parameter lets callers pass a test double.
@@ -53,7 +61,7 @@ Use the narrowest double that covers the test's intent. Prefer stubs for unit te
 - **Env vars / config:** Set and restore in setup/teardown blocks
 - **Time:** Inject timestamps as parameters rather than relying on the system clock
 
-## 3. Test isolation
+## 4. Test isolation
 
 ### Avoid global state in tests when possible
 Prefer designs that pass dependencies explicitly rather than relying on global state. When global state is unavoidable, follow the rules below.
@@ -81,7 +89,7 @@ Whether running locally or in CI, parallel test runners (pytest-xdist, Jest work
 - When sharing a test database, use per-test schemas or transaction rollback isolation
 - If a test mutates module-level state, it cannot safely run in parallel — document this constraint explicitly
 
-## 4. Test naming and structure
+## 5. Test naming and structure
 
 Test names should describe the **scenario** and **expected outcome**, not just the function name:
 - Good: `rejects_expired_token_with_401`, `returns_empty_list_when_no_matches`
@@ -101,7 +109,7 @@ Each test should follow the **Arrange / Act / Assert** (or Given / When / Then) 
 ### Regression test intent
 For tests that guard against a specific past bug, include a comment or docstring referencing the issue. This prevents future developers from deleting a test that looks redundant but guards against a known failure.
 
-## 5. Test data
+## 6. Test data
 
 - Use **factory/builder helpers** that supply sensible defaults; tests override only the fields relevant to the scenario
 - **Avoid magic values** — if a test uses `status: 3`, name the constant or comment why 3 matters
@@ -109,7 +117,7 @@ For tests that guard against a specific past bug, include a comment or docstring
 - **Shared fixtures** are appropriate for expensive setup (DB schemas, server instances), not for simple data objects
 - For tests against shared databases, use unique prefixes/suffixes (run ID, timestamp) so parallel runs and stale data don't collide
 
-## 6. Coverage judgment
+## 7. Coverage judgment
 
 ### What each test layer should verify
 
@@ -157,7 +165,7 @@ For endpoints or functions that handle concurrent writes:
 - The function handles partial failure (test one item failing in a batch)
 - The function has opt-out/preference logic (test opted-out path)
 
-## 7. Mock design principles
+## 8. Mock design principles
 
 ### Stub/mock fidelity
 - Test doubles should behave like the real thing for the patterns actually used
@@ -176,7 +184,7 @@ If an assertion checks a value that was set up directly in the test double rathe
 
 **Good (tests real logic):** stub `getUser` to return `{name: "Alice", role: "admin"}`, then assert the formatted display string equals `"Alice (Admin)"`. This tests the formatting/transformation logic the code actually performs.
 
-## 8. Common authoring mistakes
+## 9. Common authoring mistakes
 
 Avoid these when writing new tests:
 


### PR DESCRIPTION
## Summary

- Adds `## 2. Test-first invariant` section to `test-conventions/SKILL.md` with a bold ALL-CAPS rule and an industry-attested exception list (spike solutions, UI/view-layer via Humble Object pattern, configuration/wiring, physical-boundary code, test infrastructure, and refactors of covered code)
- Updates the frontmatter description to include "test-first discipline" so the skill triggers on test-sequencing prompts
- Creates `test-conventions/REFERENCES.md` with primary citations for the rule and each exception category (Beck, Meszaros, Uncle Bob, Shore, Jeffries, Fowler, DHH, Google SWE, IEEE embedded-TDD, Cooper)

## Context

Re-land of Phase 1B, reverted from PR #126 because the original draft pushed past the 200-line ceiling. This version stays at 198 lines (ceiling enforced by `check-skill-length.sh`, landed in PR #130).

Exception categories are industry-attested from multiple primary sources rather than hand-rolled — confirmed via primary-source web research before drafting. The "burden of proof is on the exception" framing anchors to Beck's own pragmatic statement ("test as little as possible to reach a given level of confidence").

Citations moved to `REFERENCES.md` rather than inline per the behavior-test rule: removing a citation changes nothing about how Claude executes TDD.

Sections 2-8 renumbered to 3-9 to make room. Pre-flight grep confirmed no cross-references to section numbers exist in the repo.

## Test plan

- [x] `wc -l claude/.claude/skills/test-conventions/SKILL.md` → 198 (≤200)
- [x] `pytest claude/.claude/` → 478 passed
- [x] `ruff check claude/.claude/` → all checks passed
- [x] `/skill-review` → clean (description scope finding applied: added "test-first discipline" to frontmatter content list)
- [x] `/code-review` → no issues found

🤖 Generated with [Claude Code](https://claude.com/claude-code)