### PR TITLE
feat: F-14 — voice polish, React-tilt softening, numbering fix

### DIFF
--- a/claude/.claude/agents/staff-frontend-engineer.md
+++ b/claude/.claude/agents/staff-frontend-engineer.md
@@ -21,7 +21,7 @@ If the diff is purely backend, infrastructure, server-only types with no contrac
 
 **Optimistic mutation lifecycle (universal invariant)** — optimistic writes must: (a) cancel in-flight refetches first, (b) snapshot current state, (c) apply optimistic update, (d) on error, restore from snapshot — not a try/catch branch, (e) on settled, invalidate relevant queries, (f) the mutation function must throw on error so rollback fires. Ad-hoc optimistic writes outside a mutation lifecycle are a bug class. TanStack Query's `onMutate`/`onError`/`onSettled` is one canonical implementation; SWR, Apollo, custom reducers must express the same invariants.
 
-**Async cancellation and effect lifecycle** — `useEffect` cleanup must abort or no-op pending work to avoid stale-closure writes / setState-on-unmounted; user-initiated requests need an `AbortController` so a faster keystroke doesn't lose to a slower stale response (request race); long-running effects need a cancellation token that the cleanup actually triggers.
+**Async cancellation and effect lifecycle** — effect-cleanup hooks (React `useEffect` cleanup, Vue `onUnmounted` / `watchEffect` cleanup, Svelte `onDestroy`, Solid `onCleanup`, Angular `ngOnDestroy`) must abort or no-op pending work to avoid stale-closure writes / state-writes-after-unmount; user-initiated requests need an `AbortController` so a faster keystroke doesn't lose to a slower stale response (request race); long-running effects need a cancellation token that the cleanup actually triggers.
 
 **Query contract mapping** — when backend response shape changes, do client selectors, types, AND cache keys all match? Co-owned with backend.
 
@@ -29,13 +29,13 @@ If the diff is purely backend, infrastructure, server-only types with no contrac
 
 **Per-state coverage on data-fetching paths** — loading, error, empty, success: all four states handled, not just the happy path.
 
-**Render stability and bundle hygiene** — inline literals in JSX props re-rendering children, missing list `key`s, un-memoized hot work; full-library imports where tree-shaking would suffice; unlazy-loaded images without intrinsic dimensions.
+**Render stability and bundle hygiene** — inline literals in component props (JSX, Vue templates, Svelte markup) re-rendering children, missing list `key`s, un-memoized hot work; full-library imports where tree-shaking would suffice; unlazy-loaded images without intrinsic dimensions.
 
 **Routing and navigation** — route guards, scroll restoration, deep-linkable state, 404/unauthorized routes, programmatic vs declarative nav, back-button after mutation.
 
 **Forms** — controlled vs uncontrolled choice, submit-in-flight double-submit prevention, field-level error mapping, dirty/reset/autosave semantics, optimistic form state vs server truth.
 
-**Error and Suspense boundaries** — placement and blast radius (what unmounts on error), recovery paths, fallback UX.
+**Error and Suspense boundaries** (React Suspense / Vue `<Suspense>` / Svelte `{#await}` / Angular `@defer`) — placement and blast radius (what unmounts on error), recovery paths, fallback UX.
 
 **SSR / hydration** (where applicable) — hydration mismatches, client-only guards, server-safe imports, flash-of-unauthorized-content.
 
@@ -51,7 +51,7 @@ If the diff is purely backend, infrastructure, server-only types with no contrac
 
 ## How to work
 
-1. Read every changed component and hook fully, including co-located tests. If a component changes branch behavior, check whether a test covers the new state.
+1. Read every changed component and hook (or composable / reactive primitive) fully, including co-located tests. If a component changes branch behavior, check whether a test covers the new state.
 2. For state/cache changes, trace cache keys. Missing invalidation is the most common optimistic-mutation bug.
 3. For accessibility findings, cite the specific interactive element.
 4. Do not propose implementations. Name the interaction, the broken state, the required behavior.

--- a/claude/.claude/skills/code-review/SKILL.md
+++ b/claude/.claude/skills/code-review/SKILL.md
@@ -130,15 +130,15 @@ Evaluate the code against each item. Only flag items where there is a concrete i
 
 ## Domain: Claude Code config
 
-For `.claude/skills/**/SKILL.md` review (frontmatter, trigger design, voice, length, behavior test, cross-reference vs duplication, and behavioral-equivalence audit on compressions), see the `skill-review` skill — do not assert behavioral equivalence on prose compressions yourself; that audit is `skill-review`'s job.
+For `.claude/skills/**/SKILL.md` review (frontmatter, trigger design, voice, length, behavior test, cross-reference vs duplication, and behavioral-equivalence audit on compressions), invoke the `skill-review` skill — do not assert behavioral equivalence on prose compressions yourself; that audit is `skill-review`'s job.
 
-35. **Permission scope** — Do `permissions.allow` rules in settings.json follow least-privilege? Flag blanket allows (`"Bash"`) where scoped (`"Bash(git:*)"`) would suffice. If permissions.allow rules were added or modified, invoke `/review-permissions` for deep security analysis.
+33. **Permission scope** — Do `permissions.allow` rules in settings.json follow least-privilege? Flag blanket allows (`"Bash"`) where scoped (`"Bash(git:*)"`) would suffice. If permissions.allow rules were added or modified, invoke `/review-permissions` for deep security analysis.
 
-For hook reviews (`claude/.claude/hooks/*.sh`, hook entries in `settings.json`), see the `claude-hook-review` skill.
+For hook reviews (`claude/.claude/hooks/*.sh`, hook entries in `settings.json`), invoke the `claude-hook-review` skill.
 
 ## Domain: Lovable config
 
-Apply when changed files match `.lovable/**`. See the `lovable-knowledge` skill for the review checklist (perspective, specificity, scope split between project/workspace knowledge, char budget, sync status).
+Apply when changed files match `.lovable/**`. Invoke the `lovable-knowledge` skill for the review checklist (perspective, specificity, scope split between project/workspace knowledge, char budget, sync status).
 
 ## Exclusions — do NOT flag these
 
@@ -252,8 +252,8 @@ The dispatcher fires reviewers per file-path domain detection. Each agent self-s
 | **30. Third-party API integration** | `staff-backend-engineer` | `ciso-reviewer` (credential scoping) |
 | **31. Sensitive data in logs** | `staff-backend-engineer` | `ciso-reviewer` |
 | **32. Performance-sensitive paths** | `staff-backend-engineer` (app-level query patterns) | `staff-data-engineer` (DDL / index / read-path) |
-| **35. Permission scope** | `ciso-reviewer` | — |
-| **36. Hook correctness** — reviewed via `claude-hook-review` skill | `staff-platform-engineer` | `ciso-reviewer` |
+| **33. Permission scope** | `ciso-reviewer` | — |
+| **34. Hook correctness** — reviewed via `claude-hook-review` skill | `staff-platform-engineer` | `ciso-reviewer` |
 
 ## Step — Record review completion
 


### PR DESCRIPTION
Closes #98.

## Summary

- **Voice standardization** (`code-review/SKILL.md` L133, L137, L141): converts three passive `see the X skill` prose pointers to imperative `invoke the X skill`, matching the already-correct form at L135 and the imperative-second-person rule in `skill-review/SKILL.md`.
- **React-tilt softening** (`staff-frontend-engineer.md` L24, L32, L38, L54): adds parenthetical cross-framework analogue labels at the four spots where React vocabulary was the only signal. Follows the existing stack-agnosticism declaration at L10 and the TanStack/SWR/Apollo pattern already present at L22.
- **Numbering fix** (`code-review/SKILL.md` L135, L255-256): renumbers items 35→33 and 36→34 in both the checklist body and Item-ownership table. `grep -rn 'item 3[3-6]' claude/` returned no hits before the change, so no external references needed updating.

## F-04 gating condition

The plan noted "Only apply item 1 if F-04 result keeps prose pointers." Per `code-review/REFERENCES.md` (decision 2026-05-04): F-04 confirmed the pointers are load-bearing and should be kept. Item 1 is unblocked.

## Test plan

- [x] 478 pytest tests pass (`pytest claude/.claude/ -q`)
- [x] `ruff check claude/.claude/` clean
- [x] `/skill-review` on staged diff — clean (marker written)
- [x] `/code-review` on staged diff — no issues (marker written)
- [x] `grep -nE '^[0-9]+\.' code-review/SKILL.md` confirms items 1-33 contiguous; 35-36 absent
- [x] `grep -rn 'item 3[3-6]' claude/` — no hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)