### PR TITLE
F-19: cross-session per-model token breakdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,8 @@ chmod +x ~/.claude/scripts/*.py
 - **`token-analyzer.py`** — cross-session per-model token breakdown (Opus / Sonnet / Haiku) with cache-hit rates, plus a list of Opus sessions that likely could have run on Sonnet (no plan-mode reasoning, no code edits). Reads `~/.claude/projects/*/*.jsonl`; no network calls, no writes.
 
   ```bash
-  ~/.claude/scripts/token-analyzer.py
+  ~/.claude/scripts/token-analyzer.py             # all-time
+  ~/.claude/scripts/token-analyzer.py --since 7d  # rolling window (e.g. 2d, 7d)
   ```
 
 ## Worktree enforcement

--- a/README.md
+++ b/README.md
@@ -161,6 +161,12 @@ chmod +x ~/.claude/scripts/*.py
   reads excluded) from session metadata, and prints the session ID so you can
   drill in with the per-session view.
 
+- **`token-analyzer.py`** — cross-session per-model token breakdown (Opus / Sonnet / Haiku) with cache-hit rates, plus a list of Opus sessions that likely could have run on Sonnet (no plan-mode reasoning, no code edits). Reads `~/.claude/projects/*/*.jsonl`; no network calls, no writes.
+
+  ```bash
+  ~/.claude/scripts/token-analyzer.py
+  ```
+
 ## Worktree enforcement
 
 Concurrent Claude Code sessions that share a working tree can race: one session's `git reset --hard`, `git stash`, or `git checkout` silently wipes another session's uncommitted edits. See [Claude Code issue #34327](https://github.com/anthropics/claude-code/issues/34327) for examples of this failure mode in the wild.

--- a/claude/.claude/scripts/tests/test_token_analyzer.py
+++ b/claude/.claude/scripts/tests/test_token_analyzer.py
@@ -1,0 +1,118 @@
+"""Smoke tests for token-analyzer.py."""
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Load token-analyzer as a module without it being on sys.path as a package.
+_SCRIPT = Path(__file__).parent.parent / "token-analyzer.py"
+_spec = importlib.util.spec_from_file_location("token_analyzer", _SCRIPT)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+
+
+def _make_assistant(model: str, inp: int, out: int, cc: int, cr: int, tool_names: list[str] | None = None) -> dict:
+    content = [{"type": "tool_use", "name": n} for n in (tool_names or [])]
+    return {
+        "type": "assistant",
+        "message": {
+            "model": model,
+            "usage": {
+                "input_tokens": inp,
+                "output_tokens": out,
+                "cache_creation_input_tokens": cc,
+                "cache_read_input_tokens": cr,
+            },
+            "content": content,
+        },
+    }
+
+
+def _make_user(text: str) -> dict:
+    return {"type": "user", "message": {"content": text}}
+
+
+@pytest.fixture()
+def fake_projects(tmp_path, monkeypatch):
+    projects = tmp_path / "projects"
+    proj_a = projects / "-home-user-repo"
+    proj_b = projects / "-home-user-other"
+    proj_a.mkdir(parents=True)
+    proj_b.mkdir(parents=True)
+    monkeypatch.setattr(_mod, "PROJECTS_DIR", projects)
+    return proj_a, proj_b
+
+
+def test_per_model_totals(fake_projects):
+    session_a, session_b = fake_projects
+    _write_jsonl(
+        session_a / "sess1.jsonl",
+        [
+            _make_user("Plan mode is active"),
+            _make_assistant("claude-opus-4-7", inp=100, out=200, cc=50, cr=300),
+        ],
+    )
+    _write_jsonl(
+        session_b / "sess2.jsonl",
+        [_make_assistant("claude-sonnet-4-6", inp=10, out=20, cc=5, cr=30)],
+    )
+
+    ft, sessions = _mod._walk()
+
+    assert ft["opus"]["inp"] == 100
+    assert ft["opus"]["out"] == 200
+    assert ft["opus"]["cc"] == 50
+    assert ft["opus"]["cr"] == 300
+    assert ft["sonnet"]["inp"] == 10
+    assert ft["sonnet"]["out"] == 20
+    assert len(sessions) == 2
+
+
+def test_cache_hit_ratio():
+    # cache_read / (cache_read + input) per spec
+    assert _mod._pct(300, 300 + 100) == "75%"
+    assert _mod._pct(0, 0) == "—"
+
+
+def test_candidate_flagging(fake_projects):
+    session_a, session_b = fake_projects
+    # Session A: Opus + plan mode → NOT a candidate
+    _write_jsonl(
+        session_a / "with_plan.jsonl",
+        [
+            _make_user("Plan mode is active in this session"),
+            _make_assistant("claude-opus-4-7", inp=100, out=1000, cc=0, cr=0),
+        ],
+    )
+    # Session B: Opus + no plan + no edits → IS a candidate (output ≥ 500)
+    _write_jsonl(
+        session_b / "no_plan.jsonl",
+        [_make_assistant("claude-opus-4-7", inp=50, out=800, cc=0, cr=0)],
+    )
+
+    _, sessions = _mod._walk()
+    cands = [s for s in sessions if s["fam"] == "opus" and not s["plan"] and not s["edits"] and s["out"] >= 500]
+    non_cands = [s for s in sessions if s["plan"]]
+
+    assert len(cands) == 1, f"expected 1 candidate, got {cands}"
+    assert len(non_cands) == 1
+    assert cands[0]["out"] == 800
+
+
+def test_edit_tool_excludes_candidate(fake_projects):
+    session_a, _ = fake_projects
+    # Opus session with an Edit call → not a candidate
+    _write_jsonl(
+        session_a / "with_edit.jsonl",
+        [_make_assistant("claude-opus-4-7", inp=50, out=600, cc=0, cr=0, tool_names=["Edit"])],
+    )
+
+    _, sessions = _mod._walk()
+    cands = [s for s in sessions if s["fam"] == "opus" and not s["plan"] and not s["edits"] and s["out"] >= 500]
+    assert len(cands) == 0

--- a/claude/.claude/scripts/tests/test_token_analyzer.py
+++ b/claude/.claude/scripts/tests/test_token_analyzer.py
@@ -1,7 +1,8 @@
 """Smoke tests for token-analyzer.py."""
 import importlib.util
 import json
-import sys
+import os
+import time
 from pathlib import Path
 
 import pytest
@@ -116,3 +117,24 @@ def test_edit_tool_excludes_candidate(fake_projects):
     _, sessions = _mod._walk()
     cands = [s for s in sessions if s["fam"] == "opus" and not s["plan"] and not s["edits"] and s["out"] >= 500]
     assert len(cands) == 0
+
+
+def test_since_filter(fake_projects):
+    session_a, session_b = fake_projects
+    old_file = session_a / "old_sess.jsonl"
+    new_file = session_b / "new_sess.jsonl"
+
+    _write_jsonl(old_file, [_make_assistant("claude-opus-4-7", inp=10, out=100, cc=0, cr=0)])
+    _write_jsonl(new_file, [_make_assistant("claude-sonnet-4-6", inp=10, out=200, cc=0, cr=0)])
+
+    # Back-date the old file to 10 days ago
+    old_mtime = time.time() - 10 * 86400
+    os.utime(old_file, (old_mtime, old_mtime))
+
+    # --since 2d should include new_file only
+    cutoff = time.time() - 2 * 86400
+    ft, sessions = _mod._walk(since=cutoff)
+
+    assert len(sessions) == 1
+    assert sessions[0]["fam"] == "sonnet"
+    assert ft.get("opus") is None or ft["opus"]["n"] == 0

--- a/claude/.claude/scripts/token-analyzer.py
+++ b/claude/.claude/scripts/token-analyzer.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """token-analyzer.py — per-model token breakdown across Claude Code sessions. No network; no writes."""
+import argparse
 import json
+import time
 from collections import defaultdict
 from pathlib import Path
 
@@ -8,6 +10,7 @@ PROJECTS_DIR = Path.home() / ".claude" / "projects"
 EDIT_TOOLS = {"Edit", "Write", "MultiEdit", "NotebookEdit"}
 _fam = lambda m: "opus" if "opus" in m else "sonnet" if "sonnet" in m else "haiku" if "haiku" in m else "other"
 _pct = lambda n, d: f"{100 * n / d:.0f}%" if d else "—"
+
 
 def _content_text(content):
     if isinstance(content, str):
@@ -17,10 +20,12 @@ def _content_text(content):
     return ""
 
 
-def _walk():
+def _walk(since: float | None = None):
     family_totals = defaultdict(lambda: {"n": 0, "inp": 0, "out": 0, "cc": 0, "cr": 0})
     sessions = []
     for jsonl in sorted(PROJECTS_DIR.glob("*/*.jsonl")):
+        if since is not None and jsonl.stat().st_mtime < since:
+            continue
         proj = jsonl.parent.name.lstrip("-").replace("-", "/", 2).split("/", 2)[-1]
         fam_out, tot = defaultdict(int), {"inp": 0, "out": 0, "cc": 0, "cr": 0}
         plan, edits = False, False
@@ -62,9 +67,22 @@ def _walk():
 
 
 def main():
-    ft, sessions = _walk()
+    parser = argparse.ArgumentParser(description="Per-model token breakdown across Claude Code sessions.")
+    parser.add_argument("--since", metavar="Nd", help="Limit to sessions whose file was modified within N days (e.g. 2d, 7d)")
+    args = parser.parse_args()
 
-    print("## Per-model token summary\n")
+    since = None
+    if args.since:
+        try:
+            days = float(args.since.rstrip("d"))
+            since = time.time() - days * 86400
+        except ValueError:
+            parser.error(f"--since: expected a number of days like '2d' or '7', got {args.since!r}")
+
+    label = f" (last {args.since})" if args.since else ""
+    ft, sessions = _walk(since)
+
+    print(f"## Per-model token summary{label}\n")
     print(f"{'Model':<8} {'Sessions':>8} {'Input':>12} {'Output':>12} {'CacheCreate':>12} {'CacheRead':>12} {'HitRate':>8}")
     print("-" * 78)
     for fam in ("opus", "sonnet", "haiku", "other"):
@@ -75,7 +93,7 @@ def main():
               f"{_pct(t['cr'], t['cr'] + t['inp']):>8}")
 
     top = sorted(sessions, key=lambda s: s["out"], reverse=True)[:10]
-    print(f"\n## Top 10 sessions by output tokens\n")
+    print(f"\n## Top 10 sessions by output tokens{label}\n")
     print(f"{'Session':>12}  {'Model':<8}  {'Output':>10}  {'Input':>10}  Plan  Edits  Project")
     print("-" * 78)
     for s in top:

--- a/claude/.claude/scripts/token-analyzer.py
+++ b/claude/.claude/scripts/token-analyzer.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""token-analyzer.py — per-model token breakdown across Claude Code sessions. No network; no writes."""
+import json
+from collections import defaultdict
+from pathlib import Path
+
+PROJECTS_DIR = Path.home() / ".claude" / "projects"
+EDIT_TOOLS = {"Edit", "Write", "MultiEdit", "NotebookEdit"}
+_fam = lambda m: "opus" if "opus" in m else "sonnet" if "sonnet" in m else "haiku" if "haiku" in m else "other"
+_pct = lambda n, d: f"{100 * n / d:.0f}%" if d else "—"
+
+def _content_text(content):
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return " ".join(b.get("text", "") for b in content if isinstance(b, dict) and b.get("type") == "text")
+    return ""
+
+
+def _walk():
+    family_totals = defaultdict(lambda: {"n": 0, "inp": 0, "out": 0, "cc": 0, "cr": 0})
+    sessions = []
+    for jsonl in sorted(PROJECTS_DIR.glob("*/*.jsonl")):
+        proj = jsonl.parent.name.lstrip("-").replace("-", "/", 2).split("/", 2)[-1]
+        fam_out, tot = defaultdict(int), {"inp": 0, "out": 0, "cc": 0, "cr": 0}
+        plan, edits = False, False
+        try:
+            with open(jsonl) as fh:
+                for raw in fh:
+                    try:
+                        rec = json.loads(raw)
+                    except json.JSONDecodeError:
+                        continue
+                    rtype, msg = rec.get("type", ""), rec.get("message", {})
+                    if rtype in ("user", "human") and "Plan mode is active" in _content_text(msg.get("content", "")):
+                        plan = True
+                    if rtype == "assistant" and isinstance(msg, dict) and "usage" in msg:
+                        u = msg["usage"]
+                        fam = _fam(msg.get("model", "").lower())
+                        inp, out, cc, cr = (u.get(k, 0) for k in (
+                            "input_tokens", "output_tokens",
+                            "cache_creation_input_tokens", "cache_read_input_tokens"))
+                        fam_out[fam] += out
+                        tot["inp"] += inp; tot["out"] += out; tot["cc"] += cc; tot["cr"] += cr
+                        if not edits and any(
+                            isinstance(b, dict) and b.get("name") in EDIT_TOOLS
+                            for b in msg.get("content", [])
+                        ):
+                            edits = True
+        except OSError:
+            continue
+        if not tot["out"]:
+            continue
+        dom = max(fam_out, key=fam_out.get) if fam_out else "other"
+        t = family_totals[dom]
+        t["n"] += 1
+        for k in ("inp", "out", "cc", "cr"):
+            t[k] += tot[k]
+        sessions.append({"id": jsonl.stem[:12], "proj": proj, "fam": dom,
+                         "out": tot["out"], "inp": tot["inp"], "plan": plan, "edits": edits})
+    return family_totals, sessions
+
+
+def main():
+    ft, sessions = _walk()
+
+    print("## Per-model token summary\n")
+    print(f"{'Model':<8} {'Sessions':>8} {'Input':>12} {'Output':>12} {'CacheCreate':>12} {'CacheRead':>12} {'HitRate':>8}")
+    print("-" * 78)
+    for fam in ("opus", "sonnet", "haiku", "other"):
+        t = ft.get(fam)
+        if not t:
+            continue
+        print(f"{fam:<8} {t['n']:>8} {t['inp']:>12,} {t['out']:>12,} {t['cc']:>12,} {t['cr']:>12,} "
+              f"{_pct(t['cr'], t['cr'] + t['inp']):>8}")
+
+    top = sorted(sessions, key=lambda s: s["out"], reverse=True)[:10]
+    print(f"\n## Top 10 sessions by output tokens\n")
+    print(f"{'Session':>12}  {'Model':<8}  {'Output':>10}  {'Input':>10}  Plan  Edits  Project")
+    print("-" * 78)
+    for s in top:
+        print(f"{s['id']:>12}  {s['fam']:<8}  {s['out']:>10,}  {s['inp']:>10,}  "
+              f"{'Y' if s['plan'] else 'N':>4}  {'Y' if s['edits'] else 'N':>5}  {s['proj']}")
+
+    cands = sorted(
+        (s for s in sessions if s["fam"] == "opus" and not s["plan"] and not s["edits"] and s["out"] >= 500),
+        key=lambda s: s["out"], reverse=True,
+    )
+    print(f"\n## Opus → Sonnet candidates ({len(cands)} sessions: no plan-mode, no edits)\n")
+    if cands:
+        print(f"{'Session':>12}  {'Output':>10}  {'Input':>10}  Project")
+        print("-" * 50)
+        for s in cands:
+            print(f"{s['id']:>12}  {s['out']:>10,}  {s['inp']:>10,}  {s['proj']}")
+    else:
+        print("None found.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `claude/.claude/scripts/token-analyzer.py` that walks `~/.claude/projects/*/*.jsonl` and outputs a Markdown per-model token breakdown + Opus→Sonnet candidate list.
- Adds `--since Nd` flag (e.g. `--since 2d`, `--since 7d`) to filter sessions by mtime for rolling-window analysis.
- Adds `claude/.claude/scripts/tests/test_token_analyzer.py` — 5 smoke tests covering per-model totals, cache-hit ratio formula, plan-mode candidate exclusion, edit-tool exclusion, and `--since` mtime filtering.
- Updates `README.md` with a bullet alongside `analyze-context.py`, including `--since` usage.

## Output shape

```
## Per-model token summary (last 2d)

Model    Sessions        Input       Output  CacheCreate    CacheRead  HitRate
...
## Top 10 sessions by output tokens (last 2d)
...
## Opus → Sonnet candidates (N sessions: no plan-mode, no edits)
...
```

## Design notes

**Per-model totals use a dominant-session heuristic:** all tokens in a session (including sidechain sub-agent turns with a different model) are credited to whichever model produced the most output in that session. A strict per-model accumulation would require attributing each assistant record to its own family before summing — that design is cleaner but adds lines and complexity for a personal at-a-glance tool.

**`--since` filters by file mtime**, not by session start timestamp. Close enough for personal usage monitoring; a session's JSONL file is only written to during the session.

**Opus→Sonnet heuristic:** sessions where `not had_plan_mode AND not had_edits AND output ≥ 500`. `had_plan_mode` is detected by the literal `"Plan mode is active"` persisting to the JSONL (confirmed by grep on live transcripts). `had_edits` checks for `Edit`/`Write`/`MultiEdit`/`NotebookEdit` tool calls. False positives are expected and acceptable — the list is for human review, not automated rerouting.

## Test plan

- [x] `pytest claude/.claude/scripts/tests/test_token_analyzer.py` — 5 passed
- [x] Smoke run against live `~/.claude/projects/` — per-model table, top-10, and candidate list all render correctly
- [x] `--since 2d` smoke run confirmed filtering works

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)