### PR TITLE
feat: add /plan-it skill (F-08)

### DIFF
--- a/claude/.claude/skills/plan-it/REFERENCES.md
+++ b/claude/.claude/skills/plan-it/REFERENCES.md
@@ -1,0 +1,102 @@
+# References — /plan-it
+
+Sources consulted during F-08 design. Read this file when editing SKILL.md
+to verify a rule still holds or to add new guidance.
+
+## Plan/spec/RFC section-structure surveys
+
+### Google design doc (primary)
+https://www.industrialempathy.com/posts/design-docs-at-google/
+
+Sections: Context and scope · Goals and non-goals · The actual design ·
+Alternatives considered · Cross-cutting concerns.
+
+Key quote: "This isn't a requirements doc — keep it succinct!" Rationale is
+required; length is not. Goals and non-goals appear in every format Google
+uses.
+
+### Squarespace RFC template (primary PDF)
+https://engineering.squarespace.com/s/Squarespace-RFC-Template.pdf
+
+Sections: Overview · Goals and Non-Goals · Background & Motivation · Design ·
+Timeline · Dependencies · Alternatives Considered/Prior Art · Operations ·
+Security/Privacy/Compliance · Risks · Revisions.
+
+Heavy format — Timeline, Operations, Security sections exist because
+Squarespace RFCs cover quarter-scale features needing org-wide signoff. Not
+appropriate for single-PR scope.
+
+### Michael Nygard ADR (primary)
+https://github.com/joelparkerhenderson/architecture-decision-record/blob/main/locales/en/templates/decision-record-template-by-michael-nygard/index.md
+
+Sections: Title · Status · Context · Decision · Consequences.
+
+ADRs are decision records, not implementation plans. Useful framing for the
+Context/Decision split but not directly applicable to plan-it's output format.
+
+### Pragmatic Engineer — cross-company RFC survey (secondary)
+https://blog.pragmaticengineer.com/rfcs-and-design-docs/
+
+Covers Sourcegraph (Summary · Background · Problem · Proposal · Definition of
+success) and HashiCorp (Background · Proposal · Abandoned ideas). Secondary
+source — Sourcegraph/HashiCorp section names come from this survey, not the
+companies' own published templates.
+
+## AI-coder plan patterns
+
+### superpowers writing-plans skill (primary)
+https://github.com/obra/superpowers/blob/main/skills/writing-plans/SKILL.md
+
+Key patterns: files-named-up-front per task, checkboxed steps sized 2-5
+minutes each, "no placeholders" rule (bans TBD/TODO/implement later), literal
+code blocks in each step, self-review checklist after writing.
+
+**Not adopted:** dual artifact (spec then plan), 200+ line plans with TDD
+step-by-step content. claude-config plans are denser, written for reviewer +
+implementer, not executor.
+
+### Devin session-prompt convention (primary)
+https://docs.devin.ai/essential-guidelines/instructing-devin-effectively
+https://cognition.ai/blog/devin-2
+
+Format: Goal · Context · Acceptance criteria · Scope and non-goals ·
+Environment hints · Closing step. Emphasizes acceptance criteria as verifiable
+conditions, not prose.
+
+Key insight: AI-era plans assume an implementer that will execute literally —
+ambiguity is the bug, not flexibility.
+
+### Aider architect mode (primary)
+https://aider.chat/2024/09/26/architect.html
+
+Separates planning from editing: a plan must be precise enough that a second
+model can mechanically apply it. Motivates keeping plan-file as design
+artifact (plan-it's job) separate from execution (F-09 /build-it's job).
+
+### Cursor agent best practices (primary)
+https://cursor.com/blog/agent-best-practices
+
+Consistent with Devin: pre-specify files to touch, bound scope with non-goals,
+acceptance criteria as the termination condition.
+
+## Convergent core (what appears in all formats)
+
+1. **Problem framing** — "Context", "Background", "Problem". Universal.
+2. **Goals + explicit non-goals** — bounds the diff. Near-universal.
+3. **Proposed design/approach** — Universal.
+4. **Alternatives/rationale** — appears in Google, Squarespace, HashiCorp,
+   Sourcegraph. Collapsed into Approach rationale for single-PR scope rather
+   than a separate section (per plan-it's Approach section description).
+
+## Anti-patterns confirmed across sources
+
+- Hour/day estimates — no single-PR template uses them; Squarespace's Timeline
+  exists for multi-week features only.
+- Exhaustive alternatives-considered listings — keep to 1-2 actually weighed;
+  fold into Approach rationale.
+- Placeholders (TBD, TODO, "implement later") — banned by superpowers; avoided
+  by all serious formats.
+- Separate test-strategy sections for single-PR scope — Verification/acceptance
+  criteria suffices.
+- Cross-cutting concern sections (security, i18n, observability) for one-PR
+  scope — surface in Verification if applicable; don't reserve empty headings.

--- a/claude/.claude/skills/plan-it/SKILL.md
+++ b/claude/.claude/skills/plan-it/SKILL.md
@@ -37,10 +37,10 @@ List every underspecified decision (edge cases, error handling, scope boundaries
 
 ## Step 5 — Architecture design
 
-Choose the approach. Surface alternatives only when the choice is non-obvious; otherwise commit and explain why. Consult `code-review`, `test-conventions`, and `verify-primary-sources` if their domains are implicated. Write the plan with these sections:
+Choose the approach. Always include brief rationale — what alternatives were weighed and why they were set aside. For trivial choices one sentence suffices; no separate alternatives section is needed. Consult `code-review`, `test-conventions`, and `verify-primary-sources` if their domains are implicated. Write the plan with these sections:
 
 1. **Context** — problem, why now, intended outcome (lead with a one-sentence goal)
-2. **Approach** — recommended only, not all alternatives
+2. **Approach** — chosen design with rationale; note alternatives considered and why they were set aside (1-2 sentences, not a separate section)
 3. **Critical files** — paths to create/modify, with **reuse opportunities** (existing functions/utilities to call rather than reimplement)
 4. **Verification** — how to test end-to-end
 5. **Out of scope** — only if scope creep was observed

--- a/claude/.claude/skills/plan-it/SKILL.md
+++ b/claude/.claude/skills/plan-it/SKILL.md
@@ -40,7 +40,7 @@ List every underspecified decision (edge cases, error handling, scope boundaries
 Choose the approach. Always include brief rationale — what alternatives were weighed and why they were set aside. For trivial choices one sentence suffices; no separate alternatives section is needed. Consult `code-review`, `test-conventions`, and `verify-primary-sources` if their domains are implicated. Write the plan with these sections:
 
 1. **Context** — problem, why now, intended outcome (lead with a one-sentence goal)
-2. **Approach** — chosen design with rationale; note alternatives considered and why they were set aside (1-2 sentences, not a separate section)
+2. **Approach** — chosen design with rationale; note alternatives considered and why they were set aside (inline in this section, not a separate block)
 3. **Critical files** — paths to create/modify, with **reuse opportunities** (existing functions/utilities to call rather than reimplement)
 4. **Verification** — how to test end-to-end
 5. **Out of scope** — only if scope creep was observed

--- a/claude/.claude/skills/plan-it/SKILL.md
+++ b/claude/.claude/skills/plan-it/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: plan-it
+description: >
+  Produce an implementation plan in .claude/plans/<topic-slug>.md
+  through Discovery, Codebase Exploration, Clarifying Questions, and
+  Architecture Design, then hand off to /plan-review for QA.
+  TRIGGER when: the user asks for a plan, design doc, or implementation
+  strategy for non-trivial work; before starting a feature branch where
+  the change spans multiple files or domains.
+  DO NOT TRIGGER when: the change is a one-line config tweak, a
+  single-file refactor with obvious shape, or the user explicitly said
+  "just implement it"; on the default branch with no intent to branch;
+  when a plan already exists and needs QA (use /plan-review instead).
+user-invocable: true
+argument-hint: "[optional topic or ticket id]"
+---
+
+# Plan-it
+
+## Step 1 — Branch + plan file
+
+If on the default branch, invoke the `branch-creation` skill to pick a slug and start from a fresh default tip. If already on a feature branch, keep it and derive the slug from the branch name — if the branch name contains `/` (e.g. `GH-42/add-auth`), use only the portion after the last `/`. Plan path is `.claude/plans/<topic-slug>.md` on the implementation branch (per `branch-creation`'s "plan files go on the implementation branch" rule).
+
+If `.claude/plans/<topic-slug>.md` already exists, open it for revision in place rather than scaffolding a new file.
+
+## Step 2 — Discovery
+
+Restate the problem, why now, and the intended outcome in one short paragraph. If any of the three is unclear, ask the user before moving on. This becomes the lead of the plan's **Context** section, with the first sentence stating the goal.
+
+## Step 3 — Codebase exploration
+
+Find similar features, the target subsystem, and integration points. Spawn `general-purpose` subagents in parallel when scope warrants — judge fan-out from surface area, do not default to a fixed count. Read the files each subagent flags before designing. Do not use `Explore` here; its read-excerpt window is wrong for design-context analysis.
+
+## Step 4 — Clarifying questions
+
+List every underspecified decision (edge cases, error handling, scope boundaries, backward compatibility) and ask the user. Do not proceed until answered or the user delegates the call to you.
+
+## Step 5 — Architecture design
+
+Choose the approach. Surface alternatives only when the choice is non-obvious; otherwise commit and explain why. Consult `code-review`, `test-conventions`, and `verify-primary-sources` if their domains are implicated. Write the plan with these sections:
+
+1. **Context** — problem, why now, intended outcome (lead with a one-sentence goal)
+2. **Approach** — recommended only, not all alternatives
+3. **Critical files** — paths to create/modify, with **reuse opportunities** (existing functions/utilities to call rather than reimplement)
+4. **Verification** — how to test end-to-end
+5. **Out of scope** — only if scope creep was observed
+
+Effort sections optional; if present, describe review surface (file count, domain spread, risk concentration), never hours or days.
+
+## Step 6 — Hand off to /plan-review
+
+Invoke `/plan-review` against the written plan file. Address any findings before presenting the plan to the user.


### PR DESCRIPTION
## Summary

- Adds `claude/.claude/skills/plan-it/SKILL.md` (52 lines, user-invocable)
- Adds `claude/.claude/skills/plan-it/REFERENCES.md` — co-located web research sources (Google design doc, Squarespace RFC, Nygard ADR, Devin, Aider, Cursor, superpowers) that informed the skill's design decisions; load-on-demand, not auto-loaded at runtime
- 6-step workflow: branch setup → discovery → codebase exploration → clarifying questions → architecture design → `/plan-review` hand-off
- Produces `.claude/plans/<slug>.md` in the lean 5-section shape (`Context · Approach · Critical files · Verification · Out of scope`) that passes `/plan-review`'s B1–B16 checklist on first try
- Delegates entirely to `branch-creation` and `plan-review`; no logic duplicated from either

## Design decisions

**Phase outline** borrowed from `feature-dev` (Discovery → Exploration → Questions → Architecture); stops at Architecture — execution belongs to F-09 `/build-it`.

**Codebase exploration uses `general-purpose`**, not `Explore` — matches `plan-review` Step 2's rationale (Explore's excerpt window is wrong for design-context analysis).

**Approach section always requires rationale** — Step 5 requires brief rationale (what alternatives were weighed and why they were set aside) even for simple choices. One sentence suffices for trivial decisions; alternatives must be inline in the Approach section, not a separate block. This matches the industry-standard pattern confirmed during F-08 research (Google design docs, Squarespace RFC, Sourcegraph RFC all require rationale; they differ only in how much).

**Slug derivation from branch name** strips everything up to and including the last `/` so ticket-prefix branches (`GH-42/add-auth`) produce a flat file at `.claude/plans/add-auth.md`, not a nested path that `require-plan-review.sh`'s `find -maxdepth 1` would miss.

**`/plan-review` is explicitly invoked at Step 6**, not left to the hook backstop — gives the skill a clean termination contract.

## Test plan

- [ ] `wc -l claude/.claude/skills/plan-it/SKILL.md` → ≤60
- [ ] Invoke `/plan-it` from the default branch on a representative task → branch-creation fires, plan written to `.claude/plans/<slug>.md`
- [ ] Invoke `/plan-it` from a ticket-prefix branch (`GH-N/topic`) → slug is `topic`, plan at `.claude/plans/topic.md`
- [ ] Invoke `/plan-it` when `.claude/plans/<slug>.md` already exists → opens existing file rather than creating sibling
- [ ] Invoke `/plan-review` on the produced plan → passes B1–B16 on first try; Approach section includes rationale

## Related

- F-09 (`/build-it`) — execution counterpart; plan file is the design artifact, not a checkbox list
- Appendix A (orphan plan files in `.claude/plans/`): `/tmp/orphan-plan-files-triage-handoff.md`
- Appendix B (hook gate policy for plan-mode authorship): `/tmp/plan-review-hook-policy-handoff.md`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)