### PR TITLE
fix: drop wallclock-time handoff heuristic

### DIFF
--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -15,7 +15,7 @@
 - Always prefer minimal, targeted changes. Do not refactor entire files or expand scope beyond what was asked. If you see an opportunity for a broader improvement, mention it separately — do not bundle it in.
 - Before assuming anything about the environment, stack, or project conventions, check first. Read the actual config files rather than guessing defaults.
 - Use descriptive variable and function names. No generic names.
-- When a session crosses ~300K output tokens or ~3 hours of wallclock time, proactively suggest a handoff. Write `/tmp/<task>-handoff.md` summarizing current state and what's next, then start a fresh session that reads it.
+- When a session crosses ~300K output tokens, proactively suggest a handoff. Run `analyze-context.py` if unsure. Write `/tmp/<task>-handoff.md` summarizing current state and what's next, then start a fresh session that reads it.
 
 ## Code Review
 

--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -15,7 +15,7 @@
 - Always prefer minimal, targeted changes. Do not refactor entire files or expand scope beyond what was asked. If you see an opportunity for a broader improvement, mention it separately — do not bundle it in.
 - Before assuming anything about the environment, stack, or project conventions, check first. Read the actual config files rather than guessing defaults.
 - Use descriptive variable and function names. No generic names.
-- When a session crosses ~300K output tokens, proactively suggest a handoff. Run `analyze-context.py` if unsure. Write `/tmp/<task>-handoff.md` summarizing current state and what's next, then start a fresh session that reads it.
+- When a session crosses ~300K output tokens, proactively suggest a handoff. Run `analyze-context.py` if unsure. Write a handoff file at `/tmp/<descriptive-task-slug>-handoff.md` (use a real slug, not the literal `<task>`), tell the user the exact path, and ask them to open a new session with: `Read <path> and continue.`
 
 ## Code Review
 


### PR DESCRIPTION
## Summary

- Removes `~3 hours of wallclock time` as a handoff trigger — wallclock is a poor proxy since idle sessions don't burn tokens while the cache stays warm
- Retains the `~300K output tokens` threshold, which is the real cost signal
- Adds `analyze-context.py` as a verification step so the threshold is checkable rather than guess-based
- Replaces the vague `/tmp/<task>-handoff.md` placeholder with an explicit instruction to use a real descriptive slug, so the user knows where to find the file
- Replaces "start a fresh session that reads it" (Claude can't do this) with "tell the user the exact path and ask them to open a new session with the prompt to paste" — honest about the human/agent responsibility split

Surfaced during a session-burn analysis where two sessions flagged by this heuristic (67h and 42h elapsed) were misleadingly described as over-threshold by wallclock when the actual driver was turn count, not idle time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)