### PR TITLE
feat: token-analyzer fidelity — per-record accumulation, windowed timestamps, tighter Opus→Sonnet heuristic

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,11 +161,11 @@ chmod +x ~/.claude/scripts/*.py
   reads excluded) from session metadata, and prints the session ID so you can
   drill in with the per-session view.
 
-- **`token-analyzer.py`** — cross-session per-model token breakdown (Opus / Sonnet / Haiku) with cache-hit rates, plus a list of Opus sessions that likely could have run on Sonnet (no plan-mode reasoning, no code edits). Reads `~/.claude/projects/*/*.jsonl`; no network calls, no writes.
+- **`token-analyzer.py`** — cross-session per-model token breakdown (Opus / Sonnet / Haiku) with cache-hit rates, plus a list of Opus sessions that likely could have run on Sonnet (no plan-mode, no edits, no sub-agent dispatch, no extended thinking, no judgment-skill invocations). Reads `~/.claude/projects/*/*.jsonl`; no network calls, no writes.
 
   ```bash
   ~/.claude/scripts/token-analyzer.py             # all-time
-  ~/.claude/scripts/token-analyzer.py --since 7d  # rolling window (e.g. 2d, 7d)
+  ~/.claude/scripts/token-analyzer.py --since 7d  # include token activity from the last N days (e.g. 2d, 7d)
   ```
 
 ## Worktree enforcement

--- a/claude/.claude/scripts/tests/test_token_analyzer.py
+++ b/claude/.claude/scripts/tests/test_token_analyzer.py
@@ -18,10 +18,29 @@ def _write_jsonl(path: Path, records: list[dict]) -> None:
     path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
 
 
-def _make_assistant(model: str, inp: int, out: int, cc: int, cr: int, tool_names: list[str] | None = None) -> dict:
+def _make_assistant(
+    model: str,
+    inp: int,
+    out: int,
+    cc: int,
+    cr: int,
+    tool_names: list[str] | None = None,
+    thinking: bool = False,
+    skill_name: str | None = None,
+    task: bool = False,
+    sidechain: bool = False,
+    timestamp: str | None = None,
+) -> dict:
     content = [{"type": "tool_use", "name": n} for n in (tool_names or [])]
-    return {
+    if thinking:
+        content.append({"type": "thinking", "thinking": "..."})
+    if skill_name is not None:
+        content.append({"type": "tool_use", "name": "Skill", "input": {"skill": skill_name}})
+    if task:
+        content.append({"type": "tool_use", "name": "Task"})
+    rec: dict = {
         "type": "assistant",
+        "isSidechain": sidechain,
         "message": {
             "model": model,
             "usage": {
@@ -33,10 +52,19 @@ def _make_assistant(model: str, inp: int, out: int, cc: int, cr: int, tool_names
             "content": content,
         },
     }
+    if timestamp is not None:
+        rec["timestamp"] = timestamp
+    return rec
 
 
 def _make_user(text: str) -> dict:
     return {"type": "user", "message": {"content": text}}
+
+
+def _iso(offset_seconds: float = 0) -> str:
+    """Return an ISO 8601 UTC timestamp offset from now by offset_seconds (negative = past)."""
+    from datetime import UTC, datetime
+    return datetime.fromtimestamp(time.time() + offset_seconds, tz=UTC).strftime("%Y-%m-%dT%H:%M:%S.000Z")
 
 
 @pytest.fixture()
@@ -75,6 +103,26 @@ def test_per_model_totals(fake_projects):
     assert len(sessions) == 2
 
 
+def test_per_model_totals_mixed_session(fake_projects):
+    """Mixed-model session credits each record's tokens to its own family."""
+    session_a, _ = fake_projects
+    _write_jsonl(
+        session_a / "mixed.jsonl",
+        [
+            _make_assistant("claude-opus-4-7", inp=100, out=200, cc=0, cr=0),
+            _make_assistant("claude-sonnet-4-6", inp=10, out=30, cc=0, cr=0),
+        ],
+    )
+
+    ft, sessions = _mod._walk()
+
+    assert ft["opus"]["out"] == 200
+    assert ft["sonnet"]["out"] == 30
+    assert ft["opus"]["n"] == 1
+    assert ft["sonnet"]["n"] == 1
+    assert len(sessions) == 1
+
+
 def test_cache_hit_ratio():
     # cache_read / (cache_read + input) per spec
     assert _mod._pct(300, 300 + 100) == "75%"
@@ -98,7 +146,8 @@ def test_candidate_flagging(fake_projects):
     )
 
     _, sessions = _mod._walk()
-    cands = [s for s in sessions if s["fam"] == "opus" and not s["plan"] and not s["edits"] and s["out"] >= 500]
+    _excl = ("plan", "edits", "task", "thinking", "judgment_skill", "sidechain")
+    cands = [s for s in sessions if s["fam"] == "opus" and not any(s[k] for k in _excl) and s["out"] >= 500]
     non_cands = [s for s in sessions if s["plan"]]
 
     assert len(cands) == 1, f"expected 1 candidate, got {cands}"
@@ -108,15 +157,105 @@ def test_candidate_flagging(fake_projects):
 
 def test_edit_tool_excludes_candidate(fake_projects):
     session_a, _ = fake_projects
-    # Opus session with an Edit call → not a candidate
     _write_jsonl(
         session_a / "with_edit.jsonl",
         [_make_assistant("claude-opus-4-7", inp=50, out=600, cc=0, cr=0, tool_names=["Edit"])],
     )
 
     _, sessions = _mod._walk()
-    cands = [s for s in sessions if s["fam"] == "opus" and not s["plan"] and not s["edits"] and s["out"] >= 500]
+    _excl = ("plan", "edits", "task", "thinking", "judgment_skill", "sidechain")
+    cands = [s for s in sessions if s["fam"] == "opus" and not any(s[k] for k in _excl) and s["out"] >= 500]
     assert len(cands) == 0
+
+
+def test_candidate_excludes_task(fake_projects):
+    session_a, _ = fake_projects
+    _write_jsonl(
+        session_a / "with_task.jsonl",
+        [_make_assistant("claude-opus-4-7", inp=50, out=600, cc=0, cr=0, task=True)],
+    )
+
+    _, sessions = _mod._walk()
+    assert sessions[0]["task"] is True
+    _excl = ("plan", "edits", "task", "thinking", "judgment_skill", "sidechain")
+    cands = [s for s in sessions if s["fam"] == "opus" and not any(s[k] for k in _excl) and s["out"] >= 500]
+    assert len(cands) == 0
+
+
+def test_candidate_excludes_thinking(fake_projects):
+    session_a, _ = fake_projects
+    _write_jsonl(
+        session_a / "with_thinking.jsonl",
+        [_make_assistant("claude-opus-4-7", inp=50, out=600, cc=0, cr=0, thinking=True)],
+    )
+
+    _, sessions = _mod._walk()
+    assert sessions[0]["thinking"] is True
+    _excl = ("plan", "edits", "task", "thinking", "judgment_skill", "sidechain")
+    cands = [s for s in sessions if s["fam"] == "opus" and not any(s[k] for k in _excl) and s["out"] >= 500]
+    assert len(cands) == 0
+
+
+def test_candidate_excludes_judgment_skill(fake_projects):
+    """Judgment skill invocation excludes; non-judgment Skill invocation does not."""
+    session_a, session_b = fake_projects
+    _write_jsonl(
+        session_a / "with_code_review.jsonl",
+        [_make_assistant("claude-opus-4-7", inp=50, out=600, cc=0, cr=0, skill_name="code-review")],
+    )
+    _write_jsonl(
+        session_b / "with_cleanup.jsonl",
+        [_make_assistant("claude-opus-4-7", inp=50, out=600, cc=0, cr=0, skill_name="cleanup-merged-branch")],
+    )
+
+    _, sessions = _mod._walk()
+    _excl = ("plan", "edits", "task", "thinking", "judgment_skill", "sidechain")
+    cands = [s for s in sessions if s["fam"] == "opus" and not any(s[k] for k in _excl) and s["out"] >= 500]
+    excluded = [s for s in sessions if s["judgment_skill"]]
+
+    assert len(excluded) == 1
+    assert len(cands) == 1
+    assert cands[0]["judgment_skill"] is False
+
+
+def test_sidechain_excluded_from_session_fam(fake_projects):
+    """Sidechain records don't shift the reported dominant family."""
+    session_a, _ = fake_projects
+    _write_jsonl(
+        session_a / "mixed_side.jsonl",
+        [
+            _make_assistant("claude-opus-4-7", inp=50, out=300, cc=0, cr=0),
+            _make_assistant("claude-sonnet-4-6", inp=200, out=800, cc=0, cr=0, sidechain=True),
+        ],
+    )
+
+    ft, sessions = _mod._walk()
+
+    assert len(sessions) == 1
+    assert sessions[0]["fam"] == "opus"   # dominant non-sidechain family
+    assert ft["opus"]["out"] == 300
+    assert ft["sonnet"]["out"] == 800     # sidechain tokens still credited correctly
+    assert sessions[0]["sidechain"] is True
+
+
+def test_sidechain_edits_do_not_disqualify_parent(fake_projects):
+    """Edit in a sidechain record does not set had_edits for the parent session."""
+    session_a, _ = fake_projects
+    _write_jsonl(
+        session_a / "parent_side_edit.jsonl",
+        [
+            _make_assistant("claude-opus-4-7", inp=50, out=600, cc=0, cr=0),
+            _make_assistant("claude-sonnet-4-6", inp=20, out=100, cc=0, cr=0,
+                            tool_names=["Edit"], sidechain=True),
+        ],
+    )
+
+    _, sessions = _mod._walk()
+    assert sessions[0]["edits"] is False
+    _excl = ("plan", "edits", "task", "thinking", "judgment_skill", "sidechain")
+    # sidechain=True means excluded anyway, but edits flag must be False
+    assert sessions[0]["sidechain"] is True
+    assert sessions[0]["edits"] is False
 
 
 def test_since_filter(fake_projects):
@@ -124,17 +263,77 @@ def test_since_filter(fake_projects):
     old_file = session_a / "old_sess.jsonl"
     new_file = session_b / "new_sess.jsonl"
 
-    _write_jsonl(old_file, [_make_assistant("claude-opus-4-7", inp=10, out=100, cc=0, cr=0)])
-    _write_jsonl(new_file, [_make_assistant("claude-sonnet-4-6", inp=10, out=200, cc=0, cr=0)])
+    _write_jsonl(old_file, [_make_assistant("claude-opus-4-7", inp=10, out=100, cc=0, cr=0,
+                                            timestamp=_iso(-10 * 86400))])
+    _write_jsonl(new_file, [_make_assistant("claude-sonnet-4-6", inp=10, out=200, cc=0, cr=0,
+                                            timestamp=_iso(-1 * 3600))])
 
-    # Back-date the old file to 10 days ago
+    # Back-date old file mtime so the mtime pre-filter also excludes it
     old_mtime = time.time() - 10 * 86400
     os.utime(old_file, (old_mtime, old_mtime))
 
-    # --since 2d should include new_file only
     cutoff = time.time() - 2 * 86400
     ft, sessions = _mod._walk(since=cutoff)
 
     assert len(sessions) == 1
     assert sessions[0]["fam"] == "sonnet"
     assert ft.get("opus") is None or ft["opus"]["n"] == 0
+
+
+def test_per_record_window_filter(fake_projects):
+    """Session with records spanning the cutoff: only in-window tokens are counted."""
+    session_a, _ = fake_projects
+    _write_jsonl(
+        session_a / "straddling.jsonl",
+        [
+            _make_assistant("claude-opus-4-7", inp=100, out=400, cc=0, cr=0,
+                            timestamp=_iso(-5 * 86400)),   # 5 days ago — out of window
+            _make_assistant("claude-opus-4-7", inp=50, out=200, cc=0, cr=0,
+                            timestamp=_iso(-1 * 3600)),     # 1 hour ago — in window
+        ],
+    )
+
+    cutoff = time.time() - 2 * 86400
+    ft, sessions = _mod._walk(since=cutoff)
+
+    assert len(sessions) == 1
+    assert sessions[0]["out"] == 200    # only in-window output counted
+    assert ft["opus"]["out"] == 200
+
+
+def test_window_session_inclusion(fake_projects):
+    """Session with all records outside the window is excluded from sessions list."""
+    session_a, session_b = fake_projects
+    _write_jsonl(
+        session_a / "all_old.jsonl",
+        [_make_assistant("claude-opus-4-7", inp=10, out=500, cc=0, cr=0,
+                         timestamp=_iso(-10 * 86400))],
+    )
+    _write_jsonl(
+        session_b / "has_new.jsonl",
+        [_make_assistant("claude-sonnet-4-6", inp=10, out=300, cc=0, cr=0,
+                         timestamp=_iso(-1 * 3600))],
+    )
+
+    cutoff = time.time() - 2 * 86400
+    _, sessions = _mod._walk(since=cutoff)
+
+    assert len(sessions) == 1
+    assert sessions[0]["fam"] == "sonnet"
+
+
+def test_malformed_timestamp_record_skipped(fake_projects):
+    """Record with unparseable timestamp is skipped; well-formed neighbors still count."""
+    session_a, _ = fake_projects
+    bad_rec = _make_assistant("claude-opus-4-7", inp=50, out=999, cc=0, cr=0)
+    bad_rec["timestamp"] = "not-an-iso-string"
+    good_rec = _make_assistant("claude-opus-4-7", inp=20, out=150, cc=0, cr=0,
+                               timestamp=_iso(-1 * 3600))
+    _write_jsonl(session_a / "mixed_ts.jsonl", [bad_rec, good_rec])
+
+    cutoff = time.time() - 2 * 86400
+    ft, sessions = _mod._walk(since=cutoff)
+
+    assert len(sessions) == 1
+    assert sessions[0]["out"] == 150    # bad record's 999 tokens excluded
+    assert ft["opus"]["out"] == 150

--- a/claude/.claude/scripts/token-analyzer.py
+++ b/claude/.claude/scripts/token-analyzer.py
@@ -4,12 +4,27 @@ import argparse
 import json
 import time
 from collections import defaultdict
+from datetime import datetime
 from pathlib import Path
 
 PROJECTS_DIR = Path.home() / ".claude" / "projects"
 EDIT_TOOLS = {"Edit", "Write", "MultiEdit", "NotebookEdit"}
-_fam = lambda m: "opus" if "opus" in m else "sonnet" if "sonnet" in m else "haiku" if "haiku" in m else "other"
-_pct = lambda n, d: f"{100 * n / d:.0f}%" if d else "—"
+JUDGMENT_SKILLS = frozenset({
+    "code-review", "plan-review", "security-review",
+    "skill-review", "respond-pr", "ultrareview",
+})
+def _fam(m: str) -> str:
+    if "opus" in m:
+        return "opus"
+    if "sonnet" in m:
+        return "sonnet"
+    if "haiku" in m:
+        return "haiku"
+    return "other"
+
+
+def _pct(n: int, d: int) -> str:
+    return f"{100 * n / d:.0f}%" if d else "—"
 
 
 def _content_text(content):
@@ -20,6 +35,16 @@ def _content_text(content):
     return ""
 
 
+def _ts_in_window(ts_str: str | None, since: float) -> bool:
+    """Return True if ts_str parses to a timestamp >= since. Missing or malformed strings return False."""
+    if not ts_str:
+        return False
+    try:
+        return datetime.fromisoformat(ts_str.replace("Z", "+00:00")).timestamp() >= since
+    except (ValueError, TypeError):
+        return False
+
+
 def _walk(since: float | None = None):
     family_totals = defaultdict(lambda: {"n": 0, "inp": 0, "out": 0, "cc": 0, "cr": 0})
     sessions = []
@@ -27,8 +52,11 @@ def _walk(since: float | None = None):
         if since is not None and jsonl.stat().st_mtime < since:
             continue
         proj = jsonl.parent.name.lstrip("-").replace("-", "/", 2).split("/", 2)[-1]
-        fam_out, tot = defaultdict(int), {"inp": 0, "out": 0, "cc": 0, "cr": 0}
-        plan, edits = False, False
+        fam_out_main = defaultdict(int)  # non-sidechain output per family, for dominant-fam
+        fam_window: dict[str, dict] = defaultdict(lambda: {"inp": 0, "out": 0, "cc": 0, "cr": 0})
+        fams_in_session: set[str] = set()
+        plan, edits, task, thinking, judgment_skill, sidechain = False, False, False, False, False, False
+        has_window_record = False
         try:
             with open(jsonl) as fh:
                 for raw in fh:
@@ -36,39 +64,68 @@ def _walk(since: float | None = None):
                         rec = json.loads(raw)
                     except json.JSONDecodeError:
                         continue
-                    rtype, msg = rec.get("type", ""), rec.get("message", {})
+                    rtype = rec.get("type", "")
+                    is_side = bool(rec.get("isSidechain"))
+                    if is_side:
+                        sidechain = True
+                    msg = rec.get("message", {})
                     if rtype in ("user", "human") and "Plan mode is active" in _content_text(msg.get("content", "")):
                         plan = True
                     if rtype == "assistant" and isinstance(msg, dict) and "usage" in msg:
                         u = msg["usage"]
                         fam = _fam(msg.get("model", "").lower())
-                        inp, out, cc, cr = (u.get(k, 0) for k in (
-                            "input_tokens", "output_tokens",
-                            "cache_creation_input_tokens", "cache_read_input_tokens"))
-                        fam_out[fam] += out
-                        tot["inp"] += inp; tot["out"] += out; tot["cc"] += cc; tot["cr"] += cr
-                        if not edits and any(
-                            isinstance(b, dict) and b.get("name") in EDIT_TOOLS
-                            for b in msg.get("content", [])
-                        ):
-                            edits = True
+                        in_window = _ts_in_window(rec.get("timestamp"), since) if since is not None else True
+                        if in_window:
+                            inp, out, cc, cr = (u.get(k, 0) for k in (
+                                "input_tokens", "output_tokens",
+                                "cache_creation_input_tokens", "cache_read_input_tokens"))
+                            fam_window[fam]["inp"] += inp
+                            fam_window[fam]["out"] += out
+                            fam_window[fam]["cc"] += cc
+                            fam_window[fam]["cr"] += cr
+                            fams_in_session.add(fam)
+                            has_window_record = True
+                            if not is_side:
+                                fam_out_main[fam] += out
+                        if not is_side:
+                            content = msg.get("content", []) or []
+                            if not edits and any(isinstance(b, dict) and b.get("name") in EDIT_TOOLS for b in content):
+                                edits = True
+                            if not task and any(isinstance(b, dict) and b.get("name") == "Task" for b in content):
+                                task = True
+                            if not thinking and any(isinstance(b, dict) and b.get("type") == "thinking" for b in content):
+                                thinking = True
+                            if not judgment_skill and any(
+                                isinstance(b, dict) and b.get("name") == "Skill"
+                                and b.get("input", {}).get("skill") in JUDGMENT_SKILLS
+                                for b in content
+                            ):
+                                judgment_skill = True
         except OSError:
             continue
-        if not tot["out"]:
+        if since is not None and not has_window_record:
             continue
-        dom = max(fam_out, key=fam_out.get) if fam_out else "other"
-        t = family_totals[dom]
-        t["n"] += 1
-        for k in ("inp", "out", "cc", "cr"):
-            t[k] += tot[k]
-        sessions.append({"id": jsonl.stem[:12], "proj": proj, "fam": dom,
-                         "out": tot["out"], "inp": tot["inp"], "plan": plan, "edits": edits})
+        total_out = sum(v["out"] for v in fam_window.values())
+        if not total_out:
+            continue
+        for fam in fams_in_session:
+            t = family_totals[fam]
+            t["n"] += 1
+            for k in ("inp", "out", "cc", "cr"):
+                t[k] += fam_window[fam][k]
+        dom = max(fam_out_main, key=fam_out_main.get) if fam_out_main else "other"
+        sessions.append({
+            "id": jsonl.stem[:12], "proj": proj, "fam": dom,
+            "out": total_out, "inp": sum(v["inp"] for v in fam_window.values()),
+            "plan": plan, "edits": edits, "task": task,
+            "thinking": thinking, "judgment_skill": judgment_skill, "sidechain": sidechain,
+        })
     return family_totals, sessions
 
 
 def main():
     parser = argparse.ArgumentParser(description="Per-model token breakdown across Claude Code sessions.")
-    parser.add_argument("--since", metavar="Nd", help="Limit to sessions whose file was modified within N days (e.g. 2d, 7d)")
+    parser.add_argument("--since", metavar="Nd", help="Limit to token activity within the last N days (e.g. 2d, 7d)")
     args = parser.parse_args()
 
     since = None
@@ -79,7 +136,7 @@ def main():
         except ValueError:
             parser.error(f"--since: expected a number of days like '2d' or '7', got {args.since!r}")
 
-    label = f" (last {args.since})" if args.since else ""
+    label = f" (activity in the last {args.since})" if args.since else ""
     ft, sessions = _walk(since)
 
     print(f"## Per-model token summary{label}\n")
@@ -100,11 +157,23 @@ def main():
         print(f"{s['id']:>12}  {s['fam']:<8}  {s['out']:>10,}  {s['inp']:>10,}  "
               f"{'Y' if s['plan'] else 'N':>4}  {'Y' if s['edits'] else 'N':>5}  {s['proj']}")
 
+    _excl_keys = ("plan", "edits", "task", "thinking", "judgment_skill", "sidechain")
+    _excl_labels = ("plan", "edits", "task", "thinking", "judgment-skill", "sidechain")
+    opus_high = [s for s in sessions if s["fam"] == "opus" and s["out"] >= 500]
+    non_cands = [s for s in opus_high if any(s[k] for k in _excl_keys)]
     cands = sorted(
-        (s for s in sessions if s["fam"] == "opus" and not s["plan"] and not s["edits"] and s["out"] >= 500),
+        [s for s in opus_high if not any(s[k] for k in _excl_keys)],
         key=lambda s: s["out"], reverse=True,
     )
-    print(f"\n## Opus → Sonnet candidates ({len(cands)} sessions: no plan-mode, no edits)\n")
+    excl_desc = "no plan-mode, no edits, no task/thinking/judgment-skill/sidechain"
+    print(f"\n## Opus → Sonnet candidates ({len(cands)} sessions: {excl_desc})\n")
+    if non_cands:
+        excl_parts = " ".join(
+            f"{lbl}={sum(1 for s in non_cands if s[key])}"
+            for key, lbl in zip(_excl_keys, _excl_labels, strict=False)
+            if any(s[key] for s in non_cands)
+        )
+        print(f"excluded {len(non_cands)} high-output Opus sessions: {excl_parts}")
     if cands:
         print(f"{'Session':>12}  {'Output':>10}  {'Input':>10}  Project")
         print("-" * 50)


### PR DESCRIPTION
## Summary

Follow-up to #135 (F-19), addressing three design issues flagged in the post-merge review.

- **Per-record token accumulation**: each assistant record's tokens are credited to its own model family rather than the session's dominant family. Mixed-model sessions (e.g. Opus parent + Sonnet sub-agents) now contribute to both families' totals. Session `fam` in top-10 and candidate list still reflects the dominant non-sidechain family.
- **Per-record `--since` windowing**: `--since Nd` now sums only tokens from records whose ISO timestamp falls within the window — long-running sessions contribute only their in-window slice. mtime stays as a cheap file-level pre-filter. Section headers relabeled to `(activity in the last Nd)` to make the semantics explicit.
- **Tighter Opus→Sonnet candidate heuristic**: adds four new exclusion signals evaluated from non-sidechain (parent) records: `Task` tool calls (dispatcher orchestration), `thinking` blocks (extended reasoning), judgment-skill invocations (`code-review`, `plan-review`, `security-review`, `skill-review`, `respond-pr`, `ultrareview`), and presence of any sidechain record. A diagnostic line above the candidate list shows excluded session counts per signal for ongoing tuning.

## Semantic note

Exclusion signals (edits, task, thinking, judgment-skill, plan) are evaluated against all records for the session lifetime, not just the in-window portion. A session that used plan-mode before the `--since` window is still correctly excluded from candidates — the Opus routing decision applied to the whole session.

## Test plan

- [x] `pytest claude/.claude/scripts/tests/test_token_analyzer.py` — 14 passed (was 5)
- [x] `ruff check claude/.claude/` — clean
- [ ] Live smoke run: `~/.claude/scripts/token-analyzer.py` — per-model totals should reflect per-record attribution; candidate list diagnostic line should show exclusion signals
- [ ] Live smoke run: `~/.claude/scripts/token-analyzer.py --since 2d` — long-running sessions should contribute only in-window tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)