### PR TITLE
fix(cleanup-merged-branch): unique temp worktree suffix to prevent concurrent-session collision

### DIFF
--- a/claude/.claude/skills/cleanup-merged-branch/SKILL.md
+++ b/claude/.claude/skills/cleanup-merged-branch/SKILL.md
@@ -84,26 +84,29 @@ Skip if step 2 showed the remote was already pruned.
 
 `git push --delete` is blocked from the main tree — it must run from
 inside a linked worktree. Run `git worktree list` and pick any path
-that is not the main repo root. If none exists, create a temporary one:
+that is not the main repo root. If none exists, create a temporary one.
+Pick a unique `<SUFFIX>` now (e.g. current epoch seconds: `date +%s`)
+and reuse the same literal value in every command below — shell
+variables don't persist across separate Bash tool calls.
 
 ```bash
-git worktree add --detach .claude/worktrees/_cleanup-tmp
+git worktree add --detach .claude/worktrees/_cleanup-tmp-<SUFFIX>
 ```
 
 Then anchor and delete in two separate Bash calls:
 
 ```bash
 # Call 1 — anchor CWD:
-cd <worktree-path>
+cd .claude/worktrees/_cleanup-tmp-<SUFFIX>
 
 # Call 2 — delete remote:
 git push origin --delete <BRANCH>
 ```
 
-If you created `_cleanup-tmp`, remove it when done:
+If you created `_cleanup-tmp-<SUFFIX>`, remove it when done:
 
 ```bash
-git worktree remove .claude/worktrees/_cleanup-tmp
+git worktree remove .claude/worktrees/_cleanup-tmp-<SUFFIX>
 ```
 
 ## 5. Fast-forward default branch


### PR DESCRIPTION
## Summary

- `_cleanup-tmp` was a fixed worktree name shared across all sessions running `/cleanup-merged-branch`
- Two concurrent sessions hitting step 4 at the same time raced: the second `git worktree add` failed with "already exists", and the first session's `worktree remove` could yank the directory out from under the second session's CWD anchor
- The auto-detect path (step 0 with no branch arg) resolves both sessions to the same branch, so a branch-name suffix wouldn't have covered the same-branch race — a timestamp/unique suffix is needed

**Observed symptom:** `getcwd: cannot access parent directories` on `worktree remove`, followed by `not a working tree` on retry from the main repo root (concurrent session pruned the git metadata too).

**Fix:** Instruct the model to pick a unique `<SUFFIX>` once at step 4 entry (e.g. epoch seconds) and reuse the same literal across all three step-4 Bash calls. Shell variables don't persist across separate Bash tool calls, so the suffix must be inlined.

## Test plan

- [ ] Read `claude/.claude/skills/cleanup-merged-branch/SKILL.md` and confirm all three `_cleanup-tmp` references now use `_cleanup-tmp-<SUFFIX>` and the "pick once, reuse" instruction is present
- [ ] Manual smoke: invoke `/cleanup-merged-branch` on a branch whose remote was not auto-deleted (forces step 4), confirm temp worktree created with unique suffix and removed cleanly
- [ ] Concurrency: in two terminals, run the step-4 bare commands simultaneously with different suffixes — both `git worktree add` calls should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)