### PR TITLE
fix(ci): broaden path filter to skills/ and scripts/, harden detect step

### DIFF
--- a/.github/workflows/hooks.yml
+++ b/.github/workflows/hooks.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Detect hook-relevant changes
         id: detect
         run: |
-          set -e
+          set -euo pipefail
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             BASE="${{ github.event.pull_request.base.sha }}"
             HEAD="${{ github.event.pull_request.head.sha }}"
@@ -50,7 +50,28 @@ jobs:
             exit 0
           fi
 
-          if git diff --name-only "$BASE" "$HEAD" | grep -qE '^(claude/\.claude/(hooks|skills/tests)/|\.github/workflows/hooks\.yml|pyproject\.toml)'; then
+          CHANGED=$(git diff --name-only "$BASE" "$HEAD")
+
+          # Include any directory that contains test files or whose contents are
+          # read by tests. Update this list when a new test or test-input
+          # directory appears under claude/.claude/.
+          REGEX='^(claude/\.claude/(hooks|skills|scripts)/|\.github/workflows/hooks\.yml|pyproject\.toml)'
+
+          MATCHED=$(echo "$CHANGED" | grep -E "$REGEX" || true)
+          UNMATCHED=$(echo "$CHANGED" | grep -vE "$REGEX" || true)
+
+          if [ -n "$MATCHED" ]; then
+            echo "Matched (will run tests):"; echo "$MATCHED" | sed 's/^/  /'
+          else
+            echo "Matched (will run tests): (none)"
+          fi
+          if [ -n "$UNMATCHED" ]; then
+            echo "Unmatched (skipped):"; echo "$UNMATCHED" | sed 's/^/  /'
+          else
+            echo "Unmatched (skipped): (none)"
+          fi
+
+          if [ -n "$MATCHED" ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- **Regex broadened**: `claude/.claude/skills/` (whole tree) and `claude/.claude/scripts/` added alongside the existing `hooks/` entry. The prior regex only matched where test *files* live — it missed that `test_skills.py` reads frontmatter from every `skills/<name>/SKILL.md`, that hook-alignment tests like `test_require_plan_review.py` read `HOOK_TEST_FIXTURE` blocks directly from skill bodies, and that `test_token_analyzer.py` exercises `scripts/token-analyzer.py`. PRs #140, #141, and #142 all silently skipped CI as a result.
- **Inclusion-rule comment added**: States what belongs in the list so the next contributor knows when to extend it (not just copy a file path pattern).
- **Shell hardening**: `set -e` → `set -euo pipefail`; fail-closed on unset variables and broken pipes.
- **Drift visibility**: Both matched and unmatched file lists are now logged on every run. When tests are skipped on a future PR, the unmatched list in the Actions log answers "why" without anyone re-running the regex by hand.

## Architecture note (for future reference)

The in-job conditional shape is the correct GitHub Actions pattern here. Workflow-level `paths:` triggers leave required status checks in `Pending` indefinitely (GH community discussion #44490, in backlog since Jan 2023, no GitHub timeline). `dorny/paths-filter` solves the N-independent-jobs aggregator problem and carries solo-maintainer supply-chain risk (sibling `tj-actions/changed-files` was compromised March 2025). The fix here is hardening the existing shape, not switching architectures.

**If this filter goes stale again** (e.g., `agents/` or `CLAUDE.md` gains test coverage), the right move at that point is to delete the filter and run tests on every PR — the saved CI minutes do not justify another round of silent skips.

## Test plan

- [ ] Merge this PR — CI on this PR's own diff should trigger `Run tests` (`.github/workflows/hooks.yml` is in the filter).
- [ ] After merge, push an empty commit to re-trigger CI on PR #141 and confirm `pytest claude/.claude/ -v` actually runs against the `plan-review/SKILL.md` changes there.
- [ ] Confirm the Actions log now shows "Matched (will run tests):" and "Unmatched (skipped):" sections on every run.
- [ ] Confirm branch protection still passes — job id `hook-tests` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)