### PR TITLE
chore(ci): pin actions/checkout and actions/setup-python to commit SHAs

### DIFF
--- a/.github/workflows/hooks.yml
+++ b/.github/workflows/hooks.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
@@ -81,7 +81,7 @@ jobs:
         if: steps.detect.outputs.changed != 'true'
         run: echo "No hook-relevant files changed; skipping pytest."
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         if: steps.detect.outputs.changed == 'true'
         with:
           python-version: '3.12'


### PR DESCRIPTION
## Summary

- Replaces `actions/checkout@v4` and `actions/setup-python@v5` (mutable floating tags) with immutable commit SHA refs in `.github/workflows/hooks.yml`
- Adds `# v4.3.1` / `# v5.6.0` trailing comments (Dependabot-compatible format; lets humans read the pinned version at a glance)
- No behavior change — pinned SHAs resolve to the same code currently executing at those tags

## Motivation

Tag mutation is a live supply-chain attack vector: a compromised maintainer credential can silently retarget a floating tag to a malicious commit (canonical example: `tj-actions/changed-files`, March 2025 — compromised across ~23k repos). On a public repo, `actions/*` actions are GitHub-org-maintained (lower marginal risk than community projects), but the cost of pinning is two lines, so the tradeoff favors pinning.

## SHAs

| Action | Tag | SHA |
|--------|-----|-----|
| `actions/checkout` | v4.3.1 (2025-11-17) | `34e114876b0b11c390a56381ad16ebd13914f8d5` |
| `actions/setup-python` | v5.6.0 (2025-04-24) | `a26af69be951a213d495a4c3e4e4022e16d87065` |

Both are lightweight tags (object type `commit`) — no annotated-tag dereference needed. Resolved via `gh api repos/actions/.../git/ref/tags/<version>`.

## Out of scope

- Major-version upgrade to v6 (deferred; see follow-up)
- Dependabot config for ongoing refresh (deferred; see follow-up)
- Repo-settings Actions allowlist (complementary control; separate decision)

## Test plan

- [ ] `hook-tests` CI job runs on this PR (`.github/workflows/hooks.yml` matches the path regex on line 58 of the workflow itself) — green confirms both pinned SHAs resolve and behave identically to the floating tags they replace
- [ ] `git diff main...pin-github-actions -- .github/workflows/hooks.yml` shows exactly two line changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)