### PR TITLE
chore(ci): enable Dependabot for github-actions ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    groups:
+      github-actions:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` to enable Dependabot version updates for the `github-actions` ecosystem
- Follow-up to #145, which pinned `actions/checkout` and `actions/setup-python` to commit SHAs — without a refresh mechanism, those pins silently age out of date
- `weekly` schedule, `open-pull-requests-limit: 3`; minor+patch updates grouped into one PR; majors arrive as individual PRs for deliberate review

## Expected downstream PRs (after this lands)

Dependabot's first batch will include the v6 major bumps:
- `actions/checkout` v4.3.1 → v6.0.2 (Node 24 runtime; latest as of 2026-05-05)
- `actions/setup-python` v5.6.0 → v6.2.0 (Node 24 runtime; latest as of 2026-05-05)

For each: confirm `hook-tests` green, confirm SHA-comment pattern preserved in the diff, then merge. To skip the weekly wait, trigger immediately via repo → Insights → Dependency graph → Dependabot → "Check for updates."

## Design notes

- SHA-pin format (`@<sha> # <tag>`) is Dependabot-native — it updates both the SHA and the tag comment automatically
- The `groups` block bundles minor+patch into one weekly PR; majors are explicitly excluded from the group so they arrive separately
- `.github/dependabot.yml` does **not** match the path-filter regex in `hooks.yml:58`, so adding this file alone won't trigger `hook-tests` (no behavior change — correct)
- For public repos, Dependabot version updates activate as soon as this file lands on `main`; no additional repo-settings toggle required

## Test plan

- [ ] `hook-tests` job runs on this PR (the diff touches `.github/workflows/hooks.yml`... actually it doesn't — this PR only adds `dependabot.yml`, so `hook-tests` will be a no-op skip, which is expected)
- [ ] After merge: repo → Insights → Dependency graph → Dependabot shows the config with no parse errors (GitHub validates within minutes)
- [ ] Optionally trigger "Check for updates" to confirm v6 PRs open with correct SHA-comment format

🤖 Generated with [Claude Code](https://claude.com/claude-code)