### PR TITLE
fix(skill): look up worktree path via git worktree list in cleanup Step 1

### DIFF
--- a/claude/.claude/skills/cleanup-merged-branch/SKILL.md
+++ b/claude/.claude/skills/cleanup-merged-branch/SKILL.md
@@ -57,10 +57,19 @@ Confirm with the user if unsure which branch to clean up.
 ## 1. Remove worktree (if present)
 
 `git worktree` is on the main-tree allowlist, so this runs without CWD
-anchoring:
+anchoring.
+
+Do not construct the path from the branch name — slashes in branch names
+become directory separators, not dashes. Look up the actual path:
 
 ```bash
-git worktree remove .claude/worktrees/<BRANCH> --force 2>/dev/null || true
+git worktree list | grep -F "[<BRANCH>]" | awk '{print $1}'
+```
+
+If that returns a path, remove it:
+
+```bash
+git worktree remove <WORKTREE_PATH> --force 2>/dev/null || true
 ```
 
 `--force` handles the case where files are open or uncommitted changes


### PR DESCRIPTION
## Summary

- Step 1 of `cleanup-merged-branch` constructed the worktree path as `.claude/worktrees/<BRANCH>`, which silently fails when the branch name contains slashes (e.g. `fix/foo` → produces `.claude/worktrees/fix/foo` instead of `.claude/worktrees/fix-foo`)
- The `|| true` swallowed the error, leaving the worktree dangling with no signal
- Step 1 now looks up the actual path via `git worktree list | grep -F "[<BRANCH>]" | awk '{print $1}'`; `grep -F` treats the bracket-wrapped branch name as a fixed string so slashes require no escaping

## Test plan

- [ ] Run `/cleanup-merged-branch` after merging a PR whose branch name contains a slash; confirm Step 1 locates and removes the worktree correctly
- [ ] Verify `514 passed` in `pytest claude/.claude/ -q` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)