### PR TITLE
docs: document project-layer composition for plan-review and code-review

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,14 @@ Each skill lives in `claude/.claude/skills/<skill-name>/SKILL.md`. A skill direc
 - **`@path` import syntax is for `CLAUDE.md` only.** The `@path/to/file` import pattern that works in `CLAUDE.md` files is not supported in `SKILL.md`.
 - **Duplicate rule text across skills intentionally.** When two skills need the same rule, copy it into both — do not extract it into a `_shared/` partial or similar abstraction. Duplication is deliberate: it keeps each skill independently readable and avoids brittle cross-skill coupling. If you find yourself wanting a shared partial, that is a signal to reconsider whether the skills should be merged, not a signal to add an include mechanism.
 
+#### Project-specific layers
+
+`/plan-review` and `/code-review` auto-load a project-specific layer if one exists in the consuming repo — so a project can extend the base checklist without forking the public skill body.
+
+- **Location:** `.claude/skills/code-review-<project>/SKILL.md` or `.claude/skills/plan-review-<project>/SKILL.md`, placed in the consuming repo. The `<project>` token is freeform; only the prefix (`code-review-` or `plan-review-`) is load-bearing.
+- **Frontmatter:** match the shape of any skill in `claude/.claude/skills/` (`name`, `description`, `user-invocable`). The parent invokes the layer via the Skill tool — not via description-based auto-trigger, which doesn't fire from inside a running skill (design rationale in [`docs/design-decisions.md`](docs/design-decisions.md)).
+- **Behavior:** glob runs from the repo root (`git rev-parse --show-toplevel`). Single match → invoked and merged into the base checklist. Multiple matches → review stops — that's a config error in the consuming project, not a review item the skill resolves. Zero matches → proceeds without a layer.
+
 ### Reviewer subagents
 
 Eight stack-agnostic reviewer personas in `claude/.claude/agents/`, spawned by `/plan-review` and `/code-review` based on the **Item ownership** tables in those skills. Each runs in its own context with read-only tools (`Read`, `Grep`, `Glob`, `Bash`).

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -1,6 +1,6 @@
 # Design Decisions
 
-Seven non-obvious choices and the reasoning behind them.
+Eight non-obvious choices and the reasoning behind them.
 
 ## 1. Hook-enforced gates over advisory instructions
 
@@ -29,3 +29,7 @@ Tier 1 is always on and requires no setup: a regex blocks `[A-Z]{2,}-\d+` tokens
 ## 7. Worktree-required as a per-project sentinel
 
 Worktree enforcement is activated per-repo by committing a `.claude/worktree-required` file. It is not a global setting because not every repo needs isolation: a small personal script with one developer has no concurrent-session race condition to guard against, and requiring worktrees there just adds friction. A multi-session feature branch with parallel Claude Code instances does need the guard. The committed sentinel means the enforcement decision lives in source control alongside the code it protects — the same `git pull` that brings the sentinel to a new machine activates enforcement there too, without any per-machine configuration.
+
+## 8. Project-layer composition via prose-pointer + glob
+
+`/code-review` and `/plan-review` each check for a project-specific layer at skill start, using an explicit prose pointer that globs for `.claude/skills/<parent>-*/SKILL.md` from the repo root and invokes a single match via the Skill tool. The mechanism is a prose pointer rather than a description-based auto-trigger because an empirical test (documented in `claude/.claude/skills/code-review/REFERENCES.md`) confirmed that auto-trigger does not fire from inside a running skill — a project-specific layer depending on description-based triggering would silently skip on every review. The glob convention generalizes across projects without editing the public skill body on each onboarding; hardcoding project names in the base skill was rejected because it would require public-repo edits to add each new project, and config-file indirection was rejected because it adds no value over the established naming convention. The tradeoff: the consuming repo must follow the `<parent>-<project>/SKILL.md` naming convention exactly — a typo produces a zero-match silent skip rather than a load error.


### PR DESCRIPTION
## Summary

- Adds `#### Project-specific layers` subsection to README.md (after `#### Skill architecture notes`) covering the naming convention, frontmatter guidance, and glob behavior
- Adds design-decisions entry #8 summarising the prose-pointer + glob choice and the rationale behind it

## Context

PR #153 landed Step 0.5 / Step 2.5 in `/code-review` and `/plan-review` that glob for `.claude/skills/<parent>-*/SKILL.md` and invoke a project-specific layer via the Skill tool. The mechanism was already in the skill bodies (for Claude) and in `code-review/REFERENCES.md` (for skill maintainers), but had no human-facing documentation. A `claude-config` adopter who wants to extend the base review skills with project-specific checklist items had no signpost for the convention.

## What shipped

**README.md** — new `#### Project-specific layers` subsection:
- Location convention (`.claude/skills/code-review-<project>/SKILL.md` / `plan-review-<project>/SKILL.md`)
- Frontmatter guidance (match an existing skill; parent invokes via Skill tool, not auto-trigger)
- Behavior: single match → invoked + merged; multiple → stops (config error); zero → proceeds

**docs/design-decisions.md** — entry #8, single paragraph matching the existing 7-entry format:
- The non-obvious bit: auto-trigger doesn't fire from inside a running skill (F-04)
- Alternatives rejected: hardcoded project names, config-file indirection
- Tradeoff: typo produces silent zero-match skip, not a load error

## Test plan

- [ ] README subsection renders cleanly between `#### Skill architecture notes` and `### Reviewer subagents`
- [ ] design-decisions #8 reads in the same voice as entries 1–7; header says "Eight"
- [ ] Glob path and behavior in both docs match `code-review/SKILL.md:25` and `plan-review/SKILL.md:50`
- [ ] 514 tests pass (`pytest claude/.claude/`), lint clean (`ruff check claude/.claude/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)