### PR TITLE
chore: trim skill catalog — marketplace plugin, plugin disables, skillOverrides

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "claude-config",
+  "description": "Jared Cordova's claude-config plugins — project-scoped skills not suitable for user-scope.",
+  "owner": {
+    "name": "Jared Cordova"
+  },
+  "plugins": [
+    {
+      "name": "lovable-knowledge",
+      "description": "How Lovable's UI knowledge fields work (Project Knowledge vs Workspace Knowledge), the .lovable/*.md repo-mirror workflow, content scope split, precedence, character limits, and review criteria for .lovable/** changes.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Jared Cordova"
+      },
+      "source": "./plugins/lovable-knowledge",
+      "category": "productivity"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "claude-config",
-  "description": "Jared Cordova's claude-config plugins — project-scoped skills not suitable for user-scope.",
+  "description": "Cordova Strategy claude-config plugins — project-scoped skills not suitable for user-scope.",
   "owner": {
-    "name": "Jared Cordova"
+    "name": "Cordova Strategy"
   },
   "plugins": [
     {
@@ -11,7 +11,7 @@
       "description": "How Lovable's UI knowledge fields work (Project Knowledge vs Workspace Knowledge), the .lovable/*.md repo-mirror workflow, content scope split, precedence, character limits, and review criteria for .lovable/** changes.",
       "version": "1.0.0",
       "author": {
-        "name": "Jared Cordova"
+        "name": "Cordova Strategy"
       },
       "source": "./plugins/lovable-knowledge",
       "category": "productivity"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,8 @@ name and matcher; do not rely solely on settings.json `if` conditions.
 
 **`REFERENCES.md` is the co-located reference file for a skill.** A skill directory may contain a `REFERENCES.md` alongside `SKILL.md` — use it for canonical URLs, key quotes, and framework notes that informed the skill's rules. `REFERENCES.md` is not loaded at skill runtime; read it manually (via Read or Bash) when editing a skill to verify a rule still holds or to add new guidance. Do not embed this reference material directly in `SKILL.md`.
 
+**Project-scoped plugins:** skills that apply to one or a few private projects — not broadly to all sessions — live under `plugins/<name>/` as marketplace plugins, not in `claude/.claude/skills/`. The repo exposes itself as a marketplace via `.claude-plugin/marketplace.json`. Add `.claude-plugin/plugin.json` and `skills/<name>/SKILL.md` inside `plugins/<name>/`. Install at project scope from the consuming repo: `claude plugin install <name>@claude-config --scope project`.
+
 ## Plans in this repo affect all stow users
 
 `claude/` is stowed into `$HOME` — changes ship to every user who clones and stows this repo, not only to the session owner. When reviewing a plan for claude-config, evaluate with that audience in mind. Files under `claude/` are not personal config; they are distributed to all stow users on `git pull`. Surface this when declaring the user surface in Step 2 of plan-review, and weight finding severity accordingly.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ flowchart LR
 - **`/config-environments`** — designing configuration that differs across environments (dev, staging, production): env var naming, credential isolation, secrets provisioning, and the anti-patterns that reintroduce tight coupling.
 - **`/sql-query-conventions`** — read-path conventions for SQL and PostgREST/Supabase queries: pagination, limits, N+1 avoidance, batch-size ceilings, explicit column selection.
 - **`/ai-instruction-and-memory-files`** — how AI coding agents load instruction files (CLAUDE.md, AGENTS.md, Cursor rules, Lovable knowledge) and Claude Code auto-memory: precedence, duplication rules, length targets, import patterns.
-- **`/lovable-knowledge`** — Lovable Project Knowledge vs Workspace Knowledge fields, the `.lovable/*.md` repo-mirror workflow, content scope split, precedence, and character limits.
 - **`/verify-primary-sources`** — when web research informs a code or design decision, read the primary documentation directly rather than trusting agent summaries or secondary sources.
 - **`/read-docx-comments`** — extract comments from `.docx` files with anchored text context.
 - **`/cleanup-merged-branch`** — removes the local worktree and branch, prunes remote tracking refs, and fast-forwards the default branch after a PR is merged. Handles squash-merge branch detection and CWD anchoring for worktree-enforced repos.
@@ -125,6 +124,16 @@ Each skill lives in `claude/.claude/skills/<skill-name>/SKILL.md`. A skill direc
 - **Location:** `.claude/skills/code-review-<project>/SKILL.md` or `.claude/skills/plan-review-<project>/SKILL.md`, placed in the consuming repo. The `<project>` token is freeform; only the prefix (`code-review-` or `plan-review-`) is load-bearing.
 - **Frontmatter:** match the shape of any skill in `claude/.claude/skills/` (`name`, `description`, `user-invocable`). The parent invokes the layer via the Skill tool — not via description-based auto-trigger, which doesn't fire from inside a running skill (design rationale in [`docs/design-decisions.md`](docs/design-decisions.md)).
 - **Behavior:** glob runs from the repo root (`git rev-parse --show-toplevel`). Single match → invoked and merged into the base checklist. Multiple matches → review stops — that's a config error in the consuming project, not a review item the skill resolves. Zero matches → proceeds without a layer.
+
+### Plugins (marketplace)
+
+Skills that apply to one or a few private projects — not broadly to all sessions — live as marketplace plugins under `plugins/<name>/` rather than in `claude/.claude/skills/`. This keeps them out of the global skill catalog and lets them be installed only in the repos that need them.
+
+This repo exposes a marketplace via `.claude-plugin/marketplace.json`. Each plugin lives under `plugins/<name>/` with a `.claude-plugin/plugin.json` manifest and skills under `plugins/<name>/skills/<name>/SKILL.md`.
+
+**Current plugins:**
+
+- **`lovable-knowledge`** — Lovable Project Knowledge vs Workspace Knowledge fields, the `.lovable/*.md` repo-mirror workflow, content scope split, precedence, and character limits. To install at project scope from a Lovable project repo: first register the marketplace (`claude plugin marketplace add <path-or-URL-to-claude-config>`), then `claude plugin install lovable-knowledge@claude-config --scope project`.
 
 ### Reviewer subagents
 

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -161,8 +161,8 @@
   },
   "enabledPlugins": {
     "skill-creator@claude-plugins-official": true,
-    "claude-md-management@claude-plugins-official": true,
-    "claude-code-setup@claude-plugins-official": true
+    "claude-md-management@claude-plugins-official": false,
+    "claude-code-setup@claude-plugins-official": false
   },
   "extraKnownMarketplaces": {
     "claude-plugins-official": {

--- a/plugins/lovable-knowledge/.claude-plugin/plugin.json
+++ b/plugins/lovable-knowledge/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "lovable-knowledge",
+  "description": "How Lovable's UI knowledge fields work (Project Knowledge vs Workspace Knowledge), the .lovable/*.md repo-mirror workflow, content scope split, precedence, character limits, and review criteria for .lovable/** changes.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Jared Cordova"
+  },
+  "skills": "./skills/"
+}

--- a/plugins/lovable-knowledge/.claude-plugin/plugin.json
+++ b/plugins/lovable-knowledge/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "description": "How Lovable's UI knowledge fields work (Project Knowledge vs Workspace Knowledge), the .lovable/*.md repo-mirror workflow, content scope split, precedence, character limits, and review criteria for .lovable/** changes.",
   "version": "1.0.0",
   "author": {
-    "name": "Jared Cordova"
+    "name": "Cordova Strategy"
   },
   "skills": "./skills/"
 }

--- a/plugins/lovable-knowledge/skills/lovable-knowledge/SKILL.md
+++ b/plugins/lovable-knowledge/skills/lovable-knowledge/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: lovable-knowledge
+description: >
+  How Lovable's UI knowledge fields work (Project Knowledge vs Workspace
+  Knowledge), the `.lovable/*.md` repo-mirror workflow, content scope
+  split, precedence, character limits, and review criteria for `.lovable/**`
+  changes.
+  TRIGGER when: editing `.lovable/*.md`; drafting changes to Lovable
+  Project Knowledge or Workspace Knowledge; deciding which Lovable
+  knowledge field a given rule belongs in; reviewing `.lovable/**`
+  changes in a PR.
+  DO NOT TRIGGER when: the project-level CLAUDE.md does not identify
+  this as a Lovable project; editing CLAUDE.md or AGENTS.md (use
+  `ai-instruction-and-memory-files`); editing agent-specific rules files
+  like `.cursorrules` or `.github/copilot-instructions.md` (out of
+  current scope); or writing code.
+user-invocable: false
+---
+
+# Lovable Knowledge — Architecture & Review
+
+The facts below come from primary sources ([Lovable Docs — Knowledge](https://docs.lovable.dev/features/knowledge)).
+
+## 1. The four sources Lovable loads
+
+> "When you send a message, Lovable reads your project knowledge, workspace knowledge, and project code... It also looks at instruction files in your project's GitHub repository such as AGENTS.md or CLAUDE.md."
+
+Effective priority order:
+
+1. **Project Knowledge** (Lovable UI field — highest priority)
+2. **Workspace Knowledge** (Lovable UI field)
+3. **AGENTS.md / CLAUDE.md** (repo files — AGENTS.md has the explicit "always read regardless of session length" guarantee)
+4. **Project code**
+
+> "Lovable is encouraged to prioritize the instructions defined in project knowledge, since they apply specifically to the current project."
+
+> "Root-level AGENTS.md files are always read by the Lovable agent regardless of session length."
+
+All four are loaded every session. Lovable docs warn that in very long
+conversations instructions can drift; the "always read" guarantee for
+AGENTS.md is the defense-in-depth.
+
+## 2. Project Knowledge vs Workspace Knowledge
+
+Per Lovable docs:
+
+| | Workspace Knowledge | Project Knowledge |
+|---|---|---|
+| Scope | Cross-project (the Lovable workspace) | Single-project |
+| Use for | Coding style, naming, libraries/frameworks, architectural patterns, testing requirements, lint rules, brand/voice, **Lovable-platform behavior** | What the app does, user personas, schema/tables, architecture decisions, domain terminology, project-specific constraints, design specifics, security/compliance, links to important references |
+| Precedence | — | **Wins on conflict** |
+| Char limit | 10,000 | 10,000 |
+
+> "Keep shared rules in workspace knowledge and project-specific details in project knowledge to avoid confusion and maximize clarity."
+
+When a rule could plausibly fit in either: ask whether it would apply to
+a *different* project in the same Lovable workspace. If yes →
+workspace. If no (it's tied to *this* product's domain, schema, or
+constraints) → project.
+
+## 3. `.lovable/` repo-mirror workflow
+
+`.lovable/project-knowledge.md` and `.lovable/workspace-knowledge.md` are
+**version-controlled mirrors** of the corresponding Lovable UI fields.
+Lovable only loads the UI fields at runtime; the repo files are not
+auto-loaded — they exist for diff review and history.
+
+**Workflow** for updating Lovable knowledge:
+
+1. Draft the change in a PR against the appropriate `.lovable/` file.
+2. Bump the "Last synced to Lovable UI" date in the file header in the
+   same PR.
+3. After merge, the human pastes the merged content into Lovable →
+   Settings → Knowledge.
+
+**Do not** assume that writing to `.lovable/` propagates to Lovable. The
+UI field is the only thing Lovable reads; the repo file is the
+authoring/review surface.
+
+**Do not** skip the repo step and paste directly into the UI without a
+PR — that loses diff review, version history, and audit trail.
+
+## 4. Authoring guidance
+
+When writing content for either field:
+
+- **Perspective.** Address Lovable in second person. Knowledge files
+  reading as internal engineering notes will confuse Lovable.
+- **Specificity.** Lovable follows literally and may over-apply vague
+  guidance. "Be careful with auth" can become "add auth checks to public
+  endpoints." Spell out the boundary cases.
+- **Context budget.** Both fields cap at 10,000 chars. Beyond that,
+  Lovable drops content. Even before the cap, length displaces active
+  task instructions — apply the same length and behavior-test discipline
+  as Claude Code skills (see `ai-instruction-and-memory-files` §3).
+
+## 5. Review checklist for `.lovable/**` changes
+
+When reviewing a PR that touches `.lovable/*.md`:
+
+1. **Perspective** — Is the new content addressed to Lovable in second
+   person?
+2. **Specificity** — Could the instruction be over-applied (e.g., "be
+   careful with auth" applied to public endpoints)?
+3. **Scope** — Cross-project conventions → `workspace-knowledge.md`;
+   this-app-specific → `project-knowledge.md`. Project knowledge wins
+   on conflict.
+4. **Char budget** — Is the file approaching the 10,000-char limit?
+5. **Sync status** — If `project-knowledge.md` or
+   `workspace-knowledge.md` changed, has the "Last synced" date been
+   bumped in the same PR? Does the PR description note that the human
+   needs to paste the merged content into the Lovable UI?
+
+## 6. Primary sources
+
+- [Lovable Docs — Knowledge](https://docs.lovable.dev/features/knowledge)
+- [agents.md standard](https://agents.md) (cross-agent AGENTS.md context)


### PR DESCRIPTION
## Summary

- **lovable-knowledge → marketplace plugin.** Moves the skill into `plugins/lovable-knowledge/` with a marketplace manifest at `.claude-plugin/marketplace.json`. The repo now acts as a marketplace so future Lovable-project repos can install at project scope (`claude plugin install lovable-knowledge@claude-config --scope project`). The user-scope copy in `claude/.claude/skills/lovable-knowledge/` is kept during the transition — a follow-up PR drops it after project-scope install is verified in consuming repos.
- **Disable two unused plugins.** `claude-md-management` and `claude-code-setup` flipped to `false` in `enabledPlugins`. Both stay cached; toggle back to `true` when needed (occasional CLAUDE.md grading, new-project onboarding). Note: `enabledPlugins` only honors committed `settings.json`, not `settings.local.json` — so this ships to all stow users. Disabling a plugin a stow user doesn't have installed is a no-op.
- **`skillOverrides` for two unused built-ins.** `simplify` and `review` overlap with existing `/code-review` and `/ready-for-review` flows. Added to `settings.local.json` (gitignored, personal preference). If that field isn't honored from local, fall back to `settings.json`.
- **Docs.** `CLAUDE.md` and `README.md` updated to document the project-scoped plugin pattern.

## Motivation

Skill catalog was over the listing budget (`skillListingBudgetFraction`), dropping 16 descriptions per session and weakening auto-trigger detection. Research confirmed:
- `Skill(name)` deny rules block invocation but do **not** reclaim catalog budget.
- `skillOverrides` (v2.1.129+) is the documented budget-reclaim lever for built-ins.
- Plugin disables reclaim the description budget from plugin-provided skills.

## Post-merge checklist (manual, before resuming work in Lovable project repos)

- [x] Register the marketplace: `claude plugin marketplace add <path-or-URL-to-claude-config>` from each consuming repo
- [x] Install at project scope: `claude plugin install lovable-knowledge@claude-config --scope project`
- [ ] Verify the skill fires in the Lovable project repo and does **not** appear in claude-config or other non-Lovable sessions
- [ ] Open follow-up PR to drop `claude/.claude/skills/lovable-knowledge/`
- [ ] Verify `skillOverrides` took effect: `/skills` should not show `simplify` or `review`

🤖 Generated with [Claude Code](https://claude.com/claude-code)