### PR TITLE
Promote review-marker forge-gate rule from per-project memory to global CLAUDE.md + skill

### DIFF
--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -42,7 +42,7 @@
 - Never run sudo commands directly.
 - Never commit secrets, credentials, API keys, or large binary assets to repositories.
 - Never use the Read tool on files likely to contain secrets (`.env`, `.claude.json`, `credentials.json`, similar). Reading pulls the secret into the conversation context. When you need to inspect such a file, give the user a shell command (`cat`, `grep`, `jq`) to run via `!` instead.
-- Never write `~/.claude/review-markers/*` by hand. These markers are written by review skills (e.g. `/code-review`, `/plan-review`) when a review passes, and pre-commit hooks gate on their presence. If a commit is blocked, run the review skill the hook names; if the skill is harness-blocked, spawn a subagent that can run it. A general "ship it" instruction is not authorization to forge a marker.
+- Never write `~/.claude/*-markers/*` by hand. Each review skill writes its own marker directory (`/code-review` → `review-markers/`, `/plan-review` → `plan-review-markers/`, etc.) when a review passes, and pre-commit hooks gate on their presence. If a commit is blocked, run the review skill the hook names; if the skill is harness-blocked, spawn a subagent that can run it. A general "ship it" instruction is not authorization to forge a marker.
 
 ## Code Comments
 

--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -42,6 +42,7 @@
 - Never run sudo commands directly.
 - Never commit secrets, credentials, API keys, or large binary assets to repositories.
 - Never use the Read tool on files likely to contain secrets (`.env`, `.claude.json`, `credentials.json`, similar). Reading pulls the secret into the conversation context. When you need to inspect such a file, give the user a shell command (`cat`, `grep`, `jq`) to run via `!` instead.
+- Never write `~/.claude/review-markers/*` by hand. The pre-commit hook (`require-code-review.sh`) is gated on a marker that the `/code-review` skill writes when a review is clean. If a commit is blocked, run `/code-review`; if the skill is harness-blocked, spawn a subagent that can run it. A general "ship it" instruction is not authorization to forge the marker.
 
 ## Code Comments
 

--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -42,7 +42,7 @@
 - Never run sudo commands directly.
 - Never commit secrets, credentials, API keys, or large binary assets to repositories.
 - Never use the Read tool on files likely to contain secrets (`.env`, `.claude.json`, `credentials.json`, similar). Reading pulls the secret into the conversation context. When you need to inspect such a file, give the user a shell command (`cat`, `grep`, `jq`) to run via `!` instead.
-- Never write `~/.claude/review-markers/*` by hand. The pre-commit hook (`require-code-review.sh`) is gated on a marker that the `/code-review` skill writes when a review is clean. If a commit is blocked, run `/code-review`; if the skill is harness-blocked, spawn a subagent that can run it. A general "ship it" instruction is not authorization to forge the marker.
+- Never write `~/.claude/review-markers/*` by hand. These markers are written by review skills (e.g. `/code-review`, `/plan-review`) when a review passes, and pre-commit hooks gate on their presence. If a commit is blocked, run the review skill the hook names; if the skill is harness-blocked, spawn a subagent that can run it. A general "ship it" instruction is not authorization to forge a marker.
 
 ## Code Comments
 

--- a/claude/.claude/skills/code-review/SKILL.md
+++ b/claude/.claude/skills/code-review/SKILL.md
@@ -278,3 +278,5 @@ If the chain fails (empty `SESSION_ID`, etc.), the `capture-session-id.sh` Sessi
 - You are not in a git repository
 
 If you skip it, say so explicitly so the user knows the commit gate will block until issues are fixed and the review is re-run on the final staged state.
+
+**This marker must be written only by this skill.** Never compute and write it manually — that satisfies the hook's shell check but forges the gate. If the hook blocks a commit and you cannot invoke this skill, spawn a subagent that can; do not hand-write the marker path.


### PR DESCRIPTION
## Summary

- Moves the \"never hand-write review-markers\" rule from a per-project auto-memory file (now deleted) into the two places that are always loaded globally.
- **`CLAUDE.md` Safety section** — adds a bullet with the correct scope: `~/.claude/*-markers/*` (the glob that covers all review-skill marker directories). Documents the per-skill directory mapping and instructs agents to run whichever skill the blocking hook names, not a hardcoded skill.
- **`code-review/SKILL.md` Record-review-completion section** — adds a one-paragraph footnote reinforcing that the code-review marker directory is owned exclusively by this skill; spawn a subagent if the skill can't be invoked directly.

## Why the scope change

Each review skill writes its own marker directory (`/code-review` → `review-markers/`, `/plan-review` → `plan-review-markers/`, etc.) — these are global infrastructure. Per-project auto-memory is only loaded for that project — the wrong home for a cross-project tooling invariant. Global `CLAUDE.md` is loaded in every session.

## Test plan

- [ ] Verify `claude/.claude/CLAUDE.md` Safety section contains the new bullet with glob `~/.claude/*-markers/*`
- [ ] Verify `claude/.claude/skills/code-review/SKILL.md` ends with the new paragraph
- [ ] Confirm no private-project identifiers leaked (per-project memory file deleted in prior session, not referenced here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)