### PR TITLE
feat(hooks): gate memory writes behind ai-instruction-and-memory-files skill

### DIFF
--- a/claude/.claude/hooks/require-memory-skill.sh
+++ b/claude/.claude/hooks/require-memory-skill.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+# set -uo pipefail but NOT -e: hooks inspect exit codes rather than aborting on them.
+set -uo pipefail
+# PreToolUse hook: block Write/Edit/MultiEdit to Claude Code auto-memory files
+# without a current ai-instruction-and-memory-files skill invocation for this turn.
+#
+# Matched tools: Write, Edit, MultiEdit (self-filters; do not rely solely on
+# the settings.json matcher condition).
+#
+# Two path classes are gated:
+#   a. MEMORY.md index — any write/edit to
+#      ~/.claude/projects/*/memory/MEMORY.md
+#   b. New topic files — Write to a path that does not yet exist under
+#      ~/.claude/projects/*/memory/ (Edit always targets an existing file, so
+#      only Write can create; MultiEdit never creates new files).
+#   Edits to existing topic files (Write or Edit to an already-present path)
+#   pass through — the index-format and frontmatter rules were already observed
+#   when the file was first created.
+#
+# Per-turn debounce: the gate fires once per user turn, keyed by the uuid of
+# the latest type=="user" entry in the transcript. uuid (not mtime) is used
+# because turns can last seconds to minutes. After the first deny, the marker
+# stores the current turn's uuid; subsequent writes in the same turn see a
+# matching marker and pass through.
+#
+# Fail-open conditions (exit 0 without denying):
+#   - session_id absent from input — cannot key a per-session marker
+#   - transcript_path absent from input — cannot read turn uuid
+#   - transcript has no type=="user" entries — no uuid to key on
+#   - unbound variable encountered (set -u) — exits non-zero but falls through
+#     to allow, since no JSON is emitted on an unbound-variable exit
+#
+# Bash-tool bypass: Bash writes (e.g. echo > file) bypass this gate because
+# the hook only intercepts Write/Edit/MultiEdit tool calls. This is an
+# acceptable limitation — realistic auto-memory writes use the Write tool.
+#
+# Defense-in-depth: the hook filters its own input by tool name; do not
+# rely solely on the settings.json matcher condition.
+#
+# Exit codes:
+#   0      — allow (no opinion)
+#   0+JSON — deny (memory write without skill invocation this turn)
+
+INPUT=$(cat)
+TOOL_NAME=$(printf '%s\n' "$INPUT" | jq -r '.tool_name // empty')
+
+# Only gate Write, Edit, and MultiEdit tool calls.
+case "$TOOL_NAME" in
+  Write|Edit|MultiEdit) ;;
+  *) exit 0 ;;
+esac
+
+FILE_PATH=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.file_path // empty')
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+REAL_PATH=$(realpath -m "$FILE_PATH")
+REAL_HOME=$(realpath -m "$HOME")
+
+# Classify path — only proceed for memory files.
+IS_CANDIDATE=0
+
+# Class (a): MEMORY.md index — always gated regardless of tool or existence.
+if [[ "$REAL_PATH" == "$REAL_HOME/.claude/projects/"*"/memory/MEMORY.md" ]]; then
+  IS_CANDIDATE=1
+fi
+
+# Class (b): new topic file — Write only, file must not exist yet.
+if [ "$IS_CANDIDATE" -eq 0 ] && \
+   [ "$TOOL_NAME" = "Write" ] && \
+   [[ "$REAL_PATH" == "$REAL_HOME/.claude/projects/"* ]] && \
+   [[ "$REAL_PATH" == *"/memory/"* ]] && \
+   [ ! -e "$FILE_PATH" ]; then
+  IS_CANDIDATE=1
+fi
+
+if [ "$IS_CANDIDATE" -eq 0 ]; then
+  exit 0
+fi
+
+SESSION_ID=$(printf '%s\n' "$INPUT" | jq -r '.session_id // empty')
+TRANSCRIPT_PATH=$(printf '%s\n' "$INPUT" | jq -r '.transcript_path // empty')
+
+# Fail open if we can't track turns.
+if [ -z "$SESSION_ID" ] || [ -z "$TRANSCRIPT_PATH" ]; then
+  exit 0
+fi
+
+LATEST_UUID=$(tail -n 200 "$TRANSCRIPT_PATH" 2>/dev/null | jq -r 'select(.type=="user") | .uuid' 2>/dev/null | tail -1)
+
+# Fail open if there are no user messages in the transcript yet.
+if [ -z "$LATEST_UUID" ]; then
+  exit 0
+fi
+
+MARKER_DIR="$HOME/.claude/.memory-skill-fired.d"
+MARKER="$MARKER_DIR/$SESSION_ID"
+
+# Per-turn debounce: if the marker's stored uuid matches the current turn's
+# latest user uuid, the skill already fired this turn — allow through.
+if [ -f "$MARKER" ] && [ "$(cat "$MARKER")" = "$LATEST_UUID" ]; then
+  exit 0
+fi
+
+# Record this turn's uuid and deny.
+mkdir -p "$MARKER_DIR"
+printf '%s' "$LATEST_UUID" > "$MARKER"
+
+REASON="Memory write blocked by ai-instruction-and-memory-files gate. You are writing to $FILE_PATH, which is part of Claude Code's auto-memory file system (MEMORY.md index or a new topic file). Invoke the ai-instruction-and-memory-files skill via the Skill tool first — it covers MEMORY.md index format, topic-file frontmatter, length budgets, and the type classification (user / feedback / project / reference). After invoking the skill, retry this write; subsequent memory writes in this turn will pass through."
+REASON_JSON=$(printf '%s' "$REASON" | jq -Rs .)
+printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' "$REASON_JSON"

--- a/claude/.claude/hooks/tests/test_require_memory_skill.py
+++ b/claude/.claude/hooks/tests/test_require_memory_skill.py
@@ -1,0 +1,211 @@
+"""Tests for require-memory-skill.sh."""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from helpers import (
+    HOOKS_DIR,
+    bash_input,
+    edit_input,
+    multiedit_input,
+    run_hook,
+    run_hook_reason,
+    write_input,
+)
+
+HOOK_PATH = HOOKS_DIR / "require-memory-skill.sh"
+
+
+@pytest.fixture
+def memory_tree(isolated_home):
+    """Populate a realistic auto-memory directory under the isolated $HOME.
+
+    Creates:
+      ~/.claude/projects/abc123/memory/MEMORY.md  (existing index)
+      ~/.claude/projects/abc123/memory/user_role.md  (existing topic file)
+
+    Returns the path to the memory directory.
+    """
+    mem_dir = isolated_home / ".claude" / "projects" / "abc123" / "memory"
+    mem_dir.mkdir(parents=True)
+    (mem_dir / "MEMORY.md").touch()
+    (mem_dir / "user_role.md").write_text("# User role\n")
+    return mem_dir
+
+
+def write_transcript(tmp_path: Path, messages: list[dict]) -> str:
+    """Write a JSONL transcript file and return its path as a string.
+
+    Each dict in `messages` is written as one JSON line. Real Claude Code
+    transcript user records include at least `type` and `uuid` fields.
+    """
+    transcript = tmp_path / "transcript.jsonl"
+    with transcript.open("w") as fh:
+        for msg in messages:
+            fh.write(json.dumps(msg) + "\n")
+    return str(transcript)
+
+
+def _memory_input(base_input: dict, session_id: str, transcript_path: str) -> dict:
+    """Merge session_id and transcript_path into an existing tool-input dict."""
+    return {**base_input, "session_id": session_id, "transcript_path": transcript_path}
+
+
+class TestRequireMemorySkill:
+    def test_memory_md_edit_blocked(self, isolated_home, memory_tree, tmp_path):
+        """Edit on MEMORY.md is denied (no marker for this turn)."""
+        transcript = write_transcript(
+            tmp_path, [{"type": "user", "uuid": "uuid-1"}]
+        )
+        memory_md = str(memory_tree / "MEMORY.md")
+        payload = _memory_input(edit_input(memory_md), "sess-edit", transcript)
+        assert run_hook(HOOK_PATH, payload) == "deny"
+
+    def test_memory_md_write_blocked(self, isolated_home, memory_tree, tmp_path):
+        """Write to MEMORY.md is denied."""
+        transcript = write_transcript(
+            tmp_path, [{"type": "user", "uuid": "uuid-2"}]
+        )
+        memory_md = str(memory_tree / "MEMORY.md")
+        payload = _memory_input(write_input(memory_md), "sess-write", transcript)
+        assert run_hook(HOOK_PATH, payload) == "deny"
+
+    def test_memory_md_multiedit_blocked(self, isolated_home, memory_tree, tmp_path):
+        """MultiEdit on MEMORY.md is denied."""
+        transcript = write_transcript(
+            tmp_path, [{"type": "user", "uuid": "uuid-3"}]
+        )
+        memory_md = str(memory_tree / "MEMORY.md")
+        payload = _memory_input(multiedit_input(memory_md), "sess-multiedit", transcript)
+        assert run_hook(HOOK_PATH, payload) == "deny"
+
+    def test_new_topic_file_write_blocked(self, isolated_home, memory_tree, tmp_path):
+        """Write to a non-existent path under memory/ is denied (new topic file)."""
+        transcript = write_transcript(
+            tmp_path, [{"type": "user", "uuid": "uuid-4"}]
+        )
+        new_topic = str(memory_tree / "new_topic.md")
+        # Confirm the file doesn't exist — the hook's class-(b) check requires it.
+        assert not Path(new_topic).exists()
+        payload = _memory_input(write_input(new_topic), "sess-new-topic", transcript)
+        assert run_hook(HOOK_PATH, payload) == "deny"
+
+    def test_existing_topic_file_edit_allowed(self, isolated_home, memory_tree, tmp_path):
+        """Edit on an existing topic file passes through (only new files are gated)."""
+        transcript = write_transcript(
+            tmp_path, [{"type": "user", "uuid": "uuid-5"}]
+        )
+        existing = str(memory_tree / "user_role.md")
+        payload = _memory_input(edit_input(existing), "sess-existing-edit", transcript)
+        assert run_hook(HOOK_PATH, payload) == "allow"
+
+    def test_existing_topic_file_write_allowed(self, isolated_home, memory_tree, tmp_path):
+        """Write overwriting an existing topic file passes through."""
+        transcript = write_transcript(
+            tmp_path, [{"type": "user", "uuid": "uuid-6"}]
+        )
+        existing = str(memory_tree / "user_role.md")
+        payload = _memory_input(write_input(existing), "sess-existing-write", transcript)
+        assert run_hook(HOOK_PATH, payload) == "allow"
+
+    def test_non_memory_path_allowed(self, isolated_home, tmp_path):
+        """Edit on a path outside the memory directory passes through."""
+        transcript = write_transcript(
+            tmp_path, [{"type": "user", "uuid": "uuid-7"}]
+        )
+        readme = str(isolated_home / "some-project" / "README.md")
+        payload = _memory_input(edit_input(readme), "sess-non-memory", transcript)
+        assert run_hook(HOOK_PATH, payload) == "allow"
+
+    def test_bash_tool_allowed(self, isolated_home, tmp_path):
+        """Bash input passes through — self-filter by tool name."""
+        payload = bash_input("echo hello", session_id="sess-bash")
+        assert run_hook(HOOK_PATH, payload) == "allow"
+
+    def test_per_turn_debounce_same_uuid(self, isolated_home, memory_tree, tmp_path):
+        """First deny writes the marker; second call in the same turn is allowed."""
+        transcript = write_transcript(
+            tmp_path, [{"type": "user", "uuid": "uuid-dedup"}]
+        )
+        memory_md = str(memory_tree / "MEMORY.md")
+        payload = _memory_input(edit_input(memory_md), "sess-dedup", transcript)
+
+        # First call → deny and write marker.
+        assert run_hook(HOOK_PATH, payload) == "deny"
+
+        # Second call with the same transcript (same latest uuid) → allow.
+        assert run_hook(HOOK_PATH, payload) == "allow"
+
+    def test_new_turn_re_blocks(self, isolated_home, memory_tree, tmp_path):
+        """After a new user message, the next call is denied again."""
+        transcript_path = tmp_path / "transcript.jsonl"
+        transcript_path.write_text(
+            json.dumps({"type": "user", "uuid": "uuid-turn1"}) + "\n"
+        )
+        memory_md = str(memory_tree / "MEMORY.md")
+        payload = _memory_input(
+            edit_input(memory_md), "sess-newturn", str(transcript_path)
+        )
+
+        # First turn → deny.
+        assert run_hook(HOOK_PATH, payload) == "deny"
+
+        # Append a new user message (new turn).
+        with transcript_path.open("a") as fh:
+            fh.write(json.dumps({"type": "user", "uuid": "uuid-turn2"}) + "\n")
+
+        # The payload references the same transcript path — hook re-reads it.
+        assert run_hook(HOOK_PATH, payload) == "deny"
+
+    def test_missing_session_id_allows(self, isolated_home, memory_tree, tmp_path):
+        """Edit on MEMORY.md with no session_id in input passes through (fail open)."""
+        transcript = write_transcript(
+            tmp_path, [{"type": "user", "uuid": "uuid-nosess"}]
+        )
+        memory_md = str(memory_tree / "MEMORY.md")
+        # Build payload without session_id.
+        payload = {**edit_input(memory_md), "transcript_path": transcript}
+        assert run_hook(HOOK_PATH, payload) == "allow"
+
+    def test_missing_transcript_path_allows(self, isolated_home, memory_tree, tmp_path):
+        """Edit on MEMORY.md with no transcript_path in input passes through."""
+        memory_md = str(memory_tree / "MEMORY.md")
+        # Build payload without transcript_path.
+        payload = {**edit_input(memory_md), "session_id": "sess-notranscript"}
+        assert run_hook(HOOK_PATH, payload) == "allow"
+
+    def test_transcript_no_user_messages_allows(self, isolated_home, memory_tree, tmp_path):
+        """Transcript with no type=='user' entries passes through (fail open)."""
+        transcript = write_transcript(
+            tmp_path,
+            [{"type": "assistant", "uuid": "uuid-asst"}],
+        )
+        memory_md = str(memory_tree / "MEMORY.md")
+        payload = _memory_input(edit_input(memory_md), "sess-nousers", transcript)
+        assert run_hook(HOOK_PATH, payload) == "allow"
+
+    def test_malformed_json_stdin(self, isolated_home, tmp_path):
+        """Malformed JSON stdin must not crash the hook and must exit 0."""
+        result = subprocess.run(
+            [str(HOOK_PATH)],
+            input="not-valid-json{{{",
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_deny_message_mentions_skill_name(self, isolated_home, memory_tree, tmp_path):
+        """Deny reason must reference ai-instruction-and-memory-files so the agent
+        knows which skill to invoke."""
+        transcript = write_transcript(
+            tmp_path, [{"type": "user", "uuid": "uuid-reason-check"}]
+        )
+        memory_md = str(memory_tree / "MEMORY.md")
+        payload = _memory_input(edit_input(memory_md), "sess-reason", transcript)
+        reason = run_hook_reason(HOOK_PATH, payload)
+        assert reason is not None
+        assert "ai-instruction-and-memory-files" in reason

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -129,6 +129,11 @@
             "type": "command",
             "command": "~/.claude/hooks/require-worktree-for-file-writes.sh",
             "statusMessage": "Checking worktree enforcement..."
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/require-memory-skill.sh",
+            "statusMessage": "Checking memory-skill gate..."
           }
         ]
       },


### PR DESCRIPTION
## Summary

- Adds `require-memory-skill.sh`, a PreToolUse hook that blocks writes to `MEMORY.md` (all tools) and new topic-file creations (Write only) behind the `ai-instruction-and-memory-files` skill
- Per-turn debounce via latest-user-uuid from the Claude Code transcript — gate fires once per turn; the skill's own memory writes pass through silently
- Fail-open on missing `session_id`, `transcript_path`, or empty user-uuid list; transcript read capped at 200 lines to stay within the 100 ms hook budget
- `set -uo pipefail` (no `-e`); Bash-tool bypass limitation documented in header comment
- 15 pytest tests covering all gated/pass-through paths, per-turn debounce, new-turn re-blocking, fail-open conditions, and deny-message content

## Scope

- `MEMORY.md` writes (Edit, Write, MultiEdit) — always gated
- New topic-file creation via Write (file doesn't exist yet) — gated
- Existing topic-file Edit or Write-overwrite — passes through (gate already observed at creation)
- Bash-tool file writes — known bypass; documented in hook header

## Test plan

- [x] `pytest claude/.claude/` passes (529 tests, including 15 new)
- [x] `ruff check claude/.claude/` clean
- [ ] Manual smoke: stow changes, start a fresh session, ask Claude to add a memory — confirm first write is denied with the gate reason, Claude invokes the skill, retry succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)