### PR TITLE
refactor(lovable-knowledge): extract quotes and sources into REFERENCES.md

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "lovable-knowledge",
       "description": "How Lovable's UI knowledge fields work (Project Knowledge vs Workspace Knowledge), the .lovable/*.md repo-mirror workflow, content scope split, precedence, character limits, and review criteria for .lovable/** changes.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "author": {
         "name": "Cordova Strategy"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "lovable-knowledge",
       "description": "How Lovable's UI knowledge fields work (Project Knowledge vs Workspace Knowledge), the .lovable/*.md repo-mirror workflow, content scope split, precedence, character limits, and review criteria for .lovable/** changes.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "author": {
         "name": "Cordova Strategy"
       },

--- a/plugins/lovable-knowledge/.claude-plugin/plugin.json
+++ b/plugins/lovable-knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lovable-knowledge",
   "description": "How Lovable's UI knowledge fields work (Project Knowledge vs Workspace Knowledge), the .lovable/*.md repo-mirror workflow, content scope split, precedence, character limits, and review criteria for .lovable/** changes.",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "author": {
     "name": "Cordova Strategy"
   },

--- a/plugins/lovable-knowledge/.claude-plugin/plugin.json
+++ b/plugins/lovable-knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lovable-knowledge",
   "description": "How Lovable's UI knowledge fields work (Project Knowledge vs Workspace Knowledge), the .lovable/*.md repo-mirror workflow, content scope split, precedence, character limits, and review criteria for .lovable/** changes.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "Cordova Strategy"
   },

--- a/plugins/lovable-knowledge/skills/lovable-knowledge/REFERENCES.md
+++ b/plugins/lovable-knowledge/skills/lovable-knowledge/REFERENCES.md
@@ -1,0 +1,25 @@
+# References — lovable-knowledge
+
+Reference material that informed this skill. Not loaded during skill execution — consult when editing the skill to verify a rule still holds or to add new guidance.
+
+## Primary source
+
+- [Lovable Docs — Knowledge](https://docs.lovable.dev/features/knowledge) — canonical reference for all Lovable knowledge-field behavior.
+
+## Source quotes
+
+### Four-source priority (informs SKILL §1)
+
+> "When you send a message, Lovable reads your project knowledge, workspace knowledge, and project code... It also looks at instruction files in your project's GitHub repository such as AGENTS.md or CLAUDE.md."
+
+> "Lovable is encouraged to prioritize the instructions defined in project knowledge, since they apply specifically to the current project."
+
+> "Root-level AGENTS.md files are always read by the Lovable agent regardless of session length."
+
+### Project vs Workspace tiebreaker (informs SKILL §2)
+
+> "Keep shared rules in workspace knowledge and project-specific details in project knowledge to avoid confusion and maximize clarity."
+
+## Cross-agent context
+
+- [agents.md standard](https://agents.md) — the cross-agent AGENTS.md spec referenced in SKILL §1's priority list. Lovable, Codex, Cursor, Aider, etc. all read AGENTS.md per this standard.

--- a/plugins/lovable-knowledge/skills/lovable-knowledge/SKILL.md
+++ b/plugins/lovable-knowledge/skills/lovable-knowledge/SKILL.md
@@ -19,11 +19,7 @@ user-invocable: false
 
 # Lovable Knowledge — Architecture & Review
 
-The facts below come from primary sources ([Lovable Docs — Knowledge](https://docs.lovable.dev/features/knowledge)).
-
 ## 1. The four sources Lovable loads
-
-> "When you send a message, Lovable reads your project knowledge, workspace knowledge, and project code... It also looks at instruction files in your project's GitHub repository such as AGENTS.md or CLAUDE.md."
 
 Effective priority order:
 
@@ -32,17 +28,11 @@ Effective priority order:
 3. **AGENTS.md / CLAUDE.md** (repo files — AGENTS.md has the explicit "always read regardless of session length" guarantee)
 4. **Project code**
 
-> "Lovable is encouraged to prioritize the instructions defined in project knowledge, since they apply specifically to the current project."
-
-> "Root-level AGENTS.md files are always read by the Lovable agent regardless of session length."
-
 All four are loaded every session. Lovable docs warn that in very long
 conversations instructions can drift; the "always read" guarantee for
 AGENTS.md is the defense-in-depth.
 
 ## 2. Project Knowledge vs Workspace Knowledge
-
-Per Lovable docs:
 
 | | Workspace Knowledge | Project Knowledge |
 |---|---|---|
@@ -50,8 +40,6 @@ Per Lovable docs:
 | Use for | Coding style, naming, libraries/frameworks, architectural patterns, testing requirements, lint rules, brand/voice, **Lovable-platform behavior** | What the app does, user personas, schema/tables, architecture decisions, domain terminology, project-specific constraints, design specifics, security/compliance, links to important references |
 | Precedence | — | **Wins on conflict** |
 | Char limit | 10,000 | 10,000 |
-
-> "Keep shared rules in workspace knowledge and project-specific details in project knowledge to avoid confusion and maximize clarity."
 
 When a rule could plausibly fit in either: ask whether it would apply to
 a *different* project in the same Lovable workspace. If yes →
@@ -110,8 +98,3 @@ When reviewing a PR that touches `.lovable/*.md`:
    `workspace-knowledge.md` changed, has the "Last synced" date been
    bumped in the same PR? Does the PR description note that the human
    needs to paste the merged content into the Lovable UI?
-
-## 6. Primary sources
-
-- [Lovable Docs — Knowledge](https://docs.lovable.dev/features/knowledge)
-- [agents.md standard](https://agents.md) (cross-agent AGENTS.md context)

--- a/plugins/lovable-knowledge/skills/lovable-knowledge/SKILL.md
+++ b/plugins/lovable-knowledge/skills/lovable-knowledge/SKILL.md
@@ -38,7 +38,7 @@ AGENTS.md is the defense-in-depth.
 |---|---|---|
 | Scope | Cross-project (the Lovable workspace) | Single-project |
 | Use for | Coding style, naming, libraries/frameworks, architectural patterns, testing requirements, lint rules, brand/voice, **Lovable-platform behavior** | What the app does, user personas, schema/tables, architecture decisions, domain terminology, project-specific constraints, design specifics, security/compliance, links to important references |
-| Precedence | — | **Wins on conflict** |
+| Precedence | — | **Prioritized on conflict** |
 | Char limit | 10,000 | 10,000 |
 
 When a rule could plausibly fit in either: ask whether it would apply to


### PR DESCRIPTION
## Summary

- Moves verbatim Lovable Docs quotes, the §6 Primary Sources URL block, and the attribution sentence out of `SKILL.md` into a new co-located `REFERENCES.md`, following the existing SKILL.md/REFERENCES.md split convention used across `claude/.claude/skills/*`
- Fixes a precision error introduced by the split: "Wins on conflict" overclaimed — the Lovable docs say Project Knowledge is *"encouraged to prioritize,"* not that it mechanically wins. Replaced with "Prioritized on conflict"
- All other operational sections are unchanged and stand alone in `SKILL.md`
- Bumps plugin version `1.0.0 → 1.1.0` (minor: REFERENCES.md is additive; precedence wording is a behavioral content change)

## Test plan

- [x] `claude plugin validate plugins/lovable-knowledge` — passes
- [x] `pytest claude/.claude/` — 512 passed
- [x] `ruff check claude/.claude/` — clean
- [x] `/skill-review` — behavioral-equivalence audit clean
- [x] `/code-review` — clean (two passes, one per commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)