### PR TITLE
chore: remove skill-creator from enabledPlugins + design doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Claude Code without enforcement will claim code is done before tests pass, skip 
 
 A CLAUDE.md instruction says "you should run code-review before committing." A PreToolUse hook says "the commit is denied until code-review ran on this exact diff in this session." This distinction is the core design choice: enforce at the tool-call boundary, not at the prompt layer, because prompt-layer instructions are advisory — the model can disregard them on any change it judges simple enough not to need review.
 
-claude-config is a **workflow-enforcement layer** — hooks that gate what Claude can do until explicit review steps are satisfied. It already enables `skill-creator`, `claude-md-management`, and `claude-code-setup` from `anthropics/claude-plugins-official`; those ship additional skills, claude-config ships the enforcement harness. Most hand-rolled `~/.claude/` configs improvise the patterns claude-config systematizes: per-session marker keying, specialist reviewer routing, and three-tier redaction.
+claude-config is a **workflow-enforcement layer** — hooks that gate what Claude can do until explicit review steps are satisfied. It wires in the `anthropics/claude-plugins-official` marketplace but ships official plugins disabled by default; stow users can enable any of them via `enabledPlugins` in their settings. claude-config ships the enforcement harness; most hand-rolled `~/.claude/` configs improvise the patterns claude-config systematizes: per-session marker keying, specialist reviewer routing, and three-tier redaction.
 
 ## Requirements
 

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -160,7 +160,6 @@
     "command": "bash ~/.claude/statusline-command.sh"
   },
   "enabledPlugins": {
-    "skill-creator@claude-plugins-official": true,
     "claude-md-management@claude-plugins-official": false,
     "claude-code-setup@claude-plugins-official": false
   },

--- a/claude/.claude/skills/skill-review/REFERENCES.md
+++ b/claude/.claude/skills/skill-review/REFERENCES.md
@@ -1,0 +1,55 @@
+# skill-review — References
+
+## Why skill-creator is disabled in this repo
+
+`skill-creator` (Anthropic's `claude-plugins-official` plugin) and
+`skill-review` (this repo's local skill) have a deliberate lane split:
+`skill-creator` owns the *authoring* loop — scaffolding a new skill
+directory, running eval/benchmark pipelines, and optimizing the
+`description` field via a `run_loop.py` search loop. `skill-review`
+owns the *audit* lane — the 11-item pre-commit checklist and the
+behavioral-equivalence table that `require-skill-review.sh` enforces
+at commit. The boundary was hand-tightened in commit `618c9ad`, which
+added `skill-creator` to `skill-review`'s DO NOT TRIGGER block to
+prevent dual-fire on every skill-edit turn.
+
+`skill-creator`'s eval/benchmark machinery is the right tool when a
+skill ships at scale: diverse phrasings from many users mean trigger
+accuracy is hard to verify by reading, mis-fires happen in sessions
+you don't observe, and a 20-query eval run pays for itself in reduced
+regressions. The `run_loop.py` description optimizer makes sense when
+you genuinely can't tell whether a wording change improves accuracy
+without measuring it.
+
+None of those conditions apply here. This repo is a single-user skill
+catalog — each stow clone is independent, mis-fires are observed in
+the same session, and the description can be tuned by reading and
+testing directly. The skill set is small and curated. `skill-review`'s
+deterministic checklist (`check-skill-length.sh` at 200 lines,
+`require-skill-review.sh` at commit) already provides stronger
+pre-commit signal than probabilistic evals for this workflow.
+
+`skill-creator`'s body also conflicts with this repo's conventions in
+two concrete places: it advocates 500-line skill bodies (its L92,
+L96), while `check-skill-length.sh` caps at 200; and it uses a
+conversational, first-person voice ("Cool? Cool.") that `skill-review`
+explicitly rejects in favor of imperative second-person. Keeping it
+enabled would present contradictory authoring guidance every time a
+skill was edited.
+
+This decision mirrors the reasoning behind the no-CI-eval-harness
+policy recorded in `feedback_ci_eval_harness_tradeoffs.md` — the same
+`claude -p` evaluation loop shape was rejected for CI on security,
+budget, and flakiness grounds. The local equivalent shares those
+tradeoffs.
+
+**Mechanism:** the `skill-creator@claude-plugins-official` entry is
+removed from `enabledPlugins` in `settings.json` entirely — not set to
+`false`. In this repo, `false` entries are quick-flip handles for
+plugins the user might want to enable for an occasional session;
+removing the entry means there's no foreseeable re-enable use case.
+`claude-md-management` and `claude-code-setup` retain their `false`
+entries as flip handles. If a future contribution to a broadly-shipped
+skill requires quantified trigger-accuracy work, add
+`"skill-creator@claude-plugins-official": true` back to `enabledPlugins`
+for that session.

--- a/claude/.claude/skills/skill-review/REFERENCES.md
+++ b/claude/.claude/skills/skill-review/REFERENCES.md
@@ -37,19 +37,11 @@ explicitly rejects in favor of imperative second-person. Keeping it
 enabled would present contradictory authoring guidance every time a
 skill was edited.
 
-This decision mirrors the reasoning behind the no-CI-eval-harness
-policy recorded in `feedback_ci_eval_harness_tradeoffs.md` — the same
-`claude -p` evaluation loop shape was rejected for CI on security,
-budget, and flakiness grounds. The local equivalent shares those
-tradeoffs.
-
 **Mechanism:** the `skill-creator@claude-plugins-official` entry is
 removed from `enabledPlugins` in `settings.json` entirely — not set to
 `false`. In this repo, `false` entries are quick-flip handles for
 plugins the user might want to enable for an occasional session;
 removing the entry means there's no foreseeable re-enable use case.
-`claude-md-management` and `claude-code-setup` retain their `false`
-entries as flip handles. If a future contribution to a broadly-shipped
-skill requires quantified trigger-accuracy work, add
-`"skill-creator@claude-plugins-official": true` back to `enabledPlugins`
-for that session.
+If a future contribution to a broadly-shipped skill requires quantified
+trigger-accuracy work, add `"skill-creator@claude-plugins-official": true`
+back to `enabledPlugins` for that session.


### PR DESCRIPTION
## Summary

- Removes `skill-creator@claude-plugins-official` from `enabledPlugins` entirely (not set to `false` — no quick-flip handle warranted; see rationale below)
- Creates `claude/.claude/skills/skill-review/REFERENCES.md` capturing why the eval/benchmark machinery doesn't fit this setup
- Updates README.md L11 to accurately describe the plugin stance (marketplace wired in, all official plugins disabled by default)

## Why this is a removal, not a `false` entry

In this repo, `enabledPlugins: false` entries are quick-flip handles — kept for plugins the user might want to re-enable for an occasional session. `skill-creator` has no foreseeable re-enable use case for a single-user skill catalog with deterministic `/skill-review` enforcement, so the entry is removed. `claude-md-management` and `claude-code-setup` retain their `false` handles.

## Stow blast radius

`claude/.claude/settings.json` is stow-distributed. This disables `skill-creator` for any user who clones and stows the repo. Downstream stow users who want it back can add `"skill-creator@claude-plugins-official": true` to their own `enabledPlugins`.

## Test plan

- [x] `python3 -c 'import json; json.load(open("claude/.claude/settings.json"))'` — JSON valid
- [x] `pytest claude/.claude/` — 512 passed (including `test_do_not_trigger_names_adjacent_skill[skill-review-skill-creator]` — test depends on naming not enablement, passes unchanged)
- [ ] Open a fresh Claude Code session, prompt "create a new skill for X" — `skill-creator` should not auto-invoke

🤖 Generated with [Claude Code](https://claude.ai/claude-code)