### PR TITLE
feat: replace inline marker recipes with marker.sh script

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Utility scripts in `claude/.claude/scripts/` (stowed to `~/.claude/scripts/`).
 **First-time setup:** after pulling this repo for the first time, make scripts executable:
 
 ```bash
-chmod +x ~/.claude/scripts/*.py
+chmod +x ~/.claude/scripts/*
 ```
 
 - **`analyze-context.py`** — inspect context window growth for a Claude Code session. Reads `~/.claude/projects/<project>/<session>.jsonl` and `~/.claude/usage-data/session-meta/` locally; no network calls, no writes.
@@ -195,6 +195,8 @@ chmod +x ~/.claude/scripts/*.py
   ~/.claude/scripts/token-analyzer.py             # all-time
   ~/.claude/scripts/token-analyzer.py --since 7d  # include token activity from the last N days (e.g. 2d, 7d)
   ```
+
+- **`marker.sh`** — write and remove review markers on behalf of workflow skills. `/code-review`, `/skill-review`, `/plan-review`, `/ready-for-review`, and `/respond-pr` write review markers via `~/.claude/scripts/marker.sh`. The 10 valid invocation shapes are allowlisted in `settings.json` for silent auto-approval. A companion `enforce-marker-script-shape.sh` hook denies any other invocation (chains, env-var prefixes, redirects) to prevent prompt-injection escalation via the allowlist.
 
 ## Worktree enforcement
 

--- a/claude/.claude/hooks/enforce-marker-script-shape.sh
+++ b/claude/.claude/hooks/enforce-marker-script-shape.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Gate: enforce strict invocation shape for ~/.claude/scripts/marker.sh.
+#
+# Fail posture: fail-closed — if jq cannot parse the input, deny.
+#
+# WARNING: Do NOT remove the internal marker.sh check below.
+# The "if" field in settings.json is unreliable — it has been observed
+# to fire this hook on ALL Bash commands. The internal grep is the actual
+# gate. The "if" field is a hint only.
+#
+# Any Bash command containing "marker.sh" must be one of the 10 valid
+# invocation shapes exactly. No chains, no env-var prefixes, no redirects,
+# no bash wrappers, no extra args. This prevents prompt-injection attacks
+# that chain marker.sh invocations with malicious commands and rely on the
+# settings.json allowlist to approve the first segment.
+set -uo pipefail
+
+INPUT=$(cat)
+COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+JQ_EXIT=$?
+
+if [ "$JQ_EXIT" -ne 0 ]; then
+  REASON_JSON='"Blocked: could not parse tool-input JSON."'
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' "$REASON_JSON"
+  exit 0
+fi
+
+# Fast-exit: no opinion on commands that don't involve marker.sh
+if ! printf '%s' "$COMMAND" | grep -qF 'marker.sh'; then
+  exit 0
+fi
+
+# Strip leading/trailing whitespace
+TRIMMED=$(printf '%s' "$COMMAND" | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//')
+
+# Strict allowlist. Tilde form (~/.claude/scripts/marker.sh) and absolute
+# path form (/home/<user>/.claude/scripts/marker.sh) are both accepted.
+# No bash wrapper, no env-var prefix, no chain operator, no redirect, no
+# extra args after the skill name.
+VALID_PATTERN='^(~|/[A-Za-z0-9_./-]+)/\.claude/scripts/marker\.sh[[:space:]]+(write[[:space:]]+(code-review|skill-review|plan-review|ready-for-review)|(activate|deactivate)[[:space:]]+(plan-review|ready-for-review|respond-pr))[[:space:]]*$'
+
+if printf '%s' "$TRIMMED" | grep -qE "$VALID_PATTERN"; then
+  exit 0
+fi
+
+# Deny. Truncate to 80 chars to avoid echoing attacker-controlled bytes verbatim.
+TRUNCATED=$(printf '%s' "$TRIMMED" | cut -c1-80)
+REASON="marker.sh invocation denied. Command (truncated): $TRUNCATED
+
+Valid shapes:
+  ~/.claude/scripts/marker.sh write code-review
+  ~/.claude/scripts/marker.sh write skill-review
+  ~/.claude/scripts/marker.sh write plan-review
+  ~/.claude/scripts/marker.sh write ready-for-review
+  ~/.claude/scripts/marker.sh activate plan-review
+  ~/.claude/scripts/marker.sh activate ready-for-review
+  ~/.claude/scripts/marker.sh activate respond-pr
+  ~/.claude/scripts/marker.sh deactivate plan-review
+  ~/.claude/scripts/marker.sh deactivate ready-for-review
+  ~/.claude/scripts/marker.sh deactivate respond-pr
+
+No chains (&&, ||, ;), env-var prefixes, bash wrappers, redirects, or extra args."
+REASON_JSON=$(printf '%s' "$REASON" | jq -Rs .)
+printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' "$REASON_JSON"

--- a/claude/.claude/hooks/enforce-marker-script-shape.sh
+++ b/claude/.claude/hooks/enforce-marker-script-shape.sh
@@ -33,6 +33,17 @@ fi
 # Strip leading/trailing whitespace
 TRIMMED=$(printf '%s' "$COMMAND" | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//')
 
+# Reject path traversal sequences before the allowlist check. The VALID_PATTERN
+# character class permits '.' and '/', which together admit '../' segments.
+# An explicit '..' pre-check closes that gap cleanly.
+if printf '%s' "$TRIMMED" | grep -qF '..'; then
+  TRUNCATED=$(printf '%s' "$TRIMMED" | cut -c1-80)
+  REASON="marker.sh invocation denied (path traversal '..' detected). Command (truncated): $TRUNCATED"
+  REASON_JSON=$(printf '%s' "$REASON" | jq -Rs .)
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' "$REASON_JSON"
+  exit 0
+fi
+
 # Strict allowlist. Tilde form (~/.claude/scripts/marker.sh) and absolute
 # path form (/home/<user>/.claude/scripts/marker.sh) are both accepted.
 # No bash wrapper, no env-var prefix, no chain operator, no redirect, no

--- a/claude/.claude/hooks/require-code-review.sh
+++ b/claude/.claude/hooks/require-code-review.sh
@@ -25,28 +25,6 @@
 # - The marker auto-invalidates as soon as the staging area changes, so
 #   re-staging after review correctly forces a re-review.
 
-# When the command shows a redirect (`>`) into a path containing
-# `review-markers` chained before `git commit`, the agent likely
-# chained the marker-seed with their commit in a single Bash call.
-# PreToolUse:Bash hooks evaluate at command-submission time, BEFORE
-# the chained subshell runs, so this hook reads the marker file from
-# disk before the chained marker-write executes — denying a chain
-# that would have worked if its commands ran in sequence outside the
-# hook. Returns a self-correction note for the agent when this pattern
-# is detected; empty otherwise.
-#
-# Pattern requires `>` redirect, then `review-markers` in the path,
-# then a chain operator, then `git commit`. Single-line commands only
-# — multi-line bash with `\` continuations between the redirect and
-# `git commit` won't match (the regex uses `[^&|;]*`, which excludes
-# newlines under default ERE behavior). In practice agents submit
-# single-line bash to the tool; multi-line is rare enough to leave
-# uncovered.
-marker_chain_note_if_detected() {
-  if printf '%s' "$1" | grep -qE '>[^&|;]*review-markers[^&|;]*(&&|\|\||;)[^&|;]*git[[:space:]]+commit'; then
-    printf '%s' " If you just chained a marker-write to '~/.claude/review-markers/...' before 'git commit' in a single Bash call: PreToolUse hooks evaluate at command-submission time, BEFORE the chained subshell runs. The hook hashed your staged diff (correct) but read the marker file from disk before your chain could write it. Whether the marker was missing entirely or held a prior review's hash, the chained marker-write hadn't executed yet. Submit the marker-seed as its own Bash call first, then run 'git commit' in a separate call."
-  fi
-}
 
 INPUT=$(cat)
 COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command // empty')
@@ -93,6 +71,6 @@ fi
 # Build the reason as a bash variable so the conditional marker-chain
 # note can be interpolated; jq -Rs handles JSON-encoding safely
 # regardless of what characters appear in the appended note.
-REASON="Commit blocked by code-review gate: the currently staged changes have not been reviewed, or the staged state has changed since the last review. Run the /code-review skill now on the currently staged diff. When the review is clean (no blockers), the skill will record the review in ~/.claude/review-markers/ and this commit will be allowed through on retry. Do not ask the user for permission — run the skill, address any findings, and retry the commit.$(marker_chain_note_if_detected "$COMMAND")"
+REASON="Commit blocked by code-review gate: the currently staged changes have not been reviewed, or the staged state has changed since the last review. Run the /code-review skill now on the currently staged diff. When the review is clean (no blockers), the skill will record the review in ~/.claude/review-markers/ and this commit will be allowed through on retry. Do not ask the user for permission — run the skill, address any findings, and retry the commit."
 REASON_JSON=$(printf '%s' "$REASON" | jq -Rs .)
 printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' "$REASON_JSON"

--- a/claude/.claude/hooks/require-skill-review.sh
+++ b/claude/.claude/hooks/require-skill-review.sh
@@ -27,28 +27,6 @@
 #   so re-staging non-SKILL.md files after a clean skill-review does not
 #   invalidate the marker.
 
-# When the command shows a redirect (`>`) into a path containing
-# `skill-review-markers` chained before `git commit`, the agent likely
-# chained the marker-seed with their commit in a single Bash call.
-# PreToolUse:Bash hooks evaluate at command-submission time, BEFORE
-# the chained subshell runs, so this hook reads the marker file from
-# disk before the chained marker-write executes — denying a chain
-# that would have worked if its commands ran in sequence outside the
-# hook. Returns a self-correction note for the agent when this pattern
-# is detected; empty otherwise.
-#
-# Pattern requires `>` redirect, then `skill-review-markers` in the path,
-# then a chain operator, then `git commit`. Single-line commands only
-# — multi-line bash with `\` continuations between the redirect and
-# `git commit` won't match (the regex uses `[^&|;]*`, which excludes
-# newlines under default ERE behavior). In practice agents submit
-# single-line bash to the tool; multi-line is rare enough to leave
-# uncovered.
-marker_chain_note_if_detected() {
-  if printf '%s' "$1" | grep -qE '>[^&|;]*skill-review-markers[^&|;]*(&&|\|\||;)[^&|;]*git[[:space:]]+commit'; then
-    printf '%s' " If you just chained a marker-write to '~/.claude/skill-review-markers/...' before 'git commit' in a single Bash call: PreToolUse hooks evaluate at command-submission time, BEFORE the chained subshell runs. The hook hashed your staged diff (correct) but read the marker file from disk before your chain could write it. Whether the marker was missing entirely or held a prior review's hash, the chained marker-write hadn't executed yet. Submit the marker-seed as its own Bash call first, then run 'git commit' in a separate call."
-  fi
-}
 
 INPUT=$(cat)
 COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command // empty')
@@ -102,6 +80,6 @@ fi
 # Build the reason as a bash variable so the conditional marker-chain
 # note can be interpolated; jq -Rs handles JSON-encoding safely
 # regardless of what characters appear in the appended note.
-REASON="Commit blocked by skill-review gate: Staged skill changes have not been audited by /skill-review. Run /skill-review on the staged SKILL.md diff; the skill must produce an explicit behavioral-equivalence table for any removed or shortened lines before committing.$(marker_chain_note_if_detected "$COMMAND")"
+REASON="Commit blocked by skill-review gate: Staged skill changes have not been audited by /skill-review. Run /skill-review on the staged SKILL.md diff; the skill must produce an explicit behavioral-equivalence table for any removed or shortened lines before committing."
 REASON_JSON=$(printf '%s' "$REASON" | jq -Rs .)
 printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' "$REASON_JSON"

--- a/claude/.claude/hooks/tests/helpers.py
+++ b/claude/.claude/hooks/tests/helpers.py
@@ -15,6 +15,7 @@ from pathlib import Path
 HOOKS_DIR = Path(__file__).resolve().parent.parent
 
 SKILLS_DIR = HOOKS_DIR.parent / "skills"
+SCRIPTS_DIR = HOOKS_DIR.parent / "scripts"
 
 # SKILL.md fences may be indented when the fixture sits inside a
 # numbered list (e.g. respond-pr's "0. **Enable hook bypass.**"). The
@@ -247,6 +248,11 @@ def write_plan_review_routing_read_marker(home: Path, session_id: str) -> Path:
 
 def run_skill_command(command: str, cwd: Path, isolated_home: Path) -> None:
     """Run a SKILL.md-extracted bash command in a sandboxed $HOME."""
+    scripts_dir = isolated_home / ".claude" / "scripts"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    marker_link = scripts_dir / "marker.sh"
+    if not marker_link.exists():
+        marker_link.symlink_to(SCRIPTS_DIR / "marker.sh")
     subprocess.run(
         ["bash", "-c", command],
         cwd=cwd,

--- a/claude/.claude/hooks/tests/test_enforce_marker_script_shape.py
+++ b/claude/.claude/hooks/tests/test_enforce_marker_script_shape.py
@@ -138,3 +138,7 @@ class TestEnforceMarkerScriptShape:
     def test_relative_path_denied(self):
         cmd = "./marker.sh write code-review"
         assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "deny"
+
+    def test_path_traversal_denied(self):
+        cmd = "/home/evil/../../home/jared/.claude/scripts/marker.sh write code-review"
+        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "deny"

--- a/claude/.claude/hooks/tests/test_enforce_marker_script_shape.py
+++ b/claude/.claude/hooks/tests/test_enforce_marker_script_shape.py
@@ -1,0 +1,140 @@
+"""Tests for enforce-marker-script-shape.sh."""
+from __future__ import annotations
+
+import pytest
+from helpers import (
+    HOOKS_DIR,
+    bash_input,
+    run_hook,
+)
+
+ENFORCE_MARKER_SCRIPT_SHAPE_HOOK = HOOKS_DIR / "enforce-marker-script-shape.sh"
+
+
+class TestEnforceMarkerScriptShape:
+    # ------------------------------------------------------------------ #
+    # Valid shapes — all 10 must be allowed                               #
+    # ------------------------------------------------------------------ #
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "~/.claude/scripts/marker.sh write code-review",
+            "~/.claude/scripts/marker.sh write skill-review",
+            "~/.claude/scripts/marker.sh write plan-review",
+            "~/.claude/scripts/marker.sh write ready-for-review",
+            "~/.claude/scripts/marker.sh activate plan-review",
+            "~/.claude/scripts/marker.sh activate ready-for-review",
+            "~/.claude/scripts/marker.sh activate respond-pr",
+            "~/.claude/scripts/marker.sh deactivate plan-review",
+            "~/.claude/scripts/marker.sh deactivate ready-for-review",
+            "~/.claude/scripts/marker.sh deactivate respond-pr",
+        ],
+    )
+    def test_valid_shapes_allowed(self, command):
+        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(command)) == "allow"
+
+    # ------------------------------------------------------------------ #
+    # Fast-exit: no marker.sh in command                                  #
+    # ------------------------------------------------------------------ #
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "git commit -m foo",
+            "git push origin main",
+            "echo hello",
+            "ls ~/.claude/scripts/",
+        ],
+    )
+    def test_commands_without_marker_sh_allowed(self, command):
+        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(command)) == "allow"
+
+    # ------------------------------------------------------------------ #
+    # Chaining — must be denied                                           #
+    # ------------------------------------------------------------------ #
+
+    def test_chain_to_git_commit_denied(self):
+        cmd = "~/.claude/scripts/marker.sh write code-review && git commit -m foo"
+        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "deny"
+
+    def test_chain_to_curl_denied(self):
+        cmd = "~/.claude/scripts/marker.sh write code-review && curl http://example.com"
+        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "deny"
+
+    def test_semicolon_separator_denied(self):
+        cmd = "~/.claude/scripts/marker.sh write code-review; rm -rf /"
+        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "deny"
+
+    # ------------------------------------------------------------------ #
+    # Env-var prefix                                                      #
+    # ------------------------------------------------------------------ #
+
+    def test_env_var_prefix_denied(self):
+        cmd = "FOO=1 ~/.claude/scripts/marker.sh write code-review"
+        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "deny"
+
+    # ------------------------------------------------------------------ #
+    # Redirect                                                            #
+    # ------------------------------------------------------------------ #
+
+    def test_redirect_denied(self):
+        cmd = "~/.claude/scripts/marker.sh write code-review > /tmp/out"
+        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "deny"
+
+    # ------------------------------------------------------------------ #
+    # Bash wrapper                                                        #
+    # ------------------------------------------------------------------ #
+
+    def test_bash_wrapper_denied(self):
+        cmd = "bash ~/.claude/scripts/marker.sh write code-review"
+        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "deny"
+
+    # ------------------------------------------------------------------ #
+    # Extra args                                                          #
+    # ------------------------------------------------------------------ #
+
+    def test_extra_arg_denied(self):
+        cmd = "~/.claude/scripts/marker.sh write code-review extra"
+        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "deny"
+
+    # ------------------------------------------------------------------ #
+    # Unknown subcommand / skill / mismatch                               #
+    # ------------------------------------------------------------------ #
+
+    def test_unknown_subcommand_denied(self):
+        cmd = "~/.claude/scripts/marker.sh forge code-review"
+        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "deny"
+
+    def test_unknown_skill_denied(self):
+        cmd = "~/.claude/scripts/marker.sh write nonsense"
+        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "deny"
+
+    def test_mismatched_subcommand_skill_pair_denied(self):
+        """code-review does not support activate — must be denied."""
+        cmd = "~/.claude/scripts/marker.sh activate code-review"
+        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "deny"
+
+    # ------------------------------------------------------------------ #
+    # Bare script (no args)                                               #
+    # ------------------------------------------------------------------ #
+
+    def test_bare_script_denied(self):
+        cmd = "~/.claude/scripts/marker.sh"
+        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "deny"
+
+    # ------------------------------------------------------------------ #
+    # Absolute path form                                                  #
+    # ------------------------------------------------------------------ #
+
+    def test_absolute_path_form_allowed(self):
+        cmd = "/home/jared/.claude/scripts/marker.sh write code-review"
+        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "allow"
+
+    # ------------------------------------------------------------------ #
+    # Relative path — must be denied                                      #
+    # ------------------------------------------------------------------ #
+
+    def test_relative_path_denied(self):
+        cmd = "./marker.sh write code-review"
+        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "deny"

--- a/claude/.claude/hooks/tests/test_marker_script.py
+++ b/claude/.claude/hooks/tests/test_marker_script.py
@@ -1,0 +1,100 @@
+"""Tests for claude/.claude/scripts/marker.sh."""
+from __future__ import annotations
+
+import os
+import subprocess
+
+import pytest
+from helpers import SCRIPTS_DIR
+
+MARKER_SCRIPT = SCRIPTS_DIR / "marker.sh"
+
+
+def _run(args: list[str], cwd, home) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(MARKER_SCRIPT)] + args,
+        cwd=cwd,
+        env={**os.environ, "HOME": str(home)},
+        capture_output=True,
+        text=True,
+    )
+
+
+class TestMarkerScriptSessionMissing:
+    """When the session file ($HOME/.claude/sessions/$PPID) does not exist,
+    every write/activate/deactivate subcommand must exit 2 and write nothing.
+    This guards against the silent-empty-suffix regression: without explicit
+    || exit 2 on the command-substitution call sites, exit 2 inside
+    _resolve_session_id() only exits the subshell — the parent continues and
+    writes a malformed marker with an empty session-id suffix."""
+
+    @pytest.mark.parametrize(
+        "args",
+        [
+            ["write", "code-review"],
+            ["write", "skill-review"],
+            ["write", "plan-review"],
+            ["write", "ready-for-review"],
+            ["activate", "plan-review"],
+            ["activate", "ready-for-review"],
+            ["activate", "respond-pr"],
+            ["deactivate", "plan-review"],
+            ["deactivate", "ready-for-review"],
+            ["deactivate", "respond-pr"],
+        ],
+    )
+    def test_exits_2_when_session_file_missing(self, isolated_home, git_repo, args):
+        result = _run(args, cwd=git_repo, home=isolated_home)
+        assert result.returncode == 2, (
+            f"marker.sh {' '.join(args)} should exit 2 when session file is absent, "
+            f"got {result.returncode}. stderr: {result.stderr!r}"
+        )
+
+    def test_no_marker_written_when_session_file_missing(self, isolated_home, git_repo):
+        _run(["write", "code-review"], cwd=git_repo, home=isolated_home)
+        marker_dir = isolated_home / ".claude" / "review-markers"
+        stray = list(marker_dir.iterdir()) if marker_dir.exists() else []
+        assert stray == [], (
+            f"marker.sh wrote a stray marker when session file was absent: {stray}"
+        )
+
+
+class TestMarkerScriptHappyPath:
+    """Smoke-test that each subcommand writes/removes the expected file when
+    the session file is present."""
+
+    def _seed_session(self, home):
+        sessions_dir = home / ".claude" / "sessions"
+        sessions_dir.mkdir(parents=True, exist_ok=True)
+        sid = "test-session-abc"
+        (sessions_dir / str(os.getpid())).write_text(sid)
+        return sid
+
+    def test_write_code_review_creates_marker(self, isolated_home, git_repo):
+        sid = self._seed_session(isolated_home)
+        result = _run(["write", "code-review"], cwd=git_repo, home=isolated_home)
+        assert result.returncode == 0, result.stderr
+        marker_dir = isolated_home / ".claude" / "review-markers"
+        files = list(marker_dir.iterdir())
+        assert len(files) == 1
+        assert files[0].name.endswith(f".{sid}")
+
+    def test_activate_creates_active_marker(self, isolated_home, git_repo):
+        sid = self._seed_session(isolated_home)
+        result = _run(["activate", "plan-review"], cwd=git_repo, home=isolated_home)
+        assert result.returncode == 0, result.stderr
+        active_file = isolated_home / ".claude" / ".plan-review-active.d" / sid
+        assert active_file.exists()
+
+    def test_deactivate_removes_active_marker(self, isolated_home, git_repo):
+        sid = self._seed_session(isolated_home)
+        active_dir = isolated_home / ".claude" / ".plan-review-active.d"
+        active_dir.mkdir(parents=True)
+        (active_dir / sid).touch()
+        result = _run(["deactivate", "plan-review"], cwd=git_repo, home=isolated_home)
+        assert result.returncode == 0, result.stderr
+        assert not (active_dir / sid).exists()
+
+    def test_help_exits_0(self, isolated_home, git_repo):
+        result = _run(["--help"], cwd=git_repo, home=isolated_home)
+        assert result.returncode == 0

--- a/claude/.claude/hooks/tests/test_require_code_review.py
+++ b/claude/.claude/hooks/tests/test_require_code_review.py
@@ -14,7 +14,6 @@ from helpers import (
     extract_skill_command,
     marker_path,
     run_hook,
-    run_hook_reason,
     run_skill_command,
     staged_diff_hash,
     write_marker,
@@ -226,68 +225,3 @@ class TestRequireCodeReview:
         non_repo.mkdir()
         assert run_hook(CODE_REVIEW_HOOK, bash_input("git commit -m foo"), cwd=non_repo) == "allow"
 
-    # The marker-chain note is appended to the deny reason ONLY when
-    # the command shows a redirect into ~/.claude/review-markers/...
-    # chained before `git commit`. This is the precise failure mode
-    # where the agent chains marker-seed && git commit in one Bash
-    # call: PreToolUse hooks fire before the chained subshell runs,
-    # so the hook reads the marker file from disk before the chained
-    # marker-write executes. Three positive cases (each chain
-    # operator), two negative cases (plain commit, and commit message
-    # mentioning `review-markers` literally), and one realistic case
-    # using the canonical marker-recipe shape from SKILL.md.
-
-    def test_chained_marker_amp_commit_appends_note(self, isolated_home, git_repo):
-        cmd = "echo abc > ~/.claude/review-markers/foo.bar && git commit -m work"
-        reason = run_hook_reason(CODE_REVIEW_HOOK, bash_input(cmd), cwd=git_repo)
-        assert reason is not None
-        assert "PreToolUse hooks evaluate" in reason
-        assert "Submit the marker-seed as its own Bash call" in reason
-
-    def test_chained_marker_semicolon_commit_appends_note(self, isolated_home, git_repo):
-        cmd = "echo abc > ~/.claude/review-markers/foo.bar ; git commit -m work"
-        reason = run_hook_reason(CODE_REVIEW_HOOK, bash_input(cmd), cwd=git_repo)
-        assert reason is not None
-        assert "PreToolUse hooks evaluate" in reason
-
-    def test_chained_marker_or_commit_appends_note(self, isolated_home, git_repo):
-        """`||` chain (run-if-fail) is unusual but parses the same way —
-        note still appended so the agent gets the hint."""
-        cmd = "echo abc > ~/.claude/review-markers/foo.bar || git commit -m work"
-        reason = run_hook_reason(CODE_REVIEW_HOOK, bash_input(cmd), cwd=git_repo)
-        assert reason is not None
-        assert "PreToolUse hooks evaluate" in reason
-
-    def test_plain_commit_no_marker_chain_note(self, isolated_home, git_repo):
-        """No chained redirect → note not appended; deny stays compact."""
-        reason = run_hook_reason(CODE_REVIEW_HOOK, bash_input("git commit -m foo"), cwd=git_repo)
-        assert reason is not None
-        assert "PreToolUse hooks evaluate" not in reason
-        assert "Submit the marker-seed" not in reason
-
-    def test_review_markers_in_commit_message_no_note(self, isolated_home, git_repo):
-        """Commit message mentioning `review-markers` literally must NOT
-        trigger the note — pattern requires `>` redirect *before* git commit,
-        which this command doesn't have. Critical false-positive guard."""
-        cmd = 'git commit -m "fix review-markers leak"'
-        reason = run_hook_reason(CODE_REVIEW_HOOK, bash_input(cmd), cwd=git_repo)
-        assert reason is not None
-        assert "PreToolUse hooks evaluate" not in reason
-
-    def test_canonical_marker_recipe_chained_with_commit_appends_note(self, isolated_home, git_repo):
-        """Realistic positive case: the actual canonical marker-seed recipe
-        from SKILL.md (multi-step pipeline ending in a redirect to a
-        review-markers path) chained to `git commit`. This mirrors the
-        exact shape an agent would produce by following the documented
-        recipe and then chaining their commit, which is the failure
-        mode the gate exists to teach against."""
-        cmd = (
-            'SESSION_ID=abc && mkdir -p ~/.claude/review-markers && '
-            'REPO_HASH=$(git rev-parse --show-toplevel | tr -d "\\n" | sha256sum | awk \'{print $1}\') && '
-            'git diff --cached | sha256sum | awk \'{print $1}\' '
-            '> ~/.claude/review-markers/$REPO_HASH.$SESSION_ID && '
-            'git commit -m "work"'
-        )
-        reason = run_hook_reason(CODE_REVIEW_HOOK, bash_input(cmd), cwd=git_repo)
-        assert reason is not None
-        assert "PreToolUse hooks evaluate" in reason

--- a/claude/.claude/hooks/tests/test_require_skill_review.py
+++ b/claude/.claude/hooks/tests/test_require_skill_review.py
@@ -13,7 +13,6 @@ from helpers import (
     edit_input,
     extract_skill_command,
     run_hook,
-    run_hook_reason,
     run_skill_command,
     skill_review_marker_path,
     write_skill_review_marker,
@@ -257,78 +256,6 @@ class TestRequireSkillReview:
         non_repo = tmp_path / "not-a-repo"
         non_repo.mkdir()
         assert run_hook(SKILL_REVIEW_HOOK, bash_input("git commit -m foo"), cwd=non_repo) == "allow"
-
-    # The marker-chain note is appended to the deny reason ONLY when
-    # the command shows a redirect into ~/.claude/skill-review-markers/...
-    # chained before `git commit`. This is the precise failure mode
-    # where the agent chains marker-seed && git commit in one Bash
-    # call: PreToolUse hooks fire before the chained subshell runs,
-    # so the hook reads the marker file from disk before the chained
-    # marker-write executes. Three positive cases (each chain
-    # operator), two negative cases (plain commit, and commit message
-    # mentioning `skill-review-markers` literally), and one realistic case
-    # using the canonical marker-recipe shape from SKILL.md.
-
-    def test_chained_marker_amp_commit_appends_note(self, isolated_home, git_repo):
-        _stage_skill_change(git_repo)
-        cmd = "echo abc > ~/.claude/skill-review-markers/foo.bar && git commit -m work"
-        reason = run_hook_reason(SKILL_REVIEW_HOOK, bash_input(cmd), cwd=git_repo)
-        assert reason is not None
-        assert "PreToolUse hooks evaluate" in reason
-        assert "Submit the marker-seed as its own Bash call" in reason
-
-    def test_chained_marker_semicolon_commit_appends_note(self, isolated_home, git_repo):
-        _stage_skill_change(git_repo)
-        cmd = "echo abc > ~/.claude/skill-review-markers/foo.bar ; git commit -m work"
-        reason = run_hook_reason(SKILL_REVIEW_HOOK, bash_input(cmd), cwd=git_repo)
-        assert reason is not None
-        assert "PreToolUse hooks evaluate" in reason
-
-    def test_chained_marker_or_commit_appends_note(self, isolated_home, git_repo):
-        """`||` chain (run-if-fail) is unusual but parses the same way —
-        note still appended so the agent gets the hint."""
-        _stage_skill_change(git_repo)
-        cmd = "echo abc > ~/.claude/skill-review-markers/foo.bar || git commit -m work"
-        reason = run_hook_reason(SKILL_REVIEW_HOOK, bash_input(cmd), cwd=git_repo)
-        assert reason is not None
-        assert "PreToolUse hooks evaluate" in reason
-
-    def test_plain_commit_no_marker_chain_note(self, isolated_home, git_repo):
-        """No chained redirect → note not appended; deny stays compact."""
-        _stage_skill_change(git_repo)
-        reason = run_hook_reason(SKILL_REVIEW_HOOK, bash_input("git commit -m foo"), cwd=git_repo)
-        assert reason is not None
-        assert "PreToolUse hooks evaluate" not in reason
-        assert "Submit the marker-seed" not in reason
-
-    def test_skill_review_markers_in_commit_message_no_note(self, isolated_home, git_repo):
-        """Commit message mentioning `skill-review-markers` literally must NOT
-        trigger the note — pattern requires `>` redirect *before* git commit,
-        which this command doesn't have. Critical false-positive guard."""
-        _stage_skill_change(git_repo)
-        cmd = 'git commit -m "fix skill-review-markers leak"'
-        reason = run_hook_reason(SKILL_REVIEW_HOOK, bash_input(cmd), cwd=git_repo)
-        assert reason is not None
-        assert "PreToolUse hooks evaluate" not in reason
-
-    def test_canonical_marker_recipe_chained_with_commit_appends_note(self, isolated_home, git_repo):
-        """Realistic positive case: the actual canonical marker-seed recipe
-        from SKILL.md (multi-step pipeline ending in a redirect to a
-        skill-review-markers path) chained to `git commit`. This mirrors the
-        exact shape an agent would produce by following the documented
-        recipe and then chaining their commit, which is the failure
-        mode the gate exists to teach against."""
-        _stage_skill_change(git_repo)
-        cmd = (
-            'SESSION_ID=abc && mkdir -p ~/.claude/skill-review-markers && '
-            'REPO_HASH=$(git rev-parse --show-toplevel | tr -d "\\n" | sha256sum | awk \'{print $1}\') && '
-            'git diff --cached -- \'claude/.claude/skills/**/SKILL.md\' | sha256sum | awk \'{print $1}\' '
-            '> ~/.claude/skill-review-markers/$REPO_HASH.$SESSION_ID && '
-            'git commit -m "work"'
-        )
-        reason = run_hook_reason(SKILL_REVIEW_HOOK, bash_input(cmd), cwd=git_repo)
-        assert reason is not None
-        assert "PreToolUse hooks evaluate" in reason
 
     def test_no_skill_in_staged_diff_allows(self, git_repo, isolated_home):
         """Commits that don't touch any SKILL.md are never gated."""

--- a/claude/.claude/scripts/marker.sh
+++ b/claude/.claude/scripts/marker.sh
@@ -41,6 +41,11 @@ _resolve_repo_hash() {
   git rev-parse --show-toplevel | tr -d '\n' | sha256sum | awk '{print $1}'
 }
 
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+  usage
+  exit 0
+fi
+
 if [ $# -ne 2 ]; then
   usage
   exit 2
@@ -129,10 +134,6 @@ case "$SUBCOMMAND" in
         exit 2
         ;;
     esac
-    ;;
-  --help|-h)
-    usage
-    exit 0
     ;;
   *)
     printf "marker.sh: unknown subcommand '%s'\n" "$SUBCOMMAND" >&2

--- a/claude/.claude/scripts/marker.sh
+++ b/claude/.claude/scripts/marker.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+# Write or remove review markers for Claude Code workflow skills.
+# Called from SKILL.md HOOK_TEST_FIXTURE fenced blocks.
+# Usage: marker.sh <write|activate|deactivate> <skill>
+set -u
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: ~/.claude/scripts/marker.sh <subcommand> <skill>
+
+Subcommands:
+  write      Write a completion marker for the given skill
+  activate   Write an active-bypass marker for the given skill
+  deactivate Remove the active-bypass marker for the given skill
+
+Valid (subcommand, skill) combinations:
+  write       code-review | skill-review | plan-review | ready-for-review
+  activate    plan-review | ready-for-review | respond-pr
+  deactivate  plan-review | ready-for-review | respond-pr
+EOF
+}
+
+_resolve_session_id() {
+  local sid
+  sid=$(cat "$HOME/.claude/sessions/$PPID" 2>/dev/null)
+  if [ -z "$sid" ]; then
+    printf 'marker.sh: SESSION_ID empty — capture-session-id.sh SessionStart hook did not run. Abort without writing a marker.\n' >&2
+    exit 2
+  fi
+  printf '%s' "$sid"
+}
+
+_resolve_repo_hash() {
+  if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
+    printf 'marker.sh: not inside a git repository\n' >&2
+    exit 2
+  fi
+  # tr -d '\n' is load-bearing: git rev-parse appends a trailing newline.
+  # require-* hooks compute the hash via printf '%s' "$REPO_ROOT" (no newline),
+  # so both sides must strip it to produce the same sha256 and matching paths.
+  git rev-parse --show-toplevel | tr -d '\n' | sha256sum | awk '{print $1}'
+}
+
+if [ $# -ne 2 ]; then
+  usage
+  exit 2
+fi
+
+SUBCOMMAND="$1"
+SKILL="$2"
+
+case "$SUBCOMMAND" in
+  write)
+    case "$SKILL" in
+      code-review)
+        SESSION_ID=$(_resolve_session_id)
+        REPO_HASH=$(_resolve_repo_hash)
+        mkdir -p "$HOME/.claude/review-markers"
+        git diff --cached | sha256sum | awk '{print $1}' \
+          > "$HOME/.claude/review-markers/$REPO_HASH.$SESSION_ID"
+        ;;
+      skill-review)
+        SESSION_ID=$(_resolve_session_id)
+        REPO_HASH=$(_resolve_repo_hash)
+        mkdir -p "$HOME/.claude/skill-review-markers"
+        # The pathspec is load-bearing: scopes the hash to SKILL.md diffs only,
+        # matching what require-skill-review.sh checks at commit time.
+        git diff --cached -- 'claude/.claude/skills/**/SKILL.md' | sha256sum | awk '{print $1}' \
+          > "$HOME/.claude/skill-review-markers/$REPO_HASH.$SESSION_ID"
+        ;;
+      plan-review)
+        SESSION_ID=$(_resolve_session_id)
+        REPO_HASH=$(_resolve_repo_hash)
+        mkdir -p "$HOME/.claude/plan-review-markers"
+        printf 'reviewed\n' > "$HOME/.claude/plan-review-markers/$REPO_HASH.$SESSION_ID"
+        ;;
+      ready-for-review)
+        SESSION_ID=$(_resolve_session_id)
+        REPO_HASH=$(_resolve_repo_hash)
+        mkdir -p "$HOME/.claude/ready-for-review-markers"
+        git rev-parse HEAD > "$HOME/.claude/ready-for-review-markers/$REPO_HASH.$SESSION_ID"
+        ;;
+      *)
+        printf "marker.sh: 'write %s' is not valid. 'write' supports: code-review, skill-review, plan-review, ready-for-review\n" "$SKILL" >&2
+        exit 2
+        ;;
+    esac
+    ;;
+  activate)
+    case "$SKILL" in
+      plan-review)
+        SESSION_ID=$(_resolve_session_id)
+        mkdir -p "$HOME/.claude/.plan-review-active.d"
+        touch "$HOME/.claude/.plan-review-active.d/$SESSION_ID"
+        ;;
+      ready-for-review)
+        SESSION_ID=$(_resolve_session_id)
+        mkdir -p "$HOME/.claude/.ready-for-review-active.d"
+        touch "$HOME/.claude/.ready-for-review-active.d/$SESSION_ID"
+        ;;
+      respond-pr)
+        SESSION_ID=$(_resolve_session_id)
+        mkdir -p "$HOME/.claude/.respond-pr-active.d"
+        touch "$HOME/.claude/.respond-pr-active.d/$SESSION_ID"
+        ;;
+      *)
+        printf "marker.sh: 'activate %s' is not valid. 'activate' supports: plan-review, ready-for-review, respond-pr\n" "$SKILL" >&2
+        exit 2
+        ;;
+    esac
+    ;;
+  deactivate)
+    case "$SKILL" in
+      plan-review)
+        SESSION_ID=$(_resolve_session_id)
+        rm -f "$HOME/.claude/.plan-review-active.d/$SESSION_ID"
+        rm -f "$HOME/.claude/.plan-review-routing-read.d/$SESSION_ID"
+        ;;
+      ready-for-review)
+        SESSION_ID=$(_resolve_session_id)
+        rm -f "$HOME/.claude/.ready-for-review-active.d/$SESSION_ID"
+        ;;
+      respond-pr)
+        SESSION_ID=$(_resolve_session_id)
+        rm -f "$HOME/.claude/.respond-pr-active.d/$SESSION_ID"
+        ;;
+      *)
+        printf "marker.sh: 'deactivate %s' is not valid. 'deactivate' supports: plan-review, ready-for-review, respond-pr\n" "$SKILL" >&2
+        exit 2
+        ;;
+    esac
+    ;;
+  --help|-h)
+    usage
+    exit 0
+    ;;
+  *)
+    printf "marker.sh: unknown subcommand '%s'\n" "$SUBCOMMAND" >&2
+    usage
+    exit 2
+    ;;
+esac

--- a/claude/.claude/scripts/marker.sh
+++ b/claude/.claude/scripts/marker.sh
@@ -58,15 +58,15 @@ case "$SUBCOMMAND" in
   write)
     case "$SKILL" in
       code-review)
-        SESSION_ID=$(_resolve_session_id)
-        REPO_HASH=$(_resolve_repo_hash)
+        SESSION_ID=$(_resolve_session_id) || exit 2
+        REPO_HASH=$(_resolve_repo_hash) || exit 2
         mkdir -p "$HOME/.claude/review-markers"
         git diff --cached | sha256sum | awk '{print $1}' \
           > "$HOME/.claude/review-markers/$REPO_HASH.$SESSION_ID"
         ;;
       skill-review)
-        SESSION_ID=$(_resolve_session_id)
-        REPO_HASH=$(_resolve_repo_hash)
+        SESSION_ID=$(_resolve_session_id) || exit 2
+        REPO_HASH=$(_resolve_repo_hash) || exit 2
         mkdir -p "$HOME/.claude/skill-review-markers"
         # The pathspec is load-bearing: scopes the hash to SKILL.md diffs only,
         # matching what require-skill-review.sh checks at commit time.
@@ -74,14 +74,14 @@ case "$SUBCOMMAND" in
           > "$HOME/.claude/skill-review-markers/$REPO_HASH.$SESSION_ID"
         ;;
       plan-review)
-        SESSION_ID=$(_resolve_session_id)
-        REPO_HASH=$(_resolve_repo_hash)
+        SESSION_ID=$(_resolve_session_id) || exit 2
+        REPO_HASH=$(_resolve_repo_hash) || exit 2
         mkdir -p "$HOME/.claude/plan-review-markers"
         printf 'reviewed\n' > "$HOME/.claude/plan-review-markers/$REPO_HASH.$SESSION_ID"
         ;;
       ready-for-review)
-        SESSION_ID=$(_resolve_session_id)
-        REPO_HASH=$(_resolve_repo_hash)
+        SESSION_ID=$(_resolve_session_id) || exit 2
+        REPO_HASH=$(_resolve_repo_hash) || exit 2
         mkdir -p "$HOME/.claude/ready-for-review-markers"
         git rev-parse HEAD > "$HOME/.claude/ready-for-review-markers/$REPO_HASH.$SESSION_ID"
         ;;
@@ -94,17 +94,17 @@ case "$SUBCOMMAND" in
   activate)
     case "$SKILL" in
       plan-review)
-        SESSION_ID=$(_resolve_session_id)
+        SESSION_ID=$(_resolve_session_id) || exit 2
         mkdir -p "$HOME/.claude/.plan-review-active.d"
         touch "$HOME/.claude/.plan-review-active.d/$SESSION_ID"
         ;;
       ready-for-review)
-        SESSION_ID=$(_resolve_session_id)
+        SESSION_ID=$(_resolve_session_id) || exit 2
         mkdir -p "$HOME/.claude/.ready-for-review-active.d"
         touch "$HOME/.claude/.ready-for-review-active.d/$SESSION_ID"
         ;;
       respond-pr)
-        SESSION_ID=$(_resolve_session_id)
+        SESSION_ID=$(_resolve_session_id) || exit 2
         mkdir -p "$HOME/.claude/.respond-pr-active.d"
         touch "$HOME/.claude/.respond-pr-active.d/$SESSION_ID"
         ;;
@@ -117,16 +117,16 @@ case "$SUBCOMMAND" in
   deactivate)
     case "$SKILL" in
       plan-review)
-        SESSION_ID=$(_resolve_session_id)
+        SESSION_ID=$(_resolve_session_id) || exit 2
         rm -f "$HOME/.claude/.plan-review-active.d/$SESSION_ID"
         rm -f "$HOME/.claude/.plan-review-routing-read.d/$SESSION_ID"
         ;;
       ready-for-review)
-        SESSION_ID=$(_resolve_session_id)
+        SESSION_ID=$(_resolve_session_id) || exit 2
         rm -f "$HOME/.claude/.ready-for-review-active.d/$SESSION_ID"
         ;;
       respond-pr)
-        SESSION_ID=$(_resolve_session_id)
+        SESSION_ID=$(_resolve_session_id) || exit 2
         rm -f "$HOME/.claude/.respond-pr-active.d/$SESSION_ID"
         ;;
       *)

--- a/claude/.claude/scripts/marker.sh
+++ b/claude/.claude/scripts/marker.sh
@@ -21,13 +21,22 @@ EOF
 }
 
 _resolve_session_id() {
-  local sid
-  sid=$(cat "$HOME/.claude/sessions/$PPID" 2>/dev/null)
-  if [ -z "$sid" ]; then
-    printf 'marker.sh: SESSION_ID empty — capture-session-id.sh SessionStart hook did not run. Abort without writing a marker.\n' >&2
-    exit 2
-  fi
-  printf '%s' "$sid"
+  local sid pid
+  # Walk up the process ancestor chain looking for a session file. Direct
+  # invocation resolves in one step ($PPID = Claude Code PID). Script
+  # invocation from the Bash tool resolves in two steps ($PPID = Bash tool
+  # shell, grandparent = Claude Code PID). The loop handles any depth.
+  pid=$PPID
+  while [ -n "$pid" ] && [ "$pid" != "0" ] && [ "$pid" != "1" ]; do
+    sid=$(cat "$HOME/.claude/sessions/$pid" 2>/dev/null)
+    if [ -n "$sid" ]; then
+      printf '%s' "$sid"
+      return 0
+    fi
+    pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' \t')
+  done
+  printf 'marker.sh: SESSION_ID empty — capture-session-id.sh SessionStart hook did not run. Abort without writing a marker.\n' >&2
+  exit 2
 }
 
 _resolve_repo_hash() {

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -107,6 +107,11 @@
           },
           {
             "type": "command",
+            "command": "~/.claude/hooks/enforce-marker-script-shape.sh",
+            "statusMessage": "Checking marker.sh invocation shape..."
+          },
+          {
+            "type": "command",
             "command": "~/.claude/hooks/require-worktree-for-git-writes.sh",
             "statusMessage": "Checking worktree enforcement..."
           }
@@ -178,6 +183,18 @@
   },
   "model": "opusplan",
   "permissions": {
+    "allow": [
+      "Bash(~/.claude/scripts/marker.sh write code-review)",
+      "Bash(~/.claude/scripts/marker.sh write skill-review)",
+      "Bash(~/.claude/scripts/marker.sh write plan-review)",
+      "Bash(~/.claude/scripts/marker.sh write ready-for-review)",
+      "Bash(~/.claude/scripts/marker.sh activate plan-review)",
+      "Bash(~/.claude/scripts/marker.sh activate ready-for-review)",
+      "Bash(~/.claude/scripts/marker.sh activate respond-pr)",
+      "Bash(~/.claude/scripts/marker.sh deactivate plan-review)",
+      "Bash(~/.claude/scripts/marker.sh deactivate ready-for-review)",
+      "Bash(~/.claude/scripts/marker.sh deactivate respond-pr)"
+    ],
     "deny": [
       "Bash(sudo *)",
       "Bash(sudo)",

--- a/claude/.claude/skills/code-review/SKILL.md
+++ b/claude/.claude/skills/code-review/SKILL.md
@@ -261,10 +261,8 @@ If the review is **clean** (no blockers, no unresolved critical findings, and yo
 
 <!-- HOOK_TEST_FIXTURE: marker-write — the hook-alignment test suite reads this exact fenced block from this file (claude/.claude/skills/code-review/SKILL.md) to verify it matches require-code-review.sh's marker layout. Do not duplicate the recipe elsewhere; the test re-reads it from here. -->
 ```
-SESSION_ID=$(cat "$HOME/.claude/sessions/$PPID") && [ -n "$SESSION_ID" ] && mkdir -p "$HOME/.claude/review-markers" && REPO_HASH=$(git rev-parse --show-toplevel | tr -d '\n' | sha256sum | awk '{print $1}') && git diff --cached | sha256sum | awk '{print $1}' > "$HOME/.claude/review-markers/$REPO_HASH.$SESSION_ID"
+~/.claude/scripts/marker.sh write code-review
 ```
-
-The `tr -d '\n'` is load-bearing: `git rev-parse` adds a trailing newline, and the hook computes the repo hash without it (`printf '%s' "$REPO_ROOT"`). Without `tr`, the marker lands at a path the hook never checks.
 
 This writes the hash of the currently staged diff into a per-session marker keyed by `<repo-hash>.<session-id>`. The pre-commit hook reads the same session-id from its JSON payload and compares the staged-diff hash against THIS session's marker — match means the commit is allowed through. Per-session keying prevents two parallel sessions in the same worktree from overwriting each other's markers. Re-staging any change invalidates the marker automatically.
 

--- a/claude/.claude/skills/plan-review/SKILL.md
+++ b/claude/.claude/skills/plan-review/SKILL.md
@@ -19,7 +19,7 @@ Write the active-session marker so this skill's own Write/Edit operations are no
 
 <!-- HOOK_TEST_FIXTURE: activate-gate — the hook-alignment test suite reads this exact fenced block from this file (claude/.claude/skills/plan-review/SKILL.md) to verify it matches require-plan-review.sh's active-marker layout. Do not duplicate the recipe elsewhere; the test re-reads it from here. -->
 ```
-SESSION_ID=$(cat "$HOME/.claude/sessions/$PPID") && [ -n "$SESSION_ID" ] && mkdir -p "$HOME/.claude/.plan-review-active.d" && touch "$HOME/.claude/.plan-review-active.d/$SESSION_ID"
+~/.claude/scripts/marker.sh activate plan-review
 ```
 
 If the chain fails (empty `SESSION_ID`, etc.), the `capture-session-id.sh` SessionStart hook didn't run — abort and report; do not proceed without the marker, since the hook would block any Write/Edit during the review.
@@ -232,12 +232,12 @@ Write the completion marker only when the verdict is **Approve** or **Approve wi
 
 <!-- HOOK_TEST_FIXTURE: record-completion — the hook-alignment test suite reads this exact fenced block from this file (claude/.claude/skills/plan-review/SKILL.md) to verify it matches require-plan-review.sh's completion-marker layout. Do not duplicate the recipe elsewhere; the test re-reads it from here. -->
 ```
-SESSION_ID=$(cat "$HOME/.claude/sessions/$PPID") && [ -n "$SESSION_ID" ] && mkdir -p "$HOME/.claude/plan-review-markers" && REPO_HASH=$(git rev-parse --show-toplevel | tr -d '\n' | sha256sum | awk '{print $1}') && printf 'reviewed\n' > "$HOME/.claude/plan-review-markers/$REPO_HASH.$SESSION_ID"
+~/.claude/scripts/marker.sh write plan-review
 ```
 
 Then remove the active-session marker:
 
 <!-- HOOK_TEST_FIXTURE: deactivate-gate — the hook-alignment test suite reads this exact fenced block from this file (claude/.claude/skills/plan-review/SKILL.md) to verify it matches require-plan-review.sh's active-marker cleanup. Do not duplicate the recipe elsewhere; the test re-reads it from here. -->
 ```
-SESSION_ID=$(cat "$HOME/.claude/sessions/$PPID" 2>/dev/null) && [ -n "$SESSION_ID" ] && rm -f "$HOME/.claude/.plan-review-active.d/$SESSION_ID" && rm -f "$HOME/.claude/.plan-review-routing-read.d/$SESSION_ID"
+~/.claude/scripts/marker.sh deactivate plan-review
 ```

--- a/claude/.claude/skills/ready-for-review/SKILL.md
+++ b/claude/.claude/skills/ready-for-review/SKILL.md
@@ -39,7 +39,7 @@ the `require-ready-for-review.sh` hook:
 
 <!-- HOOK_TEST_FIXTURE: activate-gate — the hook-alignment test suite reads this exact fenced block from this file (claude/.claude/skills/ready-for-review/SKILL.md) to verify it matches require-ready-for-review.sh's active-marker layout. Do not duplicate the recipe elsewhere; the test re-reads it from here. -->
 ```
-SESSION_ID=$(cat "$HOME/.claude/sessions/$PPID") && [ -n "$SESSION_ID" ] && mkdir -p "$HOME/.claude/.ready-for-review-active.d" && touch "$HOME/.claude/.ready-for-review-active.d/$SESSION_ID"
+~/.claude/scripts/marker.sh activate ready-for-review
 ```
 
 If the chain fails (empty `SESSION_ID`), the `capture-session-id.sh` SessionStart hook didn't run — abort and report; the gate will block iteration pushes without this marker.
@@ -167,14 +167,14 @@ and remove the active-session marker:
 
 <!-- HOOK_TEST_FIXTURE: record-completion — the hook-alignment test suite reads this exact fenced block from this file (claude/.claude/skills/ready-for-review/SKILL.md) to verify it matches require-ready-for-review.sh's completion-marker layout. Do not duplicate the recipe elsewhere; the test re-reads it from here. -->
 ```
-SESSION_ID=$(cat "$HOME/.claude/sessions/$PPID") && [ -n "$SESSION_ID" ] && mkdir -p "$HOME/.claude/ready-for-review-markers" && REPO_HASH=$(git rev-parse --show-toplevel | tr -d '\n' | sha256sum | awk '{print $1}') && git rev-parse HEAD > "$HOME/.claude/ready-for-review-markers/$REPO_HASH.$SESSION_ID"
+~/.claude/scripts/marker.sh write ready-for-review
 ```
 
 Then remove the active-session marker:
 
 <!-- HOOK_TEST_FIXTURE: deactivate-gate — the hook-alignment test suite reads this exact fenced block from this file (claude/.claude/skills/ready-for-review/SKILL.md) to verify it matches require-ready-for-review.sh's active-marker cleanup. Do not duplicate the recipe elsewhere; the test re-reads it from here. -->
 ```
-SESSION_ID=$(cat "$HOME/.claude/sessions/$PPID" 2>/dev/null) && [ -n "$SESSION_ID" ] && rm -f "$HOME/.claude/.ready-for-review-active.d/$SESSION_ID"
+~/.claude/scripts/marker.sh deactivate ready-for-review
 ```
 
 Removes only this session's file; if the skill errors before this step, do not manually clean up — the hook's 60-minute staleness cutoff handles orphans.

--- a/claude/.claude/skills/respond-pr/SKILL.md
+++ b/claude/.claude/skills/respond-pr/SKILL.md
@@ -13,7 +13,7 @@ Fetch all review comments on the current branch's open pull request and address 
 0. **Enable hook bypass.** Run:
    <!-- HOOK_TEST_FIXTURE: enable-bypass — the hook-alignment test suite reads this exact fenced block to verify it creates the marker layout require-respond-pr.sh expects. Do not duplicate elsewhere; the test re-reads it from here. -->
    ```
-   SESSION_ID=$(cat "$HOME/.claude/sessions/$PPID") && [ -n "$SESSION_ID" ] && mkdir -p "$HOME/.claude/.respond-pr-active.d" && touch "$HOME/.claude/.respond-pr-active.d/$SESSION_ID"
+   ~/.claude/scripts/marker.sh activate respond-pr
    ```
    The `require-respond-pr.sh` PreToolUse hook bypasses while THIS session's marker is fresh (<60 min) and refreshes its mtime on each bypass so long runs don't hit the staleness cutoff. Per-session keying prevents parallel respond-pr sessions from thrashing on cleanup or leaking bypass to unrelated sessions. If the chain fails (empty `SESSION_ID`, etc.), the `capture-session-id.sh` SessionStart hook didn't run — abort and report; do not proceed without the marker, since every gated `gh` call below will be blocked.
 
@@ -72,7 +72,7 @@ Fetch all review comments on the current branch's open pull request and address 
 7. **Remove this session's hook bypass marker:**
    <!-- HOOK_TEST_FIXTURE: disable-bypass — the hook-alignment test suite reads this exact fenced block to verify it removes the marker the enable step created. Do not duplicate elsewhere; the test re-reads it from here. -->
    ```
-   SESSION_ID=$(cat "$HOME/.claude/sessions/$PPID" 2>/dev/null) && [ -n "$SESSION_ID" ] && rm -f "$HOME/.claude/.respond-pr-active.d/$SESSION_ID"
+   ~/.claude/scripts/marker.sh deactivate respond-pr
    ```
    Removes only this session's file. If the skill errors out before reaching this step, don't manually clean up — the hook's 60-minute staleness cutoff handles the orphan automatically.
 

--- a/claude/.claude/skills/skill-review/SKILL.md
+++ b/claude/.claude/skills/skill-review/SKILL.md
@@ -190,11 +190,7 @@ blockers), record completion by running this command exactly once:
 
 <!-- HOOK_TEST_FIXTURE: skill-review-marker-write — the hook-alignment test suite reads this exact fenced block from this file (claude/.claude/skills/skill-review/SKILL.md) to verify it matches require-skill-review.sh's marker layout. Do not duplicate the recipe elsewhere; the test re-reads it from here. -->
 ```
-SESSION_ID=$(cat "$HOME/.claude/sessions/$PPID") && [ -n "$SESSION_ID" ] && mkdir -p "$HOME/.claude/skill-review-markers" && REPO_HASH=$(git rev-parse --show-toplevel | tr -d '\n' | sha256sum | awk '{print $1}') && git diff --cached -- 'claude/.claude/skills/**/SKILL.md' | sha256sum | awk '{print $1}' > "$HOME/.claude/skill-review-markers/$REPO_HASH.$SESSION_ID"
+~/.claude/scripts/marker.sh write skill-review
 ```
 
-The `tr -d '\n'` is load-bearing: `git rev-parse` adds a trailing
-newline, and the hook computes the repo hash without it. The pathspec
-`'claude/.claude/skills/**/SKILL.md'` is also load-bearing — it
-scopes the hash to skill diffs so non-skill re-staging does not
-invalidate a clean review.
+The pathspec `claude/.claude/skills/**/SKILL.md` is encoded inside `marker.sh write skill-review` so the marker matches what `require-skill-review.sh` checks.


### PR DESCRIPTION
## Summary

- Adds `~/.claude/scripts/marker.sh` — a single script that centralises all 10 marker write/activate/deactivate operations across five workflow skills, replacing the repeated inline bash recipes in each SKILL.md
- Adds `enforce-marker-script-shape.sh` PreToolUse:Bash hook — fail-closed gate that denies any `marker.sh` invocation outside the 10 exact valid shapes (no chains, no env-var prefixes, no redirects, no bash wrappers, no path traversal)
- Adds 10 exact-shape `permissions.allow` entries to `settings.json` for silent auto-approval of all valid marker operations
- Drops `marker_chain_note_if_detected()` from `require-code-review.sh` and `require-skill-review.sh` — the strict-shape hook owns chain prevention; the legacy `>` redirect pattern is dead-letter post-migration

## Motivation

Agents were repeatedly prompted to approve long dynamic bash chains for marker operations, and occasionally ran wrong variants. The inline recipes also duplicated `tr -d '\n'` logic across 10 locations. One script + one allowlist entry replaces all of that.

## Security model (three-layer defense)

1. `settings.json` exact-shape `allow` entries — silent approval for the 10 valid shapes; nothing else is silently allowed
2. `enforce-marker-script-shape.sh` — fail-closed hook denies any command containing `marker.sh` that doesn't match the anchored regex; includes path-traversal pre-check (`..` blocked before regex)
3. `marker.sh` own arg validation — explicit `case` whitelisting; unknown subcommand/skill exits 2 with usage

## What changed

| Surface | Change |
|---|---|
| `claude/.claude/scripts/marker.sh` | New: central write-side wrapper |
| `claude/.claude/hooks/enforce-marker-script-shape.sh` | New: strict-shape gate |
| `claude/.claude/settings.json` | Hook wired to PreToolUse:Bash; 10 allow entries added |
| `claude/.claude/hooks/require-code-review.sh` | Dropped `marker_chain_note_if_detected` (~20 lines) |
| `claude/.claude/hooks/require-skill-review.sh` | Same |
| `claude/.claude/hooks/tests/helpers.py` | `SCRIPTS_DIR` constant; `run_skill_command` symlinks `marker.sh` into sandboxed `$HOME` |
| `claude/.claude/hooks/tests/test_enforce_marker_script_shape.py` | New: 28 tests covering all 10 valid shapes + all denial cases |
| `claude/.claude/hooks/tests/test_marker_script.py` | New: 15 tests for marker.sh own behaviour (missing session file exits 2, no stray markers written, happy path) |
| `test_require_code_review.py`, `test_require_skill_review.py` | Removed chain-detection tests (behaviour now owned by enforce hook) |
| 5 × SKILL.md | 10 fixture body replacements; 2 prose trims |
| `README.md` | `chmod +x` glob broadened; `marker.sh` entry added |

## Bugs found and fixed during review

**1. Dead unreachable `--help` branch** (`fdd54c0`): The `$# -ne 2` arg-count guard fired before the `--help|-h` case was reachable. Fixed by adding an explicit `--help`/`-h` check before the count guard.

**2. `exit 2` inside command-substitution subshell silently continued parent** (`228abd0`): `exit 2` inside `_resolve_session_id()` only exits the command-substitution subshell — without `set -e`, the parent script continued with `SESSION_ID=""`, writing a marker with an empty session-id suffix no hook can match. Fixed with `|| exit 2` on every `SESSION_ID=$(...)` and `REPO_HASH=$(...)` call. Added `test_marker_script.py` to pin the invariant.

**3. Ancestor-scan needed for production PPID** (`05a3c7e`): When marker.sh runs as an executable (via shebang), the OS execs a new bash whose `$PPID` is the Bash tool shell — one level above the Claude Code process that owns the session file. Fixed `_resolve_session_id` to walk up the ancestor chain with `ps -o ppid=` until finding a PID with a session file.

## Test plan

- [x] 558 tests pass (`pytest claude/.claude/`)
- [x] `ruff check` clean
- [x] `bash -n claude/.claude/scripts/marker.sh` syntax-clean
- [x] `marker.sh --help` exits 0
- [x] `marker.sh write nonsense` exits 2 + usage on stderr
- [x] End-to-end: `/ready-for-review` ran to completion, `git push` gate passed

## Follow-up

A separate PR will extract a shared `_lib.sh` from all five `require-*.sh` hooks and `marker.sh` to DRY up repo-hash and session-id computation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)