### PR TITLE
feat(claude-hook-review): add command path resolution rule

### DIFF
--- a/claude/.claude/skills/claude-hook-review/REFERENCES.md
+++ b/claude/.claude/skills/claude-hook-review/REFERENCES.md
@@ -22,5 +22,3 @@ From the hooks reference, "Reference scripts by path" section:
 From the hooks-guide troubleshooting section:
 
 > "If you see 'command not found', use absolute paths or `$CLAUDE_PROJECT_DIR` to reference scripts."
-
-**Misattribution note:** An earlier draft of the Section 2 rule was written with the quote *"Use absolute paths: specify full paths for scripts, using `\"$CLAUDE_PROJECT_DIR\"` for the project root."* That exact wording does **not** appear on the live docs. The two real recommendations are the troubleshooting line above and the path-resolution framing in the hooks reference. Re-verify against the cited URLs if adding a new verbatim citation — do not carry forward a quoted string that can't be located in the source.

--- a/claude/.claude/skills/claude-hook-review/REFERENCES.md
+++ b/claude/.claude/skills/claude-hook-review/REFERENCES.md
@@ -1,0 +1,26 @@
+# References — claude-hook-review
+
+Reference material that informed this skill. Not loaded during skill execution — consult when editing the skill to verify a rule still holds or to add new guidance.
+
+## Anthropic hooks documentation
+
+**URLs (verified live 2026-05-06):**
+
+- Hooks reference: `https://docs.claude.com/en/docs/claude-code/hooks` (redirects to `https://code.claude.com/docs/en/hooks`)
+- Hooks guide: `https://docs.claude.com/en/docs/claude-code/hooks-guide` (redirects to `https://code.claude.com/docs/en/hooks-guide`)
+
+**Verbatim quotes used in Section 2 (path resolution):**
+
+From the hooks reference, "Reference scripts by path" section:
+
+> "Handlers run in the current directory with Claude Code's environment."
+
+> "`$CLAUDE_PROJECT_DIR`: the project root. Wrap in quotes to handle paths with spaces."
+
+> "`${CLAUDE_PLUGIN_ROOT}`: the plugin's installation directory, for scripts bundled with a plugin. Changes on each plugin update."
+
+From the hooks-guide troubleshooting section:
+
+> "If you see 'command not found', use absolute paths or `$CLAUDE_PROJECT_DIR` to reference scripts."
+
+**Misattribution note:** An earlier draft of the Section 2 rule was written with the quote *"Use absolute paths: specify full paths for scripts, using `\"$CLAUDE_PROJECT_DIR\"` for the project root."* That exact wording does **not** appear on the live docs. The two real recommendations are the troubleshooting line above and the path-resolution framing in the hooks reference. Re-verify against the cited URLs if adding a new verbatim citation — do not carry forward a quoted string that can't be located in the source.

--- a/claude/.claude/skills/claude-hook-review/SKILL.md
+++ b/claude/.claude/skills/claude-hook-review/SKILL.md
@@ -26,7 +26,19 @@ user-invocable: false
 
 **`if`-dispatch** narrows further within a matcher (e.g., `"if": "Bash(git commit *)"`) and is **advisory** — zero-cost early exit, but the real gate is the script's internal filter. If `if`-dispatch and the internal regex diverge, you get silent coverage gaps.
 
-## 2. Script skeleton
+## 2. Path resolution in `command` strings
+
+Every `command` value in `settings.json` must resolve to a stable absolute path regardless of the hook's CWD. Hooks "run in the current directory with Claude Code's environment" (Anthropic hooks reference) — the CWD is the agent's session-persisted bash directory at firing time, which can be a subdirectory, a worktree path, or wherever a prior Bash call left the session anchored.
+
+Required prefix by settings file scope:
+
+- **Project settings** (`<repo>/.claude/settings.json`): `"$CLAUDE_PROJECT_DIR"/<rest>`. Quotes around the variable handle paths with spaces.
+- **Plugin settings** (plugin-bundled `settings.json`): `${CLAUDE_PLUGIN_ROOT}/<rest>`. Resolves to the plugin's installation directory; changes on each plugin update.
+- **User settings** (`~/.claude/settings.json`): `~/<rest>`, `$HOME/<rest>`, or a literal `/...` absolute path. Acceptable because user-scoped hooks live at a fixed user-level location. claude-config's own `~/.claude/settings.json` uses `~/.claude/hooks/...` across all hook entries with no observed failures — this form is safe in shells that perform standard tilde expansion.
+
+Rejected forms: bare `./<rest>`, `../<rest>`, or unprefixed script names. Concrete failure mode: `./.claude/hooks/foo.sh` produces `/bin/sh: 1: ./.claude/hooks/foo.sh: not found` whenever the agent's CWD has drifted off the project root — for example, in a worktree session after a `cd`.
+
+## 3. Script skeleton
 
 The idiomatic pattern from `deny-private-project-refs.sh` and `require-stow-reminder.sh`:
 
@@ -62,7 +74,7 @@ Two non-obvious constraints for new gates:
 - `"permissionDecision"` must be exactly `"deny"` (lowercase) — the runtime is case-sensitive; `"Deny"`, `"block"`, or any variant silently allows.
 - `jq -r '... // empty'` exits **0** on missing fields (empty string, not a non-zero exit). `JQ_EXIT` guards against JSON parse failures only. For allow-list-style gates (deny anything outside a known set), also guard on `[ -z "$COMMAND" ]`. For deny-list-style gates (deny specific operations, allow all else), empty `COMMAND` correctly falls through.
 
-## 3. Fail-open vs fail-closed posture
+## 4. Fail-open vs fail-closed posture
 
 **Fail-closed** when the gate prevents a leak: parse failure → deny (a hook that can't read its input can't verify the operation is safe). Example: `deny-private-project-refs.sh:101–104`.
 
@@ -70,11 +82,11 @@ Two non-obvious constraints for new gates:
 
 State the chosen posture in the script header. Reviewers shouldn't have to re-derive it from the code.
 
-## 4. Dispatch design and drift risk
+## 5. Dispatch design and drift risk
 
 `settings.json` carries `if`-patterns for zero-cost early dispatch (e.g., `Bash(git commit *)`, `Bash(gh pr create *)`, `Bash(gh pr edit *)`). The script's internal regex is the authoritative gate. When both surfaces cover the same operation, they must stay in sync — document the pairing explicitly in the script header (`deny-private-project-refs.sh:9–14` is the model). A drift between `if`-pattern and internal regex creates silent coverage gaps.
 
-## 5. Escape hatches and allowlists
+## 6. Escape hatches and allowlists
 
 Two distinct extension surfaces — don't conflate them:
 
@@ -83,15 +95,15 @@ Two distinct extension surfaces — don't conflate them:
 
 Prefer named variables over magic strings buried in a regex; future contributors need a clear place to extend and a clear signal about which surface is appropriate.
 
-## 6. Performance budget
+## 7. Performance budget
 
 Hooks fire on every matching tool call. Budget <100ms per fire. Subprocess spawns (`jq`, `grep`) add up — avoid loops over them. No network calls. No unbounded file I/O. If the hook reads user-controlled input, cap the read before scanning.
 
-## 7. Test patterns
+## 8. Test patterns
 
 `claude/.claude/hooks/tests/test_hooks.py` is the model. Each test feeds tool-input JSON on stdin and reads `permissionDecision` from stdout. Cover boundary cases: malformed JSON input, unreadable file paths, pseudo-file paths (`/dev/stdin`, `/dev/fd/*`). When a test needs synthetic project-shaped tokens, follow the file's existing precedent for invented prefixes — do **not** invent prefixes that resemble real private projects.
 
-## 8. Review checklist
+## 9. Review checklist
 
 Flag these on a hook PR:
 
@@ -105,3 +117,4 @@ Flag these on a hook PR:
 - Tests cover new code paths; synthetic prefixes only, no real project names.
 - No unbounded loops, no network calls, no unbounded file I/O.
 - Header lists known gaps the hook does not close.
+- **`command` path resolution**: every `command` starts with `"$CLAUDE_PROJECT_DIR"`, `${CLAUDE_PLUGIN_ROOT}`, or a stable user-level prefix (`~`, `$HOME`, literal `/`). Bare `./` or unprefixed names fail review — see Section 2.


### PR DESCRIPTION
## Summary

- Adds **Section 2 \"Path resolution in `command` strings\"** to `claude-hook-review/SKILL.md`, encoding the convention that every `command` in `settings.json` must resolve to a stable absolute path regardless of the hook's CWD
- Adds a corresponding bullet to the Section 9 review checklist
- Creates `claude-hook-review/REFERENCES.md` with verified Anthropic primary-source citations

## Background

Hook commands registered with relative-path prefixes (`./`) fail in worktree sessions when the agent's bash CWD has drifted from the project root (e.g., after a prior `cd`). Per Anthropic's hooks reference: *"Handlers run in the current directory with Claude Code's environment."* The fix is using `"$CLAUDE_PROJECT_DIR"` for project-scoped hooks — this resolves to the project root regardless of CWD.

A separate PR in a consuming repo rewrites existing hook commands to use `$CLAUDE_PROJECT_DIR`. This PR encodes the convention so `claude-hook-review` catches the same failure mode in any future hook PR it reviews.

## Scope decisions

- **Worktree-creation skill change dropped**: claude-config has no worktree-creation skill or script; `.claude/hooks/` is tracked in git and materializes in every worktree automatically. The failure mode is settings-file path resolution, fully addressed by this PR.
- **Behavioral test fixtures not added**: no skill in this repo uses behavioral fixtures; the rule lives in the body for human/audit-agent consumption.

## Test plan

- [x] `pytest claude/.claude/` — 527 tests pass (ran during implementation)
- [x] `wc -l SKILL.md` — 120 lines, under the 200-line cap (ran during implementation)
- [x] Read SKILL.md cold — Section 2 is self-contained without REFERENCES.md
- [x] Bad fixture (`"command": "./.claude/hooks/foo.sh"`) — manually verified against rule text: Section 2 + Section 9 bullet flag it
- [x] Good fixture (`"command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/foo.sh"`) — manually verified: passes
- [ ] Post-merge smoke test: invoke `/claude-hook-review` live against both fixtures (Skill tool loads from stowed main; can't test new rule until merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)