### PR TITLE
docs(hook): document worktree hook false-positive on prose containing git <word>

### DIFF
--- a/claude/.claude/hooks/require-worktree-for-git-writes.sh
+++ b/claude/.claude/hooks/require-worktree-for-git-writes.sh
@@ -12,6 +12,14 @@
 # bootstrap `git worktree add` isn't denied on the main tree). Anything
 # else is denied when run from the main working tree of an opted-in repo.
 # Allowed unconditionally inside a linked worktree.
+#
+# Known limitation: parses the Bash command as a string, splitting on
+# shell operators only. Heredoc bodies, single-quoted, and double-quoted
+# regions are not distinguished from live command text — a Bash command
+# whose prose contains the literal `git <word>` (e.g. inside a `<<EOF`
+# heredoc writing a file) can be denied as if it invoked `git <word>`.
+# Workaround: write prose-containing files via the Write/Edit tool, not
+# Bash heredocs.
 
 # Defensive: prevent GIT_DIR / GIT_WORK_TREE env overrides from making the
 # main tree impersonate a linked worktree via rev-parse output.


### PR DESCRIPTION
## Summary

The worktree-enforcement hook (`require-worktree-for-git-writes.sh`) parses Bash commands as raw strings, splitting only on shell operators (`;`, `&&`, `||`, `|`, `$(`, backtick). Heredoc bodies, single-quoted strings, and double-quoted strings are not distinguished from live command text.

A Bash command whose prose contains the literal `git <word>` — for example, a `cat <<'EOF' ... EOF` heredoc writing a file that mentions "raw git commands" — can be denied as if it had invoked that subcommand, because the word following `git` is treated as the candidate subcommand and checked against the read-only allowlist.

## Why not fix it

Three approaches were considered and rejected:

1. **Heredoc-stripping pre-pass** (~30 lines): would catch the `<<EOF` shape but miss single/double-quoted prose, and a parser bug in the pre-pass fails closed — trading one known false-positive for a class of unknown ones.
2. **Real bash parser (bashlex)**: new dependency, parse latency on every Bash invocation, and parse failures introduce *new* false denials on shapes the current string-walk accepts.
3. **Do nothing**: leaves a working hook with a documented edge case. The workaround (use `Write`/`Edit` for prose-containing files instead of `cat <<EOF`) is already the right tool — those tools bypass the hook entirely.

## Change

Comment-only. Adds an 8-line "Known limitation" block to the hook's header so the next debugger doesn't re-investigate.

## Workaround

Write prose-containing files via the `Write` or `Edit` tool rather than through a Bash heredoc. Both tools bypass the hook.

## Test plan

- [x] `pytest claude/.claude/hooks/tests/test_require_worktree_for_git_writes.py` — 66 passed, unchanged (comment-only edit)
- [x] No regression test added (pinning the FP would block future parser improvements)

🤖 Generated with [Claude Code](https://claude.com/claude-code)