### PR TITLE
refactor(tests): move helpers.py to shared claude/.claude/tests/ directory

### DIFF
--- a/.github/workflows/hooks.yml
+++ b/.github/workflows/hooks.yml
@@ -55,7 +55,7 @@ jobs:
           # Include any directory that contains test files or whose contents are
           # read by tests. Update this list when a new test or test-input
           # directory appears under claude/.claude/.
-          REGEX='^(claude/\.claude/(hooks|skills|scripts)/|\.github/workflows/hooks\.yml|pyproject\.toml)'
+          REGEX='^(claude/\.claude/(hooks|skills|scripts|tests)/|\.github/workflows/hooks\.yml|pyproject\.toml)'
 
           MATCHED=$(echo "$CHANGED" | grep -E "$REGEX" || true)
           UNMATCHED=$(echo "$CHANGED" | grep -vE "$REGEX" || true)

--- a/claude/.claude/tests/helpers.py
+++ b/claude/.claude/tests/helpers.py
@@ -1,4 +1,4 @@
-"""Pure helpers and path constants shared across hook test files.
+"""Pure helpers and path constants shared across hook and script test files.
 
 No pytest decorators here — this is a plain Python module. Import
 explicitly from each test file that needs these symbols.
@@ -12,10 +12,11 @@ import re
 import subprocess
 from pathlib import Path
 
-HOOKS_DIR = Path(__file__).resolve().parent.parent
+CLAUDE_DIR = Path(__file__).resolve().parent.parent
 
-SKILLS_DIR = HOOKS_DIR.parent / "skills"
-SCRIPTS_DIR = HOOKS_DIR.parent / "scripts"
+HOOKS_DIR = CLAUDE_DIR / "hooks"
+SKILLS_DIR = CLAUDE_DIR / "skills"
+SCRIPTS_DIR = CLAUDE_DIR / "scripts"
 
 # SKILL.md fences may be indented when the fixture sits inside a
 # numbered list (e.g. respond-pr's "0. **Enable hook bypass.**"). The

--- a/claude/.claude/tests/helpers.py
+++ b/claude/.claude/tests/helpers.py
@@ -1,4 +1,4 @@
-"""Pure helpers and path constants shared across hook and script test files.
+"""Pure helpers and path constants shared across hook, skill, and script test files.
 
 No pytest decorators here — this is a plain Python module. Import
 explicitly from each test file that needs these symbols.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,6 @@ target-version = "py312"
 
 [tool.ruff.lint]
 select = ["E", "F", "B", "I", "UP", "SIM"]
+
+[tool.pytest.ini_options]
+pythonpath = ["claude/.claude/tests"]


### PR DESCRIPTION
## Summary

- Moves `claude/.claude/hooks/tests/helpers.py` → `claude/.claude/tests/helpers.py` via `git mv` (preserves blame history)
- Refactors path constants to anchor from `CLAUDE_DIR` (`.claude/` root) rather than the old `HOOKS_DIR.parent` chain — cleaner now that the file no longer lives under `hooks/`
- Adds `[tool.pytest.ini_options] pythonpath = ["claude/.claude/tests"]` to `pyproject.toml` so the 19 existing `from helpers import ...` statements in hook-test files resolve unchanged
- Extends the CI path-filter regex in `hooks.yml` to include `claude/.claude/tests/` so changes to the relocated file still trigger the test suite

No changes to any of the 19 hook-test import sites or to `conftest.py`. `pytest claude/.claude/ -v` → 558 passed.

Closes #164

## Test plan

- [x] `pytest claude/.claude/ -v` — 558 passed (verified locally before commit)
- [x] `ruff check claude/.claude/` — clean
- [x] `git log --follow claude/.claude/tests/helpers.py` — blame preserved
- [ ] CI "Hook tests" check passes on this PR (path filter now covers `claude/.claude/tests/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)