### PR TITLE
refactor: extract _marker_lib_repo_hash shared helper from require-* hooks and marker.sh

### DIFF
--- a/claude/.claude/hooks/_lib.sh
+++ b/claude/.claude/hooks/_lib.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Shared helper library sourced by require-*.sh hooks and scripts/marker.sh.
+# Keep this file the single source of truth for any recipe that must produce
+# byte-identical output on both the read side (hooks) and the write side
+# (marker.sh). Source it; do not invoke it directly.
+
+# Compute the marker repo-hash for an absolute repo-toplevel path.
+# Input must have no trailing newline -- printf '%s' omits one, so the SHA
+# covers exactly the bytes of $1.
+# Usage: hash=$(_marker_lib_repo_hash "$REPO_ROOT")
+_marker_lib_repo_hash() {
+  printf '%s' "$1" | sha256sum | awk '{print $1}'
+}

--- a/claude/.claude/hooks/require-code-review.sh
+++ b/claude/.claude/hooks/require-code-review.sh
@@ -25,6 +25,7 @@
 # - The marker auto-invalidates as soon as the staging area changes, so
 #   re-staging after review correctly forces a re-review.
 
+. "$(dirname "$0")/_lib.sh"
 
 INPUT=$(cat)
 COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command // empty')
@@ -50,7 +51,7 @@ if [ -z "$(git diff --cached 2>/dev/null)" ]; then
   exit 0
 fi
 
-REPO_HASH=$(printf '%s' "$REPO_ROOT" | sha256sum | awk '{print $1}')
+REPO_HASH=$(_marker_lib_repo_hash "$REPO_ROOT")
 SESSION_ID=$(printf '%s\n' "$INPUT" | jq -r '.session_id // empty')
 CURRENT_HASH=$(git diff --cached | sha256sum | awk '{print $1}')
 

--- a/claude/.claude/hooks/require-plan-review.sh
+++ b/claude/.claude/hooks/require-plan-review.sh
@@ -26,6 +26,8 @@
 #   0      — allow (no opinion)
 #   0+JSON — deny (plan exists but no review marker for this session)
 
+. "$(dirname "$0")/_lib.sh"
+
 INPUT=$(cat)
 TOOL_NAME=$(printf '%s\n' "$INPUT" | jq -r '.tool_name // empty')
 
@@ -65,7 +67,7 @@ if [ -n "$SESSION_ID" ]; then
   fi
 
   # Completion-marker check.
-  REPO_HASH=$(printf '%s' "$REPO_ROOT" | sha256sum | awk '{print $1}')
+  REPO_HASH=$(_marker_lib_repo_hash "$REPO_ROOT")
   MARKER="$HOME/.claude/plan-review-markers/$REPO_HASH.$SESSION_ID"
   if [ -f "$MARKER" ]; then
     exit 0

--- a/claude/.claude/hooks/require-ready-for-review.sh
+++ b/claude/.claude/hooks/require-ready-for-review.sh
@@ -33,6 +33,8 @@
 # - gh pr view fails (network issue, gh not configured, etc.) — fail-open
 #   to keep the user unblocked; the skill's prose triggers still fire.
 
+. "$(dirname "$0")/_lib.sh"
+
 INPUT=$(cat)
 TOOL=$(printf '%s\n' "$INPUT" | jq -r '.tool_name // empty')
 if [ "$TOOL" != "Bash" ]; then
@@ -135,7 +137,7 @@ fi
 
 # Completion-marker check.
 if [ -n "$SESSION_ID" ]; then
-  REPO_HASH=$(printf '%s' "$REPO_ROOT" | sha256sum | awk '{print $1}')
+  REPO_HASH=$(_marker_lib_repo_hash "$REPO_ROOT")
   MARKER="$HOME/.claude/ready-for-review-markers/$REPO_HASH.$SESSION_ID"
   if [ -f "$MARKER" ]; then
     MARKER_HEAD=$(tr -d '[:space:]' < "$MARKER")

--- a/claude/.claude/hooks/require-skill-review.sh
+++ b/claude/.claude/hooks/require-skill-review.sh
@@ -27,6 +27,7 @@
 #   so re-staging non-SKILL.md files after a clean skill-review does not
 #   invalidate the marker.
 
+. "$(dirname "$0")/_lib.sh"
 
 INPUT=$(cat)
 COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command // empty')
@@ -59,7 +60,7 @@ if [ -z "$(git diff --cached 2>/dev/null)" ]; then
   exit 0
 fi
 
-REPO_HASH=$(printf '%s' "$REPO_ROOT" | sha256sum | awk '{print $1}')
+REPO_HASH=$(_marker_lib_repo_hash "$REPO_ROOT")
 SESSION_ID=$(printf '%s\n' "$INPUT" | jq -r '.session_id // empty')
 CURRENT_HASH=$(git diff --cached -- 'claude/.claude/skills/**/SKILL.md' | sha256sum | awk '{print $1}')
 

--- a/claude/.claude/hooks/tests/conftest.py
+++ b/claude/.claude/hooks/tests/conftest.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import subprocess
 
 import pytest
+from helpers import HOOKS_DIR
 
 
 @pytest.fixture
@@ -15,6 +16,9 @@ def isolated_home(monkeypatch, tmp_path):
     """Sandbox $HOME so the hooks' marker files don't collide with real state."""
     home = tmp_path / "home"
     (home / ".claude" / "review-markers").mkdir(parents=True)
+    hooks_dir = home / ".claude" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    (hooks_dir / "_lib.sh").symlink_to(HOOKS_DIR / "_lib.sh")
     monkeypatch.setenv("HOME", str(home))
     return home
 

--- a/claude/.claude/hooks/tests/test_marker_lib.py
+++ b/claude/.claude/hooks/tests/test_marker_lib.py
@@ -1,0 +1,56 @@
+"""Tests for _lib.sh shared helper library."""
+from __future__ import annotations
+
+import hashlib
+import subprocess
+
+from helpers import HOOKS_DIR
+
+LIB_SH = HOOKS_DIR / "_lib.sh"
+
+
+def _run_lib_fn(fn_call: str) -> str:
+    """Source _lib.sh in a bash subprocess and evaluate fn_call."""
+    result = subprocess.run(
+        ["bash", "-c", f'. "{LIB_SH}"; {fn_call}'],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+class TestMarkerLibRepoHash:
+    def test_known_path_matches_python_sha256(self):
+        path = "/some/known/path"
+        expected = hashlib.sha256(path.encode()).hexdigest()
+        actual = _run_lib_fn(f'_marker_lib_repo_hash "{path}"')
+        assert actual == expected, (
+            f"_marker_lib_repo_hash produced {actual!r}, expected {expected!r}"
+        )
+
+    def test_no_trailing_newline_in_hash_input(self):
+        # Verify that the hash equals the Python sha256 of the bare path bytes,
+        # confirming printf '%s' does not add a trailing newline to the input.
+        path = "/tmp/foo"
+        expected = hashlib.sha256(path.encode()).hexdigest()
+        actual = _run_lib_fn(f'_marker_lib_repo_hash "{path}"')
+        assert actual == expected, (
+            f"_marker_lib_repo_hash produced {actual!r}, expected {expected!r}"
+        )
+
+    def test_matches_inline_recipe(self):
+        # Both the library function and the original inline recipe must produce
+        # the same hash for the same path. This detects recipe drift between
+        # the library and any remaining inline usage.
+        path = "/tmp/test-repo"
+        from_lib = _run_lib_fn(f'_marker_lib_repo_hash "{path}"')
+        from_inline = subprocess.run(
+            ["bash", "-c", f"printf '%s' '{path}' | sha256sum | awk '{{print $1}}'"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        assert from_lib == from_inline, (
+            f"Library hash {from_lib!r} != inline recipe {from_inline!r}"
+        )

--- a/claude/.claude/hooks/tests/test_marker_lib.py
+++ b/claude/.claude/hooks/tests/test_marker_lib.py
@@ -29,14 +29,19 @@ class TestMarkerLibRepoHash:
             f"_marker_lib_repo_hash produced {actual!r}, expected {expected!r}"
         )
 
-    def test_no_trailing_newline_in_hash_input(self):
-        # Verify that the hash equals the Python sha256 of the bare path bytes,
-        # confirming printf '%s' does not add a trailing newline to the input.
+    def test_trailing_newline_produces_different_hash(self):
+        # If printf '%s' ever starts emitting a trailing newline, the hash would
+        # match sha256("/tmp/foo\n") instead of sha256("/tmp/foo"). Assert the
+        # two are distinct so this test fails if the recipe regresses.
         path = "/tmp/foo"
-        expected = hashlib.sha256(path.encode()).hexdigest()
+        hash_without_newline = hashlib.sha256(path.encode()).hexdigest()
+        hash_with_newline = hashlib.sha256((path + "\n").encode()).hexdigest()
         actual = _run_lib_fn(f'_marker_lib_repo_hash "{path}"')
-        assert actual == expected, (
-            f"_marker_lib_repo_hash produced {actual!r}, expected {expected!r}"
+        assert actual == hash_without_newline, (
+            f"_marker_lib_repo_hash produced {actual!r}, expected no-newline hash {hash_without_newline!r}"
+        )
+        assert actual != hash_with_newline, (
+            "hash matched the newline-suffixed input — printf '%s' may be adding a trailing newline"
         )
 
     def test_matches_inline_recipe(self):

--- a/claude/.claude/scripts/marker.sh
+++ b/claude/.claude/scripts/marker.sh
@@ -2,6 +2,10 @@
 # Write or remove review markers for Claude Code workflow skills.
 # Called from SKILL.md HOOK_TEST_FIXTURE fenced blocks.
 # Usage: marker.sh <write|activate|deactivate> <skill>
+# _marker_lib_repo_hash is defined in the sourced library so the hash recipe
+# stays in sync with the read side (require-*.sh hooks) automatically.
+. "$HOME/.claude/hooks/_lib.sh"
+
 set -u
 
 usage() {
@@ -47,7 +51,7 @@ _resolve_repo_hash() {
   # tr -d '\n' is load-bearing: git rev-parse appends a trailing newline.
   # require-* hooks compute the hash via printf '%s' "$REPO_ROOT" (no newline),
   # so both sides must strip it to produce the same sha256 and matching paths.
-  git rev-parse --show-toplevel | tr -d '\n' | sha256sum | awk '{print $1}'
+  _marker_lib_repo_hash "$(git rev-parse --show-toplevel | tr -d '\n')"
 }
 
 if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then

--- a/claude/.claude/tests/helpers.py
+++ b/claude/.claude/tests/helpers.py
@@ -254,6 +254,11 @@ def run_skill_command(command: str, cwd: Path, isolated_home: Path) -> None:
     marker_link = scripts_dir / "marker.sh"
     if not marker_link.exists():
         marker_link.symlink_to(SCRIPTS_DIR / "marker.sh")
+    hooks_dir = isolated_home / ".claude" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    lib_link = hooks_dir / "_lib.sh"
+    if not lib_link.exists():
+        lib_link.symlink_to(HOOKS_DIR / "_lib.sh")
     subprocess.run(
         ["bash", "-c", command],
         cwd=cwd,


### PR DESCRIPTION
## Summary

- Adds `claude/.claude/hooks/_lib.sh` — a sourced bash library exporting `_marker_lib_repo_hash()`, the single source of truth for the marker repo-hash recipe
- Updates four hooks (`require-code-review.sh`, `require-skill-review.sh`, `require-plan-review.sh`, `require-ready-for-review.sh`) to source the lib and replace their inline one-liners
- Updates `marker.sh` to source the lib via `$HOME/.claude/hooks/_lib.sh` and call `_marker_lib_repo_hash` inside `_resolve_repo_hash()`
- Adds `test_marker_lib.py` with 3 tests pinning the function's output against Python `hashlib.sha256`, the original inline recipe, and a falsifiable newline-regression check

## What problem this solves

Before PR #162, both the read side (hooks) and write side (`marker.sh`) computed the repo-hash independently. PR #162 added a comment documenting the `tr -d '\n'` / `printf '%s'` equivalence, but a comment alone can't prevent drift. This PR makes drift structurally impossible: there is now one recipe and both sides reference it.

`require-respond-pr.sh` is untouched — it does not compute a repo-hash.

## Scope rationale

The predecessor plan also proposed sharing session-id resolution and marker-path construction. After reviewing the merged PR #162:

- Session-id resolution cannot be shared: hooks parse a JSON payload via `jq`; `marker.sh` walks the process ancestor chain via `ps -o ppid=`. Different mechanisms by necessity.
- Marker-path literals don't compute anything and can't drift.

This PR covers the one genuine drift surface and nothing else.

## Test plan

- [x] `bash -n claude/.claude/hooks/_lib.sh` — syntax clean
- [x] 561 tests pass (`pytest claude/.claude/ -x -q` — 3 new tests added)
- [x] `ruff check` clean
- [x] Code review passed
- [ ] End-to-end smoke: `/code-review` → marker written → `git commit` allowed (verified post-push by CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)