### PR TITLE
refactor(ci): rename workflow from Hook tests to Tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-# WARNING: The job id ("hook-tests") is the status check context string
+# WARNING: The job id ("tests") is the status check context string
 # referenced by branch protection on main. Renaming the job silently breaks
 # the required-check match. If you rename the job, also update the
 # required_status_checks.contexts list via:
@@ -6,7 +6,7 @@
 # (The workflow-level "name:" does NOT affect the context string for GitHub
 # Actions checks — only the job id does.)
 
-name: Hook tests
+name: Tests
 
 on:
   push:
@@ -17,11 +17,11 @@ permissions:
   contents: read
 
 concurrency:
-  group: hooks-${{ github.ref }}
+  group: tests-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  hook-tests:
+  tests:
     runs-on: ubuntu-24.04
     timeout-minutes: 2
     steps:
@@ -55,7 +55,7 @@ jobs:
           # Include any directory that contains test files or whose contents are
           # read by tests. Update this list when a new test or test-input
           # directory appears under claude/.claude/.
-          REGEX='^(claude/\.claude/(hooks|skills|scripts|tests)/|\.github/workflows/hooks\.yml|pyproject\.toml)'
+          REGEX='^(claude/\.claude/(hooks|skills|scripts|tests)/|\.github/workflows/tests\.yml|pyproject\.toml)'
 
           MATCHED=$(echo "$CHANGED" | grep -E "$REGEX" || true)
           UNMATCHED=$(echo "$CHANGED" | grep -vE "$REGEX" || true)

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ Pytest suite covering hooks (allow, deny, and ask paths) and skill description c
 pytest claude/.claude/
 ```
 
-CI runs this on every PR and main push via `.github/workflows/hooks.yml`.
+CI runs this on every PR and main push via `.github/workflows/tests.yml`.
 
 ## Threat model
 

--- a/claude/.claude/hooks/tests/test_require_worktree_for_git_writes.py
+++ b/claude/.claude/hooks/tests/test_require_worktree_for_git_writes.py
@@ -359,7 +359,7 @@ class TestRequireWorktreeForGitWrites:
         assert (
             run_hook(
                 WORKTREE_HOOK,
-                bash_input("git log -- .github/workflows/hooks.yml"),
+                bash_input("git log -- .github/workflows/tests.yml"),
                 cwd=opted_in_repo,
             )
             == "allow"


### PR DESCRIPTION
## Summary

- The workflow runs `pytest` across hooks, skills, scripts, and tests — plus `ruff` lint — not just hooks. The name \"Hook tests\" and job id `hook-tests` understated its scope.
- Renames `.github/workflows/hooks.yml` → `tests.yml`, workflow `name:` → `Tests`, job id → `tests`, concurrency group → `tests-*`, and path-filter self-reference.
- Updates the README prose mention and a stale test fixture string in `test_require_worktree_for_git_writes.py`.

## Branch protection lockstep — do before merging

The job id rename changes the required status-check context string from `hook-tests` to `tests`. Before merging:

1. **Verify live BP state and check for concurrent PRs:**
   ```
   gh api repos/jcdendrite/claude-config/branches/main/protection --jq '.required_status_checks.contexts'
   gh pr list --state open
   ```
2. In GitHub UI: Settings → Branches → branch protection rule for `main` → required status checks → remove `hook-tests`, add `tests`. Save.
3. Wait for the `tests` check on this PR to go green, then merge.
4. Rebase any other open PRs onto post-merge `main` so they produce a `tests` check.

## Test plan

- [ ] Verify the Actions tab on this PR shows the workflow name **Tests** and the check is named **tests**
- [ ] After merge: confirm `gh api repos/jcdendrite/claude-config/branches/main/protection --jq '.required_status_checks.contexts'` lists `tests` and not `hook-tests`
- [ ] After merge: open a test PR touching `claude/.claude/hooks/` — confirm the `tests` check runs and is required
- [ ] After merge: open a README-only PR — confirm the workflow fires but skips pytest

🤖 Generated with [Claude Code](https://claude.com/claude-code)