### PR TITLE
fix(memory-hook): replace per-turn UUID debounce with active-marker bypass

### DIFF
--- a/claude/.claude/hooks/enforce-marker-script-shape.sh
+++ b/claude/.claude/hooks/enforce-marker-script-shape.sh
@@ -8,7 +8,7 @@
 # to fire this hook on ALL Bash commands. The internal grep is the actual
 # gate. The "if" field is a hint only.
 #
-# Any Bash command containing "marker.sh" must be one of the 10 valid
+# Any Bash command containing "marker.sh" must be one of the 12 valid
 # invocation shapes exactly. No chains, no env-var prefixes, no redirects,
 # no bash wrappers, no extra args. This prevents prompt-injection attacks
 # that chain marker.sh invocations with malicious commands and rely on the
@@ -48,7 +48,7 @@ fi
 # path form (/home/<user>/.claude/scripts/marker.sh) are both accepted.
 # No bash wrapper, no env-var prefix, no chain operator, no redirect, no
 # extra args after the skill name.
-VALID_PATTERN='^(~|/[A-Za-z0-9_./-]+)/\.claude/scripts/marker\.sh[[:space:]]+(write[[:space:]]+(code-review|skill-review|plan-review|ready-for-review)|(activate|deactivate)[[:space:]]+(plan-review|ready-for-review|respond-pr))[[:space:]]*$'
+VALID_PATTERN='^(~|/[A-Za-z0-9_./-]+)/\.claude/scripts/marker\.sh[[:space:]]+(write[[:space:]]+(code-review|skill-review|plan-review|ready-for-review)|(activate|deactivate)[[:space:]]+(plan-review|ready-for-review|respond-pr|memory-skill))[[:space:]]*$'
 
 if printf '%s' "$TRIMMED" | grep -qE "$VALID_PATTERN"; then
   exit 0
@@ -66,9 +66,11 @@ Valid shapes:
   ~/.claude/scripts/marker.sh activate plan-review
   ~/.claude/scripts/marker.sh activate ready-for-review
   ~/.claude/scripts/marker.sh activate respond-pr
+  ~/.claude/scripts/marker.sh activate memory-skill
   ~/.claude/scripts/marker.sh deactivate plan-review
   ~/.claude/scripts/marker.sh deactivate ready-for-review
   ~/.claude/scripts/marker.sh deactivate respond-pr
+  ~/.claude/scripts/marker.sh deactivate memory-skill
 
 No chains (&&, ||, ;), env-var prefixes, bash wrappers, redirects, or extra args."
 REASON_JSON=$(printf '%s' "$REASON" | jq -Rs .)

--- a/claude/.claude/hooks/require-memory-skill.sh
+++ b/claude/.claude/hooks/require-memory-skill.sh
@@ -2,7 +2,7 @@
 # set -uo pipefail but NOT -e: hooks inspect exit codes rather than aborting on them.
 set -uo pipefail
 # PreToolUse hook: block Write/Edit/MultiEdit to Claude Code auto-memory files
-# without a current ai-instruction-and-memory-files skill invocation for this turn.
+# without an active ai-instruction-and-memory-files skill session for this session.
 #
 # Matched tools: Write, Edit, MultiEdit (self-filters; do not rely solely on
 # the settings.json matcher condition).
@@ -17,29 +17,29 @@ set -uo pipefail
 #   pass through — the index-format and frontmatter rules were already observed
 #   when the file was first created.
 #
-# Per-turn debounce: the gate fires once per user turn, keyed by the uuid of
-# the latest type=="user" entry in the transcript. uuid (not mtime) is used
-# because turns can last seconds to minutes. After the first deny, the marker
-# stores the current turn's uuid; subsequent writes in the same turn see a
-# matching marker and pass through.
+# Active-bypass marker: ~/.claude/.memory-skill-active.d/<session_id> — written
+# by the ai-instruction-and-memory-files skill at Step 0 via
+# `marker.sh activate memory-skill`, removed at its final step via
+# `marker.sh deactivate memory-skill`. While THIS session's marker exists AND
+# is fresh (<60 min old), the hook allows through so the skill's own
+# Write/Edit calls during the memory-write session are not re-blocked.
+# mtime is refreshed on each bypass to handle long sessions that span multiple
+# memory writes without hitting the staleness cutoff.
 #
 # Fail-open conditions (exit 0 without denying):
 #   - session_id absent from input — cannot key a per-session marker
-#   - transcript_path absent from input — cannot read turn uuid
-#   - transcript has no type=="user" entries — no uuid to key on
 #   - unbound variable encountered (set -u) — exits non-zero but falls through
 #     to allow, since no JSON is emitted on an unbound-variable exit
 #
 # Bash-tool bypass: Bash writes (e.g. echo > file) bypass this gate because
-# the hook only intercepts Write/Edit/MultiEdit tool calls. This is an
-# acceptable limitation — realistic auto-memory writes use the Write tool.
+# the hook only intercepts Write/Edit/MultiEdit tool calls.
 #
 # Defense-in-depth: the hook filters its own input by tool name; do not
 # rely solely on the settings.json matcher condition.
 #
 # Exit codes:
 #   0      — allow (no opinion)
-#   0+JSON — deny (memory write without skill invocation this turn)
+#   0+JSON — deny (memory write without active skill session)
 
 INPUT=$(cat)
 TOOL_NAME=$(printf '%s\n' "$INPUT" | jq -r '.tool_name // empty')
@@ -80,33 +80,20 @@ if [ "$IS_CANDIDATE" -eq 0 ]; then
 fi
 
 SESSION_ID=$(printf '%s\n' "$INPUT" | jq -r '.session_id // empty')
-TRANSCRIPT_PATH=$(printf '%s\n' "$INPUT" | jq -r '.transcript_path // empty')
 
-# Fail open if we can't track turns.
-if [ -z "$SESSION_ID" ] || [ -z "$TRANSCRIPT_PATH" ]; then
+# Fail open if we can't key the per-session marker.
+if [ -z "$SESSION_ID" ]; then
   exit 0
 fi
 
-LATEST_UUID=$(tail -n 200 "$TRANSCRIPT_PATH" 2>/dev/null | jq -r 'select(.type=="user") | .uuid' 2>/dev/null | tail -1)
-
-# Fail open if there are no user messages in the transcript yet.
-if [ -z "$LATEST_UUID" ]; then
+# Active-bypass: fresh marker for THIS session means the skill is active —
+# allow through and refresh the marker's mtime so long sessions don't time out.
+ACTIVE_MARKER="$HOME/.claude/.memory-skill-active.d/$SESSION_ID"
+if [ -f "$ACTIVE_MARKER" ] && [ -n "$(find "$ACTIVE_MARKER" -mmin -60 2>/dev/null)" ]; then
+  touch "$ACTIVE_MARKER" 2>/dev/null
   exit 0
 fi
 
-MARKER_DIR="$HOME/.claude/.memory-skill-fired.d"
-MARKER="$MARKER_DIR/$SESSION_ID"
-
-# Per-turn debounce: if the marker's stored uuid matches the current turn's
-# latest user uuid, the skill already fired this turn — allow through.
-if [ -f "$MARKER" ] && [ "$(cat "$MARKER")" = "$LATEST_UUID" ]; then
-  exit 0
-fi
-
-# Record this turn's uuid and deny.
-mkdir -p "$MARKER_DIR"
-printf '%s' "$LATEST_UUID" > "$MARKER"
-
-REASON="Memory write blocked by ai-instruction-and-memory-files gate. You are writing to $FILE_PATH, which is part of Claude Code's auto-memory file system (MEMORY.md index or a new topic file). Invoke the ai-instruction-and-memory-files skill via the Skill tool first — it covers MEMORY.md index format, topic-file frontmatter, length budgets, and the type classification (user / feedback / project / reference). After invoking the skill, retry this write; subsequent memory writes in this turn will pass through."
+REASON="Memory write blocked by ai-instruction-and-memory-files gate. You are writing to $FILE_PATH, which is part of Claude Code's auto-memory file system (MEMORY.md index or a new topic file). Invoke the ai-instruction-and-memory-files skill via the Skill tool first — it covers MEMORY.md index format, topic-file frontmatter, length budgets, and the type classification (user / feedback / project / reference). The skill's Step 0 activates a bypass marker so all memory writes in the session pass through after the skill is loaded."
 REASON_JSON=$(printf '%s' "$REASON" | jq -Rs .)
 printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' "$REASON_JSON"

--- a/claude/.claude/hooks/tests/test_enforce_marker_script_shape.py
+++ b/claude/.claude/hooks/tests/test_enforce_marker_script_shape.py
@@ -13,7 +13,7 @@ ENFORCE_MARKER_SCRIPT_SHAPE_HOOK = HOOKS_DIR / "enforce-marker-script-shape.sh"
 
 class TestEnforceMarkerScriptShape:
     # ------------------------------------------------------------------ #
-    # Valid shapes — all 10 must be allowed                               #
+    # Valid shapes — all 12 must be allowed                               #
     # ------------------------------------------------------------------ #
 
     @pytest.mark.parametrize(
@@ -26,9 +26,11 @@ class TestEnforceMarkerScriptShape:
             "~/.claude/scripts/marker.sh activate plan-review",
             "~/.claude/scripts/marker.sh activate ready-for-review",
             "~/.claude/scripts/marker.sh activate respond-pr",
+            "~/.claude/scripts/marker.sh activate memory-skill",
             "~/.claude/scripts/marker.sh deactivate plan-review",
             "~/.claude/scripts/marker.sh deactivate ready-for-review",
             "~/.claude/scripts/marker.sh deactivate respond-pr",
+            "~/.claude/scripts/marker.sh deactivate memory-skill",
         ],
     )
     def test_valid_shapes_allowed(self, command):
@@ -113,6 +115,16 @@ class TestEnforceMarkerScriptShape:
     def test_mismatched_subcommand_skill_pair_denied(self):
         """code-review does not support activate — must be denied."""
         cmd = "~/.claude/scripts/marker.sh activate code-review"
+        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "deny"
+
+    def test_memory_skill_extra_arg_denied(self):
+        """activate memory-skill with a trailing arg must be denied."""
+        cmd = "~/.claude/scripts/marker.sh activate memory-skill extra"
+        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "deny"
+
+    def test_memory_skill_underscore_denied(self):
+        """Underscore form (memory_skill) is not in the allowlist."""
+        cmd = "~/.claude/scripts/marker.sh activate memory_skill"
         assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "deny"
 
     # ------------------------------------------------------------------ #

--- a/claude/.claude/hooks/tests/test_marker_script.py
+++ b/claude/.claude/hooks/tests/test_marker_script.py
@@ -38,9 +38,11 @@ class TestMarkerScriptSessionMissing:
             ["activate", "plan-review"],
             ["activate", "ready-for-review"],
             ["activate", "respond-pr"],
+            ["activate", "memory-skill"],
             ["deactivate", "plan-review"],
             ["deactivate", "ready-for-review"],
             ["deactivate", "respond-pr"],
+            ["deactivate", "memory-skill"],
         ],
     )
     def test_exits_2_when_session_file_missing(self, isolated_home, git_repo, args):
@@ -92,6 +94,22 @@ class TestMarkerScriptHappyPath:
         active_dir.mkdir(parents=True)
         (active_dir / sid).touch()
         result = _run(["deactivate", "plan-review"], cwd=git_repo, home=isolated_home)
+        assert result.returncode == 0, result.stderr
+        assert not (active_dir / sid).exists()
+
+    def test_activate_memory_skill_creates_active_marker(self, isolated_home, git_repo):
+        sid = self._seed_session(isolated_home)
+        result = _run(["activate", "memory-skill"], cwd=git_repo, home=isolated_home)
+        assert result.returncode == 0, result.stderr
+        active_file = isolated_home / ".claude" / ".memory-skill-active.d" / sid
+        assert active_file.exists()
+
+    def test_deactivate_memory_skill_removes_active_marker(self, isolated_home, git_repo):
+        sid = self._seed_session(isolated_home)
+        active_dir = isolated_home / ".claude" / ".memory-skill-active.d"
+        active_dir.mkdir(parents=True)
+        (active_dir / sid).touch()
+        result = _run(["deactivate", "memory-skill"], cwd=git_repo, home=isolated_home)
         assert result.returncode == 0, result.stderr
         assert not (active_dir / sid).exists()
 

--- a/claude/.claude/hooks/tests/test_require_memory_skill.py
+++ b/claude/.claude/hooks/tests/test_require_memory_skill.py
@@ -1,22 +1,27 @@
 """Tests for require-memory-skill.sh."""
 from __future__ import annotations
 
-import json
+import os
 import subprocess
+import time
 from pathlib import Path
 
 import pytest
 from helpers import (
     HOOKS_DIR,
+    SKILLS_DIR,
     bash_input,
     edit_input,
+    extract_skill_command,
     multiedit_input,
     run_hook,
     run_hook_reason,
+    run_skill_command,
     write_input,
 )
 
 HOOK_PATH = HOOKS_DIR / "require-memory-skill.sh"
+AI_MEMORY_SKILL = SKILLS_DIR / "ai-instruction-and-memory-files" / "SKILL.md"
 
 
 @pytest.fixture
@@ -36,158 +41,76 @@ def memory_tree(isolated_home):
     return mem_dir
 
 
-def write_transcript(tmp_path: Path, messages: list[dict]) -> str:
-    """Write a JSONL transcript file and return its path as a string.
-
-    Each dict in `messages` is written as one JSON line. Real Claude Code
-    transcript user records include at least `type` and `uuid` fields.
-    """
-    transcript = tmp_path / "transcript.jsonl"
-    with transcript.open("w") as fh:
-        for msg in messages:
-            fh.write(json.dumps(msg) + "\n")
-    return str(transcript)
+def _memory_input(base_input: dict, session_id: str) -> dict:
+    """Merge session_id into an existing tool-input dict."""
+    return {**base_input, "session_id": session_id}
 
 
-def _memory_input(base_input: dict, session_id: str, transcript_path: str) -> dict:
-    """Merge session_id and transcript_path into an existing tool-input dict."""
-    return {**base_input, "session_id": session_id, "transcript_path": transcript_path}
+def _write_active_marker(isolated_home: Path, session_id: str) -> Path:
+    """Create a fresh active-bypass marker for the given session."""
+    marker_dir = isolated_home / ".claude" / ".memory-skill-active.d"
+    marker_dir.mkdir(parents=True, exist_ok=True)
+    marker = marker_dir / session_id
+    marker.touch()
+    return marker
 
 
 class TestRequireMemorySkill:
-    def test_memory_md_edit_blocked(self, isolated_home, memory_tree, tmp_path):
-        """Edit on MEMORY.md is denied (no marker for this turn)."""
-        transcript = write_transcript(
-            tmp_path, [{"type": "user", "uuid": "uuid-1"}]
-        )
+    def test_memory_md_edit_blocked(self, isolated_home, memory_tree):
+        """Edit on MEMORY.md is denied (no active marker for this session)."""
         memory_md = str(memory_tree / "MEMORY.md")
-        payload = _memory_input(edit_input(memory_md), "sess-edit", transcript)
+        payload = _memory_input(edit_input(memory_md), "sess-edit")
         assert run_hook(HOOK_PATH, payload) == "deny"
 
-    def test_memory_md_write_blocked(self, isolated_home, memory_tree, tmp_path):
+    def test_memory_md_write_blocked(self, isolated_home, memory_tree):
         """Write to MEMORY.md is denied."""
-        transcript = write_transcript(
-            tmp_path, [{"type": "user", "uuid": "uuid-2"}]
-        )
         memory_md = str(memory_tree / "MEMORY.md")
-        payload = _memory_input(write_input(memory_md), "sess-write", transcript)
+        payload = _memory_input(write_input(memory_md), "sess-write")
         assert run_hook(HOOK_PATH, payload) == "deny"
 
-    def test_memory_md_multiedit_blocked(self, isolated_home, memory_tree, tmp_path):
+    def test_memory_md_multiedit_blocked(self, isolated_home, memory_tree):
         """MultiEdit on MEMORY.md is denied."""
-        transcript = write_transcript(
-            tmp_path, [{"type": "user", "uuid": "uuid-3"}]
-        )
         memory_md = str(memory_tree / "MEMORY.md")
-        payload = _memory_input(multiedit_input(memory_md), "sess-multiedit", transcript)
+        payload = _memory_input(multiedit_input(memory_md), "sess-multiedit")
         assert run_hook(HOOK_PATH, payload) == "deny"
 
-    def test_new_topic_file_write_blocked(self, isolated_home, memory_tree, tmp_path):
+    def test_new_topic_file_write_blocked(self, isolated_home, memory_tree):
         """Write to a non-existent path under memory/ is denied (new topic file)."""
-        transcript = write_transcript(
-            tmp_path, [{"type": "user", "uuid": "uuid-4"}]
-        )
         new_topic = str(memory_tree / "new_topic.md")
-        # Confirm the file doesn't exist — the hook's class-(b) check requires it.
         assert not Path(new_topic).exists()
-        payload = _memory_input(write_input(new_topic), "sess-new-topic", transcript)
+        payload = _memory_input(write_input(new_topic), "sess-new-topic")
         assert run_hook(HOOK_PATH, payload) == "deny"
 
-    def test_existing_topic_file_edit_allowed(self, isolated_home, memory_tree, tmp_path):
+    def test_existing_topic_file_edit_allowed(self, isolated_home, memory_tree):
         """Edit on an existing topic file passes through (only new files are gated)."""
-        transcript = write_transcript(
-            tmp_path, [{"type": "user", "uuid": "uuid-5"}]
-        )
         existing = str(memory_tree / "user_role.md")
-        payload = _memory_input(edit_input(existing), "sess-existing-edit", transcript)
+        payload = _memory_input(edit_input(existing), "sess-existing-edit")
         assert run_hook(HOOK_PATH, payload) == "allow"
 
-    def test_existing_topic_file_write_allowed(self, isolated_home, memory_tree, tmp_path):
+    def test_existing_topic_file_write_allowed(self, isolated_home, memory_tree):
         """Write overwriting an existing topic file passes through."""
-        transcript = write_transcript(
-            tmp_path, [{"type": "user", "uuid": "uuid-6"}]
-        )
         existing = str(memory_tree / "user_role.md")
-        payload = _memory_input(write_input(existing), "sess-existing-write", transcript)
+        payload = _memory_input(write_input(existing), "sess-existing-write")
         assert run_hook(HOOK_PATH, payload) == "allow"
 
-    def test_non_memory_path_allowed(self, isolated_home, tmp_path):
+    def test_non_memory_path_allowed(self, isolated_home):
         """Edit on a path outside the memory directory passes through."""
-        transcript = write_transcript(
-            tmp_path, [{"type": "user", "uuid": "uuid-7"}]
-        )
         readme = str(isolated_home / "some-project" / "README.md")
-        payload = _memory_input(edit_input(readme), "sess-non-memory", transcript)
+        payload = _memory_input(edit_input(readme), "sess-non-memory")
         assert run_hook(HOOK_PATH, payload) == "allow"
 
-    def test_bash_tool_allowed(self, isolated_home, tmp_path):
+    def test_bash_tool_allowed(self, isolated_home):
         """Bash input passes through — self-filter by tool name."""
         payload = bash_input("echo hello", session_id="sess-bash")
         assert run_hook(HOOK_PATH, payload) == "allow"
 
-    def test_per_turn_debounce_same_uuid(self, isolated_home, memory_tree, tmp_path):
-        """First deny writes the marker; second call in the same turn is allowed."""
-        transcript = write_transcript(
-            tmp_path, [{"type": "user", "uuid": "uuid-dedup"}]
-        )
-        memory_md = str(memory_tree / "MEMORY.md")
-        payload = _memory_input(edit_input(memory_md), "sess-dedup", transcript)
-
-        # First call → deny and write marker.
-        assert run_hook(HOOK_PATH, payload) == "deny"
-
-        # Second call with the same transcript (same latest uuid) → allow.
-        assert run_hook(HOOK_PATH, payload) == "allow"
-
-    def test_new_turn_re_blocks(self, isolated_home, memory_tree, tmp_path):
-        """After a new user message, the next call is denied again."""
-        transcript_path = tmp_path / "transcript.jsonl"
-        transcript_path.write_text(
-            json.dumps({"type": "user", "uuid": "uuid-turn1"}) + "\n"
-        )
-        memory_md = str(memory_tree / "MEMORY.md")
-        payload = _memory_input(
-            edit_input(memory_md), "sess-newturn", str(transcript_path)
-        )
-
-        # First turn → deny.
-        assert run_hook(HOOK_PATH, payload) == "deny"
-
-        # Append a new user message (new turn).
-        with transcript_path.open("a") as fh:
-            fh.write(json.dumps({"type": "user", "uuid": "uuid-turn2"}) + "\n")
-
-        # The payload references the same transcript path — hook re-reads it.
-        assert run_hook(HOOK_PATH, payload) == "deny"
-
-    def test_missing_session_id_allows(self, isolated_home, memory_tree, tmp_path):
+    def test_missing_session_id_allows(self, isolated_home, memory_tree):
         """Edit on MEMORY.md with no session_id in input passes through (fail open)."""
-        transcript = write_transcript(
-            tmp_path, [{"type": "user", "uuid": "uuid-nosess"}]
-        )
         memory_md = str(memory_tree / "MEMORY.md")
-        # Build payload without session_id.
-        payload = {**edit_input(memory_md), "transcript_path": transcript}
+        payload = edit_input(memory_md)
         assert run_hook(HOOK_PATH, payload) == "allow"
 
-    def test_missing_transcript_path_allows(self, isolated_home, memory_tree, tmp_path):
-        """Edit on MEMORY.md with no transcript_path in input passes through."""
-        memory_md = str(memory_tree / "MEMORY.md")
-        # Build payload without transcript_path.
-        payload = {**edit_input(memory_md), "session_id": "sess-notranscript"}
-        assert run_hook(HOOK_PATH, payload) == "allow"
-
-    def test_transcript_no_user_messages_allows(self, isolated_home, memory_tree, tmp_path):
-        """Transcript with no type=='user' entries passes through (fail open)."""
-        transcript = write_transcript(
-            tmp_path,
-            [{"type": "assistant", "uuid": "uuid-asst"}],
-        )
-        memory_md = str(memory_tree / "MEMORY.md")
-        payload = _memory_input(edit_input(memory_md), "sess-nousers", transcript)
-        assert run_hook(HOOK_PATH, payload) == "allow"
-
-    def test_malformed_json_stdin(self, isolated_home, tmp_path):
+    def test_malformed_json_stdin(self, isolated_home):
         """Malformed JSON stdin must not crash the hook and must exit 0."""
         result = subprocess.run(
             [str(HOOK_PATH)],
@@ -198,14 +121,109 @@ class TestRequireMemorySkill:
         assert result.returncode == 0
         assert result.stdout.strip() == ""
 
-    def test_deny_message_mentions_skill_name(self, isolated_home, memory_tree, tmp_path):
-        """Deny reason must reference ai-instruction-and-memory-files so the agent
-        knows which skill to invoke."""
-        transcript = write_transcript(
-            tmp_path, [{"type": "user", "uuid": "uuid-reason-check"}]
-        )
+    def test_deny_message_mentions_skill_name(self, isolated_home, memory_tree):
+        """Deny reason must reference ai-instruction-and-memory-files."""
         memory_md = str(memory_tree / "MEMORY.md")
-        payload = _memory_input(edit_input(memory_md), "sess-reason", transcript)
+        payload = _memory_input(edit_input(memory_md), "sess-reason")
         reason = run_hook_reason(HOOK_PATH, payload)
         assert reason is not None
         assert "ai-instruction-and-memory-files" in reason
+
+    # -- Active-marker bypass tests ------------------------------------------
+
+    def test_active_marker_present_allows(self, isolated_home, memory_tree):
+        """Fresh active-bypass marker allows Edit on MEMORY.md through."""
+        sid = "sess-active-allow"
+        _write_active_marker(isolated_home, sid)
+        memory_md = str(memory_tree / "MEMORY.md")
+        payload = _memory_input(edit_input(memory_md), sid)
+        assert run_hook(HOOK_PATH, payload) == "allow"
+
+    def test_active_marker_stale_denies(self, isolated_home, memory_tree):
+        """Marker older than 60 minutes does not bypass — gate re-fires."""
+        sid = "sess-stale"
+        marker = _write_active_marker(isolated_home, sid)
+        # Set mtime to 61 minutes ago.
+        stale_time = time.time() - 61 * 60
+        os.utime(marker, (stale_time, stale_time))
+        memory_md = str(memory_tree / "MEMORY.md")
+        payload = _memory_input(edit_input(memory_md), sid)
+        assert run_hook(HOOK_PATH, payload) == "deny"
+
+    def test_active_marker_mtime_refreshed_on_bypass(self, isolated_home, memory_tree):
+        """Hook touches the marker on each bypass so long sessions stay alive."""
+        sid = "sess-refresh"
+        marker = _write_active_marker(isolated_home, sid)
+        # Set mtime to 55 minutes ago — still fresh but clearly in the past.
+        old_time = time.time() - 55 * 60
+        os.utime(marker, (old_time, old_time))
+        memory_md = str(memory_tree / "MEMORY.md")
+        payload = _memory_input(edit_input(memory_md), sid)
+        assert run_hook(HOOK_PATH, payload) == "allow"
+        # Mtime must now be within the last minute.
+        refreshed_mtime = marker.stat().st_mtime
+        assert (time.time() - refreshed_mtime) < 60, (
+            "Hook did not refresh the marker's mtime on bypass — "
+            "long sessions will hit the 60-min staleness cutoff mid-run."
+        )
+
+    def test_active_marker_other_session_does_not_bypass(self, isolated_home, memory_tree):
+        """Active marker keyed to a different session_id does not bypass this session."""
+        _write_active_marker(isolated_home, "sess-other")
+        memory_md = str(memory_tree / "MEMORY.md")
+        payload = _memory_input(edit_input(memory_md), "sess-current")
+        assert run_hook(HOOK_PATH, payload) == "deny"
+
+    # -- Skill ↔ hook alignment -----------------------------------------------
+    # Execute the SKILL.md activate / deactivate recipes verbatim. If the skill
+    # body drifts from the marker layout require-memory-skill.sh expects, these fail.
+
+    def test_skill_activate_command_creates_bypass_marker(
+        self, isolated_home, memory_tree, git_repo
+    ):
+        """Run the SKILL.md activate-gate recipe and verify the resulting marker
+        authorizes a previously-gated Edit on MEMORY.md."""
+        sid = "test-session-memory-skill-activate"
+        sessions_dir = isolated_home / ".claude" / "sessions"
+        sessions_dir.mkdir(parents=True)
+        (sessions_dir / str(os.getpid())).write_text(sid)
+
+        memory_md = str(memory_tree / "MEMORY.md")
+        assert (
+            run_hook(HOOK_PATH, _memory_input(edit_input(memory_md), sid)) == "deny"
+        ), "precondition: MEMORY.md edit must be gated before activate runs"
+
+        activate_command = extract_skill_command(AI_MEMORY_SKILL, "activate-gate")
+        run_skill_command(activate_command, cwd=git_repo, isolated_home=isolated_home)
+
+        marker = isolated_home / ".claude" / ".memory-skill-active.d" / sid
+        assert marker.exists(), (
+            "SKILL.md activate-gate recipe ran but no marker landed at the "
+            "path the hook checks — the skill and hook disagree on layout."
+        )
+        assert run_hook(HOOK_PATH, _memory_input(edit_input(memory_md), sid)) == "allow"
+
+    def test_skill_deactivate_command_removes_bypass_marker(
+        self, isolated_home, memory_tree, git_repo
+    ):
+        """Run activate then deactivate from SKILL.md; verify deactivate removes
+        the marker and the hook re-gates subsequent writes."""
+        sid = "test-session-memory-skill-deactivate"
+        sessions_dir = isolated_home / ".claude" / "sessions"
+        sessions_dir.mkdir(parents=True)
+        (sessions_dir / str(os.getpid())).write_text(sid)
+
+        activate_command = extract_skill_command(AI_MEMORY_SKILL, "activate-gate")
+        run_skill_command(activate_command, cwd=git_repo, isolated_home=isolated_home)
+        marker = isolated_home / ".claude" / ".memory-skill-active.d" / sid
+        assert marker.exists(), "activate-gate setup did not create the marker"
+
+        deactivate_command = extract_skill_command(AI_MEMORY_SKILL, "deactivate-gate")
+        run_skill_command(deactivate_command, cwd=git_repo, isolated_home=isolated_home)
+
+        assert not marker.exists(), (
+            "SKILL.md deactivate-gate recipe ran but the marker is still "
+            "present — the skill and hook disagree on the marker path."
+        )
+        memory_md = str(memory_tree / "MEMORY.md")
+        assert run_hook(HOOK_PATH, _memory_input(edit_input(memory_md), sid)) == "deny"

--- a/claude/.claude/scripts/marker.sh
+++ b/claude/.claude/scripts/marker.sh
@@ -15,8 +15,8 @@ Subcommands:
 
 Valid (subcommand, skill) combinations:
   write       code-review | skill-review | plan-review | ready-for-review
-  activate    plan-review | ready-for-review | respond-pr
-  deactivate  plan-review | ready-for-review | respond-pr
+  activate    plan-review | ready-for-review | respond-pr | memory-skill
+  deactivate  plan-review | ready-for-review | respond-pr | memory-skill
 EOF
 }
 
@@ -117,8 +117,13 @@ case "$SUBCOMMAND" in
         mkdir -p "$HOME/.claude/.respond-pr-active.d"
         touch "$HOME/.claude/.respond-pr-active.d/$SESSION_ID"
         ;;
+      memory-skill)
+        SESSION_ID=$(_resolve_session_id) || exit 2
+        mkdir -p "$HOME/.claude/.memory-skill-active.d"
+        touch "$HOME/.claude/.memory-skill-active.d/$SESSION_ID"
+        ;;
       *)
-        printf "marker.sh: 'activate %s' is not valid. 'activate' supports: plan-review, ready-for-review, respond-pr\n" "$SKILL" >&2
+        printf "marker.sh: 'activate %s' is not valid. 'activate' supports: plan-review, ready-for-review, respond-pr, memory-skill\n" "$SKILL" >&2
         exit 2
         ;;
     esac
@@ -138,8 +143,12 @@ case "$SUBCOMMAND" in
         SESSION_ID=$(_resolve_session_id) || exit 2
         rm -f "$HOME/.claude/.respond-pr-active.d/$SESSION_ID"
         ;;
+      memory-skill)
+        SESSION_ID=$(_resolve_session_id) || exit 2
+        rm -f "$HOME/.claude/.memory-skill-active.d/$SESSION_ID"
+        ;;
       *)
-        printf "marker.sh: 'deactivate %s' is not valid. 'deactivate' supports: plan-review, ready-for-review, respond-pr\n" "$SKILL" >&2
+        printf "marker.sh: 'deactivate %s' is not valid. 'deactivate' supports: plan-review, ready-for-review, respond-pr, memory-skill\n" "$SKILL" >&2
         exit 2
         ;;
     esac

--- a/claude/.claude/skills/ai-instruction-and-memory-files/REFERENCES.md
+++ b/claude/.claude/skills/ai-instruction-and-memory-files/REFERENCES.md
@@ -1,0 +1,11 @@
+# References — ai-instruction-and-memory-files
+
+Primary sources that informed the rules in SKILL.md. Not loaded at skill runtime;
+read manually when verifying a rule or adding new guidance.
+
+- [Claude Code — How Claude remembers your project](https://code.claude.com/docs/en/memory)
+- [Claude Code — Best Practices](https://code.claude.com/docs/en/best-practices)
+- [claude-code CHANGELOG.md](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md)
+- [agents.md standard](https://agents.md)
+- [Context Rot — Chroma Research](https://research.trychroma.com/context-rot)
+- [Writing a good CLAUDE.md — HumanLayer](https://www.humanlayer.dev/blog/writing-a-good-claude-md)

--- a/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
+++ b/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
@@ -21,11 +21,20 @@ description: >
 user-invocable: false
 ---
 
+## Step 0 — Activate gate session
+
+<!-- HOOK_TEST_FIXTURE: activate-gate — the hook-alignment test suite reads this block from claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md to verify it matches require-memory-skill.sh's active-marker layout. Do not duplicate elsewhere; the test re-reads it from here. -->
+```
+~/.claude/scripts/marker.sh activate memory-skill
+```
+
+While active, `require-memory-skill.sh` bypasses for this session (<60 min freshness; mtime refreshed on each pass). If the command fails (empty `SESSION_ID`), abort — `capture-session-id.sh` SessionStart hook did not run, and every gated memory write below will be blocked.
+
 # AI Instruction & Memory Files — Architecture
 
-The facts below come from primary sources (Anthropic docs, agents.md
-standard). Treat them as durable context: when CLAUDE.md / AGENTS.md
-questions come up, start here rather than re-researching.
+The facts below come from primary sources (URLs in co-located REFERENCES.md).
+When CLAUDE.md / AGENTS.md questions arise, start here; open REFERENCES.md
+only to verify a specific URL or quote.
 
 ## 1. Claude Code loads CLAUDE.md only — NOT AGENTS.md
 
@@ -181,11 +190,11 @@ the user is and how they prefer to collaborate, feedback calibration
 (corrections **and** validated judgment calls) with the *why* story,
 time-sensitive project context, and references to external systems.
 
-## 6. Primary sources
+## Final step — Deactivate gate session
 
-- [Claude Code — How Claude remembers your project](https://code.claude.com/docs/en/memory)
-- [Claude Code — Best Practices](https://code.claude.com/docs/en/best-practices)
-- [claude-code CHANGELOG.md](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md)
-- [agents.md standard](https://agents.md)
-- [Context Rot — Chroma Research](https://research.trychroma.com/context-rot)
-- [Writing a good CLAUDE.md — HumanLayer](https://www.humanlayer.dev/blog/writing-a-good-claude-md)
+<!-- HOOK_TEST_FIXTURE: deactivate-gate — the hook-alignment test suite reads this block from claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md to verify it matches require-memory-skill.sh's active-marker cleanup. Do not duplicate elsewhere; the test re-reads it from here. -->
+```
+~/.claude/scripts/marker.sh deactivate memory-skill
+```
+
+Removes this session's bypass marker. Orphaned markers (if the skill errors before reaching this step) expire automatically after 60 minutes.


### PR DESCRIPTION
## Summary

- Fixes memory gate false-positives caused by system-reminder injections advancing the per-turn UUID — each injection creates a new `type=="user"` transcript entry, so the debounce's "same turn" window never opens and writes that should pass re-deny
- Replaces UUID debounce with the active-bypass pattern (mirrors `plan-review` and `respond-pr`): the `ai-instruction-and-memory-files` skill writes `~/.claude/.<name>-active.d/<session_id>` at Step 0, hook bypasses while fresh (<60 min, mtime refreshed on each pass), skill removes marker at final step
- Extends `scripts/marker.sh` and `enforce-marker-script-shape.sh` with `activate memory-skill` / `deactivate memory-skill` (12 valid shapes total, up from 10)
- Adds Step 0 and Final step with `HOOK_TEST_FIXTURE` markers to `ai-instruction-and-memory-files/SKILL.md`; moves primary source URLs to new `REFERENCES.md` (repo convention for load-on-demand reference material) to keep SKILL.md at 200 lines

## Test plan

- [ ] 568 tests pass (`pytest claude/.claude/`)
- [ ] Ruff lint passes (`ruff check claude/.claude/`)
- [ ] Live smoke test: memory write gates correctly before skill invoked, passes after activate marker is written, re-gates after deactivate removes it
- [ ] System-reminder injection no longer re-denies writes mid-skill (the regression case this fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
