### PR TITLE
feat(ready-for-review): route verify-class commands through a subagent

### DIFF
--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -19,7 +19,7 @@
 
 ### Heavy command output
 
-Verify-class runs (full test suites, lint, typecheck, build) should run via the `Agent` tool with `subagent_type: general-purpose` — not directly via `Bash` in the parent. The subagent absorbs the output and returns a verdict plus any failure excerpts; the parent's prompt cache and working state stay intact. This applies to suite-level runs; commands scoped to a single test file or single test name during interactive debugging can stay inline.
+Verify-class runs (full test suites, lint, typecheck, build) should run via the `Agent` tool with `subagent_type: general-purpose` — not directly via `Bash` in the parent. The subagent writes full output to `${TMPDIR:-/tmp}/<command-slug>-<epoch-ms>.txt` and returns a structured verdict plus the file paths; the parent reads the file for more detail rather than re-running. This applies to suite-level runs; commands scoped to a single test file or single test name during interactive debugging can stay inline.
 
 ## Code Review
 

--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -17,6 +17,10 @@
 - Use descriptive variable and function names. No generic names.
 - When a session crosses ~300K output tokens, proactively suggest a handoff. Run `analyze-context.py` if unsure. Write a handoff file at `/tmp/<descriptive-task-slug>-handoff.md` (use a real slug, not the literal `<task>`), tell the user the exact path, and ask them to open a new session with: `Read <path> and continue.`
 
+### Heavy command output
+
+Verify-class runs (full test suites, lint, typecheck, build) should run via the `Agent` tool with `subagent_type: general-purpose` — not directly via `Bash` in the parent. The subagent absorbs the output and returns a verdict plus any failure excerpts; the parent's prompt cache and working state stay intact. This applies to suite-level runs; commands scoped to a single test file or single test name during interactive debugging can stay inline.
+
 ## Code Review
 
 - After writing or modifying code, run `/code-review` before presenting the code to the user. If the review finds issues, fix them first, then present the final version.

--- a/claude/.claude/skills/ready-for-review/SKILL.md
+++ b/claude/.claude/skills/ready-for-review/SKILL.md
@@ -60,7 +60,7 @@ commands. Otherwise inspect the config (`package.json`, `pyproject.toml`,
 `go.mod`, `Cargo.toml`, `Makefile`, CI workflows) to identify the project's
 test, lint, and typecheck commands. Do not invent — skip undefined steps.
 
-**Run the commands via the `Agent` tool with `subagent_type: general-purpose`** — not inline Bash. Suite-level output displaces parent working state and invalidates the prompt cache; fork is worse (inherits parent context). Report: per-command name/exit code/pass-fail, smallest failure excerpt (last ~50 lines or runner summary), overall PASS or FAIL. For more diagnosis, spawn a follow-up subagent — do not re-run inline.
+**Run the commands via the `Agent` tool with `subagent_type: general-purpose`** — not inline Bash. Suite-level output displaces parent working state and invalidates the prompt cache; fork is worse (inherits parent context). The subagent writes each command's full output to `${TMPDIR:-/tmp}/<slug>-<epoch-ms>.txt` (slug = command lowercased with non-alphanumeric runs collapsed to `-`, e.g. `npm test` → `npm-test`; epoch-ms via `date +%s%3N`), then returns: per-command name/exit code/pass-fail, smallest failure excerpt (last ~50 lines or runner summary), overall PASS or FAIL, and the output file paths. If the parent needs more detail, Read the file — do not re-run.
 
 **Inline exception.** Run a command directly only when scoped to a single test file or test name — e.g. `npx vitest run src/components/X.test.tsx` or `pytest -k test_y`. Suite-level runs always go through the subagent.
 

--- a/claude/.claude/skills/ready-for-review/SKILL.md
+++ b/claude/.claude/skills/ready-for-review/SKILL.md
@@ -55,14 +55,14 @@ If the chain fails (empty `SESSION_ID`), the `capture-session-id.sh` SessionStar
 
 ## 2. Verification (halt on fail)
 
-If the repo's CLAUDE.md has an explicit Testing or Verification
-section, run exactly what it specifies.
+If the repo's CLAUDE.md has a Testing or Verification section, use those
+commands. Otherwise inspect the config (`package.json`, `pyproject.toml`,
+`go.mod`, `Cargo.toml`, `Makefile`, CI workflows) to identify the project's
+test, lint, and typecheck commands. Do not invent — skip undefined steps.
 
-Otherwise, inspect the repo's config (`package.json` scripts,
-`pyproject.toml`, `go.mod`, `Cargo.toml`, `Makefile`, CI workflow
-files, etc.) and run the test, lint, and typecheck commands the
-project actually defines. Do not invent or guess commands — if the
-project doesn't define a lint step, don't add one.
+**Run the commands via the `Agent` tool with `subagent_type: general-purpose`** — not inline Bash. Suite-level output displaces parent working state and invalidates the prompt cache; fork is worse (inherits parent context). Report: per-command name/exit code/pass-fail, smallest failure excerpt (last ~50 lines or runner summary), overall PASS or FAIL. For more diagnosis, spawn a follow-up subagent — do not re-run inline.
+
+**Inline exception.** Run a command directly only when scoped to a single test file or test name — e.g. `npx vitest run src/components/X.test.tsx` or `pytest -k test_y`. Suite-level runs always go through the subagent.
 
 **Scope exceptions — skip step 2 entirely:** skip when the diff
 contains no executable code — only markdown, plans, or non-executable


### PR DESCRIPTION
## Summary

- **`claude/.claude/skills/ready-for-review/SKILL.md`** — Step 2 routes suite-level verification commands through `Agent` with `subagent_type: general-purpose` instead of inline Bash. The subagent writes each command's full output to `${TMPDIR:-/tmp}/<slug>-<epoch-ms>.txt` (slug = command lowercased with non-alphanumeric runs collapsed to `-`; epoch-ms via `date +%s%3N`), then returns a structured verdict (per-command status, smallest failure excerpt, overall PASS or FAIL) plus the output file paths. The parent reads the file for more detail rather than re-running or spawning a follow-up subagent.
- **`claude/.claude/CLAUDE.md`** — New `### Heavy command output` subsection under Working Style formalises the same rule globally, so ad-hoc "run the tests" requests honour it even when the skill isn't triggered.
- Inline exception preserved in both locations: commands scoped to a single test file or test name during interactive debugging may run directly in the parent.

## Why

Verify-class commands produce high-volume single-pass output that displaces parent working state and invalidates the prompt cache — and this compounds when verification runs multiple times per gate iteration. Subagent isolation keeps the parent context clean; writing output to a temp file lets the parent read more detail without re-running commands or spawning a second subagent. `${TMPDIR:-/tmp}` respects user-scoped temp dirs on macOS; epoch-ms prevents same-second collisions when commands run in parallel.

## Notes

- **Hard precondition before merge**: Plan B's Verification Step 0 (lock-hook compatibility check on the consuming project) must pass before this lands. Plan B applies the same rule to a project-scoped skill and verifies that the project's test-lock hook handles subagent execution correctly.
- Rule is fully generic; no private-project references.

## Test plan

- [x] `pytest claude/.claude/` — 568 passed (HOOK_TEST_FIXTURE blocks in steps 0 and 7 are untouched)
- [x] `ruff check claude/.claude/` — clean
- [x] `/skill-review` on SKILL.md diff — clean (behavioral-equivalence table has no N rows, both commits)
- [x] `/code-review` on full staged diff — no findings (both commits)
- [x] `ready-for-review/SKILL.md` line count: 200 (at limit, not over)
- [x] Temp file naming reviewed by `staff-platform-engineer` — F3 (epoch-ms), F1 (`${TMPDIR:-/tmp}`) addressed; F2/F4 accepted trade-offs

🤖 Generated with [Claude Code](https://claude.com/claude-code)