### PR TITLE
feat(context): proactive handoff + post-compact marker re-injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ flowchart LR
 - **`/ai-instruction-and-memory-files`** — how AI coding agents load instruction files (CLAUDE.md, AGENTS.md, Cursor rules, Lovable knowledge) and Claude Code auto-memory: precedence, duplication rules, length targets, import patterns.
 - **`/verify-primary-sources`** — when web research informs a code or design decision, read the primary documentation directly rather than trusting agent summaries or secondary sources.
 - **`/read-docx-comments`** — extract comments from `.docx` files with anchored text context.
+- **`/handoff`** — write a structured cross-session handoff file at `/tmp/<slug>-handoff.md` capturing goal, status, next step, modified files, active markers, open questions, and the resume incantation (`Read /tmp/<slug>-handoff.md and continue.`). User-invoked only — implemented as a slash command at `claude/.claude/commands/handoff.md`, not a skill, to keep it out of the always-loaded skills catalog. Claude proactively suggests `/handoff` when context usage exceeds ~60% with an incomplete task; you decide whether to invoke.
 
 Each skill lives in `claude/.claude/skills/<skill-name>/SKILL.md`. A skill directory may also contain a `REFERENCES.md` — canonical references (URLs, key quotes, framework notes) that informed the skill's rules. `REFERENCES.md` is not loaded during skill execution; consult it when editing a skill to verify a rule still holds or to add new guidance.
 
@@ -198,6 +199,35 @@ chmod +x ~/.claude/scripts/*
 - **`marker.sh`** — write and remove review markers on behalf of workflow skills. `/code-review`, `/skill-review`, `/plan-review`, `/ready-for-review`, and `/respond-pr` write review markers via `~/.claude/scripts/marker.sh`. The 10 valid invocation shapes are allowlisted in `settings.json` for silent auto-approval. A companion `enforce-marker-script-shape.sh` hook denies any other invocation (chains, env-var prefixes, redirects) to prevent prompt-injection escalation via the allowlist.
 
 - **`cleanup-merged-branches.sh`** — discovers all local branches whose PRs are merged (queried via `gh pr list --head <branch> --state merged`) and cleans them up: removes the worktree, force-deletes the local branch, prunes the remote tracking ref, deletes the remote branch if not auto-deleted, and fast-forwards the default branch. Run from any shell (or via `!` from any Claude session — auto-approved by the paired `permissions.allow` entries). Pass `--dry-run` to preview without acting.
+
+## Context management
+
+Claude Code compresses conversation history when the context window fills up. This config adds three layers to keep that process reliable.
+
+### How it works
+
+1. **Marker re-injection (automatic).** `session-marker-dashboard.sh` is registered with matcher `startup|clear|compact`, so it fires after `/compact` and `/clear` — not just on session start. It emits `hookSpecificOutput.additionalContext` with the current state of all active review-skill gate markers, restoring marker knowledge in the resumed context automatically. You don't need to do anything for this to work.
+
+2. **Compaction guidance (`COMPACT_INSTRUCTIONS.md`).** `claude/.claude/CLAUDE.md` points the compaction summarizer at `~/.claude/COMPACT_INSTRUCTIONS.md`, which defines the structured digest shape both `/compact` and `/handoff` produce. See the file for sections and per-section guidance. Whether the summarizer follows external references is unverified — if compaction still drops critical state, inline the file contents under `## State digest format` in CLAUDE.md as a fallback.
+
+3. **`/handoff` slash command (user-invoked).** When the task will continue in a fresh session, run `/handoff` to write a structured resume file at `/tmp/<slug>-handoff.md`. Claude proactively suggests this at ~60% context usage (same threshold Anthropic recommends for manual `/compact`) because:
+   - Quality: cleaner context → more accurate handoff.
+   - Token efficiency: once you decide to hand off, every turn beyond 60% is waste.
+
+### When to use which
+
+| Situation | Right action |
+|---|---|
+| Same session, conversation is noisy but task continues | `/compact` (guided by `COMPACT_INSTRUCTIONS.md`) |
+| Switching to an unrelated task | `/clear` (intent-driven, no percentage threshold) |
+| Ending a session, will resume later | `/handoff` (produces resume file) |
+| Context >83.5%: auto-compact fires | Happens automatically; marker state is restored by the hook |
+
+### Threshold reference
+
+- ~60%: suggested threshold for both `/compact` and `/handoff` — [Anthropic best practices](https://code.claude.com/docs/en/best-practices) cites 60% as the point where manual compaction produces the highest-quality summary.
+- ~83.5%: auto-compact trigger (community-reported; configurable via `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`).
+- Run `~/.claude/scripts/analyze-context.py` to inspect token usage for the current session.
 
 ## Worktree enforcement
 

--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -15,7 +15,7 @@
 - Always prefer minimal, targeted changes. Do not refactor entire files or expand scope beyond what was asked. If you see an opportunity for a broader improvement, mention it separately — do not bundle it in.
 - Before assuming anything about the environment, stack, or project conventions, check first. Read the actual config files rather than guessing defaults.
 - Use descriptive variable and function names. No generic names.
-- When a session crosses ~300K output tokens, proactively suggest a handoff. Run `analyze-context.py` if unsure. Write a handoff file at `/tmp/<descriptive-task-slug>-handoff.md` (use a real slug, not the literal `<task>`), tell the user the exact path, and ask them to open a new session with: `Read <path> and continue.`
+- When a session crosses ~60% context usage (visible via statusline `.context_window.used_percentage`) AND the current task is incomplete, proactively suggest the user run `/handoff`. This is the same threshold Anthropic recommends for manual `/compact`, for the same reasons: cleaner context produces a higher-quality handoff, and every turn beyond 60% burns tokens that the handoff was meant to save. Do not run it yourself — it's a user-invoked slash command. If the user agrees, the command writes `/tmp/<slug>-handoff.md` and provides the resume incantation. Run `analyze-context.py` if unsure about the threshold.
 
 ### Heavy command output
 
@@ -55,6 +55,10 @@ Comments must be readable by a future coder who has not read the PR description,
 - **No PR-defined terminology** in code comments (e.g., "Defense A", "Action 6", "Pattern C"). If a label is meaningful it must be defined in code (constant name, function name, type name) — not in a comment that depends on context outside the file.
 - **No "used to be X" / "was Y before"** framing. The rationale-vs-prior-version belongs in the commit message or PR body.
 - **Self-test:** if you can't write the comment such that it survives the PR being merged and the description being lost, don't write the comment. Move the rationale to the commit message instead.
+
+## Compact Instructions
+
+See `~/.claude/COMPACT_INSTRUCTIONS.md` for what to preserve and what may be dropped during conversation compaction.
 
 ## Output Preferences
 

--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -56,9 +56,9 @@ Comments must be readable by a future coder who has not read the PR description,
 - **No "used to be X" / "was Y before"** framing. The rationale-vs-prior-version belongs in the commit message or PR body.
 - **Self-test:** if you can't write the comment such that it survives the PR being merged and the description being lost, don't write the comment. Move the rationale to the commit message instead.
 
-## Compact Instructions
+## State digest format
 
-See `~/.claude/COMPACT_INSTRUCTIONS.md` for what to preserve and what may be dropped during conversation compaction.
+See `~/.claude/COMPACT_INSTRUCTIONS.md` for the structured digest shape both `/compact` and `/handoff` produce.
 
 ## Output Preferences
 

--- a/claude/.claude/COMPACT_INSTRUCTIONS.md
+++ b/claude/.claude/COMPACT_INSTRUCTIONS.md
@@ -1,0 +1,16 @@
+# Compaction Instructions
+
+Read this file when summarizing the conversation for `/compact` (manual or auto). Preserve:
+
+- Active markers in `~/.claude/*-markers/` and `~/.claude/.*-active.d/` — include filenames and which skill wrote them
+- Working directory and current git branch
+- The current task focus and most recent uncommitted work
+- File paths edited this session and their state (staged / unstaged / committed)
+- Open AskUserQuestion exchanges and pending decisions
+- Recent failed commands and their root causes
+
+You may drop:
+
+- Successful tool output already acted on
+- Exploratory dead-ends that didn't inform the final approach
+- Verbatim file contents already on disk (paths suffice)

--- a/claude/.claude/COMPACT_INSTRUCTIONS.md
+++ b/claude/.claude/COMPACT_INSTRUCTIONS.md
@@ -1,15 +1,38 @@
-# Compaction Instructions
+# State digest format
 
-Read this file when summarizing the conversation for `/compact` (manual or auto). Preserve:
+Read this file when summarizing the conversation for `/compact`
+(manual or auto). The same shape is used by `/handoff` for
+cross-session resume files — a context-reset agent reads the same
+digest regardless of how the context was reset.
 
-- Active markers in `~/.claude/*-markers/` and `~/.claude/.*-active.d/` — include filenames and which skill wrote them
-- Working directory and current git branch
-- The current task focus and most recent uncommitted work
-- File paths edited this session and their state (staged / unstaged / committed)
-- Open AskUserQuestion exchanges and pending decisions
-- Recent failed commands and their root causes
+Produce a summary with these sections, in order:
 
-You may drop:
+## §1 Goal
+One sentence: what was being attempted.
+
+## §2 Status
+done / in-flight / blocked.
+
+## §3 Next concrete step
+The exact command, file edit, or question to resume on. No vague
+"continue the work."
+
+## §4 Files modified this session
+Header line: working directory + current git branch.
+Then list paths edited this session and their state (staged /
+unstaged / committed). Include the most recent uncommitted work.
+
+## §5 Active gates / markers
+List active markers under `~/.claude/*-markers/` and
+`~/.claude/.*-active.d/` — filenames, which skill wrote each, and
+(for completion markers) the staged-diff hash the marker covers.
+
+## §6 Open questions / decisions deferred
+Open AskUserQuestion exchanges, pending decisions the user still
+owes a call on, and recent failed commands + root causes the
+resuming session needs to know.
+
+## You may drop
 
 - Successful tool output already acted on
 - Exploratory dead-ends that didn't inform the final approach

--- a/claude/.claude/commands/handoff.md
+++ b/claude/.claude/commands/handoff.md
@@ -1,0 +1,29 @@
+Write a cross-session handoff file that lets a fresh Claude session resume the current task without asking clarifying questions.
+
+## What to produce
+
+Write `/tmp/<descriptive-slug>-handoff.md` where the slug names the task, not the date. Examples: `respond-pr-skill-edge-case-handoff.md`, `claude-md-redaction-handoff.md`. Never use `<task>-handoff.md` literally.
+
+Target under 200 lines. Reference files by path; do not inline their contents.
+
+## Sections
+
+1. **Goal** — one sentence: what was being attempted.
+2. **Status** — done / in-flight / blocked.
+3. **Next concrete step** — the exact command, file edit, or question to resume on. No vague "continue the work."
+4. **Files modified this session** — run `git status` and `git diff --stat`; list paths and their state (staged / unstaged / committed).
+5. **Active gates / markers** — run:
+   ```
+   ls ~/.claude/review-markers/ ~/.claude/skill-review-markers/ ~/.claude/plan-review-markers/ ~/.claude/.*-active.d/ 2>/dev/null
+   ```
+   For each marker file: which skill wrote it, and (for completion markers) which staged-diff hash it covers.
+6. **Open questions / decisions deferred** — anything the user still owes a call on.
+7. **Resume command** — `Read /tmp/<slug>-handoff.md and continue.`
+
+## Pre-write checklist
+
+Before writing the file, verify:
+- No placeholder text ("TBD", "TODO", "fill in later") in any section
+- Status is consistent with Next concrete step and Open questions
+- You are not claiming "done" for any step whose verification is still pending
+- The resume command names the exact file you are about to write

--- a/claude/.claude/commands/handoff.md
+++ b/claude/.claude/commands/handoff.md
@@ -1,29 +1,32 @@
-Write a cross-session handoff file that lets a fresh Claude session resume the current task without asking clarifying questions.
+Write a cross-session handoff file at `/tmp/<descriptive-slug>-handoff.md`.
 
-## What to produce
+The file uses the structured shape defined in
+`~/.claude/COMPACT_INSTRUCTIONS.md` (§1–§6). Apply the same
+per-section guidance — the difference between a `/handoff` file and a
+`/compact` summary is the carrier (file vs. inline summary), not the
+content shape.
 
-Write `/tmp/<descriptive-slug>-handoff.md` where the slug names the task, not the date. Examples: `respond-pr-skill-edge-case-handoff.md`, `claude-md-redaction-handoff.md`. Never use `<task>-handoff.md` literally.
+After §6, append:
 
-Target under 200 lines. Reference files by path; do not inline their contents.
+## §7 Resume command
+`Read /tmp/<slug>-handoff.md and continue.`
 
-## Sections
+## Slug naming
 
-1. **Goal** — one sentence: what was being attempted.
-2. **Status** — done / in-flight / blocked.
-3. **Next concrete step** — the exact command, file edit, or question to resume on. No vague "continue the work."
-4. **Files modified this session** — run `git status` and `git diff --stat`; list paths and their state (staged / unstaged / committed).
-5. **Active gates / markers** — run:
-   ```
-   ls ~/.claude/review-markers/ ~/.claude/skill-review-markers/ ~/.claude/plan-review-markers/ ~/.claude/.*-active.d/ 2>/dev/null
-   ```
-   For each marker file: which skill wrote it, and (for completion markers) which staged-diff hash it covers.
-6. **Open questions / decisions deferred** — anything the user still owes a call on.
-7. **Resume command** — `Read /tmp/<slug>-handoff.md and continue.`
+The slug names the task, not the date. Examples:
+`respond-pr-skill-edge-case-handoff.md`,
+`claude-md-redaction-handoff.md`. Never use `<task>-handoff.md`
+literally.
+
+Target under 200 lines. Reference files by path; do not inline
+contents.
 
 ## Pre-write checklist
 
 Before writing the file, verify:
+- Every section §1–§6 from `~/.claude/COMPACT_INSTRUCTIONS.md` is populated
 - No placeholder text ("TBD", "TODO", "fill in later") in any section
-- Status is consistent with Next concrete step and Open questions
+- §2 Status is consistent with §3 Next concrete step and §6 Open questions
 - You are not claiming "done" for any step whose verification is still pending
-- The resume command names the exact file you are about to write
+- §7 Resume command names the exact file you are about to write
+- Markers in §5 use the globs `~/.claude/*-markers/` and `~/.claude/.*-active.d/` — not a hardcoded subdir list

--- a/claude/.claude/hooks/session-marker-dashboard.sh
+++ b/claude/.claude/hooks/session-marker-dashboard.sh
@@ -2,15 +2,15 @@
 # SessionStart hook: surface active gate-bypass marker state to the resuming
 # Claude session.
 #
-# Audience: Claude (the agent), not humans. The harness injects plain-text
-# stdout from SessionStart hooks directly into the agent's conversation context
-# at session start. This lets a new session — after compaction or restart —
-# see which review-skill gates are already bypassed without having to rediscover
-# the on-disk state itself.
+# Audience: Claude (the agent), not humans. Output is a JSON payload with
+# hookSpecificOutput.additionalContext — the harness injects it into the
+# agent's conversation context. Registered with matcher "startup|clear|compact"
+# so it fires on fresh starts AND after /compact and /clear, restoring marker
+# knowledge in each resumed context.
 #
-# Emits output only when at least one active marker is present or stale.
-# All-absent (normal fresh-session state) produces no output, keeping routine
-# session starts noise-free.
+# Emits hookSpecificOutput only when at least one active marker is present or
+# stale. All-absent (normal fresh-session state) produces no output, keeping
+# routine session starts noise-free.
 #
 # Active markers are session-scoped (keyed by session_id) so they can be
 # checked here regardless of which git repo the session opens in. Completion
@@ -55,7 +55,8 @@ if [ "$PLAN_REVIEW_STATUS" = "absent" ] \
   exit 0
 fi
 
-printf "Active review-skill gate markers detected for this session. Each line below shows one skill's bypass state — \"present\" means the gate is bypassed (skill is mid-run or was interrupted); \"stale\" (>60 min old) means the bypass has expired and the gate is back in force.\n"
-printf "  plan-review-active: %s\n" "$PLAN_REVIEW_STATUS"
-printf "  ready-for-review-active: %s\n" "$READY_FOR_REVIEW_STATUS"
-printf "  respond-pr-active: %s\n" "$RESPOND_PR_STATUS"
+ADDITIONAL_CONTEXT=$(printf 'Active review-skill gate markers detected for this session. Each line below shows one skill'"'"'s bypass state — "present" means the gate is bypassed (skill is mid-run or was interrupted); "stale" (>60 min old) means the bypass has expired and the gate is back in force.\n  plan-review-active: %s\n  ready-for-review-active: %s\n  respond-pr-active: %s' \
+  "$PLAN_REVIEW_STATUS" "$READY_FOR_REVIEW_STATUS" "$RESPOND_PR_STATUS")
+jq -n --arg ctx "$ADDITIONAL_CONTEXT" \
+  '{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: $ctx}}' || true
+exit 0

--- a/claude/.claude/hooks/tests/test_session_marker_dashboard.py
+++ b/claude/.claude/hooks/tests/test_session_marker_dashboard.py
@@ -1,9 +1,10 @@
 """Tests for session-marker-dashboard.sh.
 
-The hook is a SessionStart hook whose stdout is injected by the harness
-into the Claude session's conversation context. It surfaces existing
-active-marker state so Claude can see which review-skill gates are
-currently bypassed when resuming after compaction.
+The hook is a SessionStart hook (matcher: startup|clear|compact) that emits
+hookSpecificOutput.additionalContext — the harness injects this JSON payload
+into the agent's conversation context on session start, /clear, and /compact.
+It surfaces existing active-marker state so Claude can see which review-skill
+gates are currently bypassed when resuming after compaction.
 
 Output is emitted only when at least one active marker is present or
 stale — an all-absent state (normal fresh session) produces no output.
@@ -32,6 +33,11 @@ def _run_dashboard(payload: dict, isolated_home: Path) -> subprocess.CompletedPr
     )
 
 
+def _additional_context(result: subprocess.CompletedProcess) -> str:
+    """Parse the hookSpecificOutput.additionalContext from the hook's JSON output."""
+    return json.loads(result.stdout)["hookSpecificOutput"]["additionalContext"]
+
+
 class TestSessionMarkerDashboard:
     def test_all_absent_produces_no_output(self, isolated_home):
         """When no active markers exist, the hook exits silently."""
@@ -39,19 +45,20 @@ class TestSessionMarkerDashboard:
         assert result.returncode == 0
         assert result.stdout == ""
 
-    def test_fresh_plan_review_marker_prints_dashboard(self, isolated_home):
-        """A fresh plan-review-active marker triggers dashboard output."""
+    def test_fresh_plan_review_marker_emits_json(self, isolated_home):
+        """A fresh plan-review-active marker triggers JSON dashboard output."""
         sid = "sess-pr-active"
         marker_dir = isolated_home / ".claude" / ".plan-review-active.d"
         marker_dir.mkdir(parents=True)
         (marker_dir / sid).touch()
         result = _run_dashboard({"session_id": sid}, isolated_home)
         assert result.returncode == 0
-        assert "plan-review-active" in result.stdout
-        assert "present" in result.stdout
+        ctx = _additional_context(result)
+        assert "plan-review-active" in ctx
+        assert "present" in ctx
 
     def test_stale_plan_review_marker_shows_stale(self, isolated_home):
-        """A >60-min-old active marker is labelled 'stale'."""
+        """A >60-min-old active marker is labelled 'stale' in the context."""
         sid = "sess-pr-stale"
         marker_dir = isolated_home / ".claude" / ".plan-review-active.d"
         marker_dir.mkdir(parents=True)
@@ -61,30 +68,33 @@ class TestSessionMarkerDashboard:
         os.utime(marker, (ninety_min_ago, ninety_min_ago))
         result = _run_dashboard({"session_id": sid}, isolated_home)
         assert result.returncode == 0
-        assert "stale" in result.stdout
-        assert "plan-review-active" in result.stdout
+        ctx = _additional_context(result)
+        assert "stale" in ctx
+        assert "plan-review-active" in ctx
 
     def test_respond_pr_marker_triggers_output(self, isolated_home):
-        """A respond-pr-active marker also triggers the dashboard."""
+        """A respond-pr-active marker triggers dashboard output."""
         sid = "sess-rpr-active"
         marker_dir = isolated_home / ".claude" / ".respond-pr-active.d"
         marker_dir.mkdir(parents=True)
         (marker_dir / sid).touch()
         result = _run_dashboard({"session_id": sid}, isolated_home)
         assert result.returncode == 0
-        assert "respond-pr-active" in result.stdout
-        assert "present" in result.stdout
+        ctx = _additional_context(result)
+        assert "respond-pr-active" in ctx
+        assert "present" in ctx
 
     def test_ready_for_review_marker_triggers_output(self, isolated_home):
-        """A ready-for-review-active marker triggers the dashboard."""
+        """A ready-for-review-active marker triggers dashboard output."""
         sid = "sess-rfr-active"
         marker_dir = isolated_home / ".claude" / ".ready-for-review-active.d"
         marker_dir.mkdir(parents=True)
         (marker_dir / sid).touch()
         result = _run_dashboard({"session_id": sid}, isolated_home)
         assert result.returncode == 0
-        assert "ready-for-review-active" in result.stdout
-        assert "present" in result.stdout
+        ctx = _additional_context(result)
+        assert "ready-for-review-active" in ctx
+        assert "present" in ctx
 
     def test_other_sessions_marker_does_not_trigger(self, isolated_home):
         """Session A's active marker must not appear in session B's dashboard."""
@@ -102,7 +112,7 @@ class TestSessionMarkerDashboard:
         assert result.stdout == ""
 
     def test_all_three_markers_all_shown(self, isolated_home):
-        """When all three skills have active markers, all three appear."""
+        """When all three skills have active markers, all three appear in context."""
         sid = "sess-all-active"
         for skill in ("plan-review", "ready-for-review", "respond-pr"):
             marker_dir = isolated_home / ".claude" / f".{skill}-active.d"
@@ -110,9 +120,23 @@ class TestSessionMarkerDashboard:
             (marker_dir / sid).touch()
         result = _run_dashboard({"session_id": sid}, isolated_home)
         assert result.returncode == 0
-        assert "plan-review-active: present" in result.stdout
-        assert "ready-for-review-active: present" in result.stdout
-        assert "respond-pr-active: present" in result.stdout
+        ctx = _additional_context(result)
+        assert "plan-review-active: present" in ctx
+        assert "ready-for-review-active: present" in ctx
+        assert "respond-pr-active: present" in ctx
+
+    def test_output_is_valid_json_with_correct_shape(self, isolated_home):
+        """When markers are active, output must be parseable JSON with hookEventName + additionalContext."""
+        sid = "sess-json-shape"
+        marker_dir = isolated_home / ".claude" / ".plan-review-active.d"
+        marker_dir.mkdir(parents=True)
+        (marker_dir / sid).touch()
+        result = _run_dashboard({"session_id": sid}, isolated_home)
+        assert result.returncode == 0
+        parsed = json.loads(result.stdout)
+        hook_output = parsed["hookSpecificOutput"]
+        assert hook_output["hookEventName"] == "SessionStart"
+        assert isinstance(hook_output["additionalContext"], str)
 
     def test_exit_0_always(self, isolated_home):
         """Hook must always exit 0 to avoid blocking session startup."""

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -6,7 +6,12 @@
           {
             "type": "command",
             "command": "~/.claude/hooks/capture-session-id.sh"
-          },
+          }
+        ]
+      },
+      {
+        "matcher": "startup|clear|compact",
+        "hooks": [
           {
             "type": "command",
             "command": "~/.claude/hooks/session-marker-dashboard.sh"


### PR DESCRIPTION
## Summary

- **Phase 0 — marker re-injection after /compact and /clear:** `session-marker-dashboard.sh` now has `"matcher": "startup|clear|compact"` in settings.json, so it re-fires after compaction and clears. Output converted from plain-text stdout to `hookSpecificOutput.additionalContext` JSON (with `hookEventName: "SessionStart"` per the documented Claude Code hook contract). Fixes the core complaint: post-compact Claude now has fresh on-disk marker knowledge.

- **Phase 1 — state digest format (`COMPACT_INSTRUCTIONS.md`):** New `claude/.claude/COMPACT_INSTRUCTIONS.md` defines a **structured digest shape** (§1 Goal → §2 Status → §3 Next concrete step → §4 Files → §5 Markers → §6 Open questions) that both `/compact` and `/handoff` produce. Both modes deliver a state digest to a context-reset agent with the same information need — the carrier differs (inline summary vs. file) but the shape is canonical. `CLAUDE.md` references the file under `## State digest format`.

- **Phase 2 — `/handoff` slash command:** New `claude/.claude/commands/handoff.md` is a thin shell over the COMPACT_INSTRUCTIONS shape. It tells Claude to write a file at `/tmp/<slug>-handoff.md` using §1–§6 from `COMPACT_INSTRUCTIONS.md`, then append §7 Resume command plus a pre-write checklist. Slash command (not a skill) to avoid loading into the always-active skills catalog. `CLAUDE.md` nudge now suggests `/handoff` at ~60% context usage — matching Anthropic's recommended manual-/compact threshold (same rationale: cleaner context = better output, and every turn beyond 60% burns tokens destined for waste).

- **Phase 3 — README:** Documents all three layers, the decision table (compact vs clear vs handoff), and the threshold guide (60% / 83.5%).

## Post-merge: re-run install.sh

This PR adds two new top-level entries under `claude/.claude/`:
- `claude/.claude/COMPACT_INSTRUCTIONS.md`
- `claude/.claude/commands/`

Stow links each top-level child individually. These new entries **will not appear in `~/.claude/` on `git pull` alone** — symlinks are only created when stow runs. After merging, run:

```bash
./install.sh
```

Without this, `/handoff` won't be discoverable and `COMPACT_INSTRUCTIONS.md` won't be referenced by CLAUDE.md at runtime.

## Key implementation decision verified from official docs

- `"matcher": "startup|clear|compact"` for `SessionStart` is the exact documented syntax — `startup`, `clear`, `compact` are valid trigger values (plus `resume`).
- `hookSpecificOutput.hookEventName` is required alongside `additionalContext` in the JSON form.
- Plain-text stdout also works for `SessionStart` context injection per docs — but the JSON form is more explicit and forward-compatible.

## Phase 1 verification needed (open question)

CLAUDE.md says "See `~/.claude/COMPACT_INSTRUCTIONS.md`" but it's unverified whether the compaction summarizer follows file references. Test by: triggering `/compact` with active markers, then asking "what markers were active before?" If the summarizer ignores the reference, inline the file contents directly under `## State digest format` in CLAUDE.md.

## Test plan

- [x] 598/598 tests pass (`pytest claude/.claude/`)
- [x] 10 dashboard tests pass including new `test_output_is_valid_json_with_correct_shape` and updated assertions
- [ ] Manual: start a session, write an active marker, run `/compact`, ask about markers — should match `ls ~/.claude/*-markers/`
- [ ] Manual: repeat with `/clear` to confirm the matcher catches both
- [ ] Manual: type `/handoff` mid-task, open the produced file in a fresh session, verify clean resume
- [ ] Manual: verify Claude suggests `/handoff` around 60% context usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)