### PR TITLE
fix(scripts): skip locked worktrees in cleanup-merged-branches.sh

### DIFF
--- a/claude/.claude/scripts/cleanup-merged-branches.sh
+++ b/claude/.claude/scripts/cleanup-merged-branches.sh
@@ -142,7 +142,24 @@ if [ "$DRY_RUN" -eq 1 ]; then
   if [ "${#MERGED_BRANCHES[@]}" -gt 0 ]; then
     echo "Would clean up:"
     for BRANCH in "${MERGED_BRANCHES[@]}"; do
-      echo "  ${BRANCH} (${MERGED_PR_INFO[$BRANCH]})"
+      _DRY_LOCKED=0
+      _DRY_MATCHED=0
+      while IFS= read -r _line; do
+        if [[ "$_line" == "worktree "* ]]; then
+          _DRY_MATCHED=0
+        elif [[ "$_line" == "branch refs/heads/${BRANCH}" ]]; then
+          _DRY_MATCHED=1
+        elif [ "$_DRY_MATCHED" -eq 1 ] && [[ "$_line" == "locked"* ]]; then
+          _DRY_LOCKED=1
+        elif [ -z "$_line" ]; then
+          _DRY_MATCHED=0
+        fi
+      done < <(git worktree list --porcelain)
+      if [ "$_DRY_LOCKED" -eq 1 ]; then
+        echo "  ${BRANCH} (${MERGED_PR_INFO[$BRANCH]}) [locked — will skip]"
+      else
+        echo "  ${BRANCH} (${MERGED_PR_INFO[$BRANCH]})"
+      fi
     done
   fi
 
@@ -195,18 +212,45 @@ for BRANCH in "${MERGED_BRANCHES[@]}"; do
   # Step 1: Remove worktree (if present)
   # Use --porcelain to get the exact path; do NOT construct from branch name
   # (slashes in branch names would break path interpolation).
+  # The `locked` line appears after `branch` in a porcelain record, so we
+  # use a deferred-commit pattern: finalize path + lock state at each record
+  # boundary rather than at the moment the branch line is matched.
   WORKTREE_PATH=""
+  WORKTREE_LOCKED=0
+  _CANDIDATE_PATH=""
+  _CANDIDATE_LOCKED=0
+  _CANDIDATE_MATCHED=0
+  _commit_wt_candidate() {
+    if [ "$_CANDIDATE_MATCHED" -eq 1 ]; then
+      WORKTREE_PATH="$_CANDIDATE_PATH"
+      WORKTREE_LOCKED="$_CANDIDATE_LOCKED"
+    fi
+  }
   while IFS= read -r line; do
     if [[ "$line" == "worktree "* ]]; then
-      CANDIDATE_PATH="${line#worktree }"
+      _commit_wt_candidate
+      _CANDIDATE_PATH="${line#worktree }"
+      _CANDIDATE_LOCKED=0
+      _CANDIDATE_MATCHED=0
     elif [[ "$line" == "branch refs/heads/${BRANCH}" ]]; then
-      WORKTREE_PATH="$CANDIDATE_PATH"
+      _CANDIDATE_MATCHED=1
+    elif [[ "$line" == "locked"* ]]; then
+      _CANDIDATE_LOCKED=1
     fi
   done < <(git worktree list --porcelain)
+  _commit_wt_candidate  # finalize the last record
 
   if [ -n "$WORKTREE_PATH" ] && [ "$WORKTREE_PATH" != "$REPO_ROOT" ]; then
-    git worktree remove "$WORKTREE_PATH" --force 2>/dev/null || true
-    echo "    worktree:       removed: ${WORKTREE_PATH}"
+    if [ "$WORKTREE_LOCKED" -eq 1 ]; then
+      echo "    worktree:       locked (skipped)"
+      continue
+    fi
+    if git worktree remove "$WORKTREE_PATH" 2>/dev/null; then
+      echo "    worktree:       removed: ${WORKTREE_PATH}"
+    else
+      echo "    worktree:       remove failed (manual step needed)"
+      continue
+    fi
   else
     echo "    worktree:       not found"
   fi

--- a/claude/.claude/scripts/tests/test_cleanup_merged_branches.py
+++ b/claude/.claude/scripts/tests/test_cleanup_merged_branches.py
@@ -567,3 +567,107 @@ class TestGhUnauthenticated:
         result = _run_script(local, env)
         assert result.returncode != 0
         assert "auth" in result.stderr.lower() or "login" in result.stderr.lower()
+
+
+class TestLockedWorktreeSkipped:
+    """Case 17: branch with a locked worktree is fully skipped (worktree, local branch, remote)."""
+
+    def test_locked_worktree_is_skipped(self, tmp_path, fake_gh):
+        local, bare = _make_repo_with_remote(tmp_path)
+        _make_feature_branch(local, "feat/locked-wt")
+        subprocess.run(["git", "branch", "-D", "feat/locked-wt"], cwd=bare, check=True)
+
+        wt_path = tmp_path / "locked-tree"
+        _make_worktree(local, "feat/locked-wt", wt_path)
+        subprocess.run(
+            ["git", "worktree", "lock", str(wt_path), "--reason", "test lock"],
+            cwd=local, check=True, capture_output=True,
+        )
+
+        env = fake_gh({"feat/locked-wt": {"number": 200, "mergedAt": "2026-05-01"}})
+        result = _run_script(local, env)
+
+        assert result.returncode == 0
+        assert "locked (skipped)" in result.stdout
+        assert wt_path.exists(), "locked worktree should not be removed"
+        ref_check = subprocess.run(
+            ["git", "rev-parse", "--verify", "refs/heads/feat/locked-wt"],
+            cwd=local, capture_output=True,
+        )
+        assert ref_check.returncode == 0, "local branch should still exist when worktree is locked"
+
+    def test_locked_annotated_in_dry_run(self, tmp_path, fake_gh):
+        local, bare = _make_repo_with_remote(tmp_path)
+        _make_feature_branch(local, "feat/locked-dry")
+        subprocess.run(["git", "branch", "-D", "feat/locked-dry"], cwd=bare, check=True)
+
+        wt_path = tmp_path / "locked-dry-tree"
+        _make_worktree(local, "feat/locked-dry", wt_path)
+        subprocess.run(
+            ["git", "worktree", "lock", str(wt_path), "--reason", "test lock"],
+            cwd=local, check=True, capture_output=True,
+        )
+
+        env = fake_gh({"feat/locked-dry": {"number": 210, "mergedAt": "2026-05-01"}})
+        result = _run_script(local, env, args=["--dry-run"])
+
+        assert result.returncode == 0
+        assert "Would clean up" in result.stdout
+        assert "feat/locked-dry" in result.stdout
+        assert "locked" in result.stdout and "will skip" in result.stdout
+        # Dry-run must not touch the worktree or branch
+        assert wt_path.exists()
+        ref_check = subprocess.run(
+            ["git", "rev-parse", "--verify", "refs/heads/feat/locked-dry"],
+            cwd=local, capture_output=True,
+        )
+        assert ref_check.returncode == 0
+
+
+class TestLockedWorktreeMixedWithUnlocked:
+    """Case 18: locked and unlocked merged branches in same run — locked skipped, unlocked cleaned."""
+
+    def test_mixed_locked_and_unlocked(self, tmp_path, fake_gh):
+        local, bare = _make_repo_with_remote(tmp_path)
+
+        # Branch 1: locked worktree
+        _make_feature_branch(local, "feat/locked-mix")
+        subprocess.run(["git", "branch", "-D", "feat/locked-mix"], cwd=bare, check=True)
+        locked_wt = tmp_path / "locked-mix-tree"
+        _make_worktree(local, "feat/locked-mix", locked_wt)
+        subprocess.run(
+            ["git", "worktree", "lock", str(locked_wt), "--reason", "test lock"],
+            cwd=local, check=True, capture_output=True,
+        )
+
+        # Branch 2: unlocked worktree
+        _make_feature_branch(local, "feat/unlocked-mix")
+        subprocess.run(["git", "branch", "-D", "feat/unlocked-mix"], cwd=bare, check=True)
+        unlocked_wt = tmp_path / "unlocked-mix-tree"
+        _make_worktree(local, "feat/unlocked-mix", unlocked_wt)
+
+        env = fake_gh({
+            "feat/locked-mix": {"number": 201, "mergedAt": "2026-05-01"},
+            "feat/unlocked-mix": {"number": 202, "mergedAt": "2026-05-01"},
+        })
+        result = _run_script(local, env)
+
+        assert result.returncode == 0
+
+        # Locked branch: skipped entirely
+        assert "locked (skipped)" in result.stdout
+        assert locked_wt.exists(), "locked worktree should remain"
+        ref_locked = subprocess.run(
+            ["git", "rev-parse", "--verify", "refs/heads/feat/locked-mix"],
+            cwd=local, capture_output=True,
+        )
+        assert ref_locked.returncode == 0, "locked local branch should remain"
+
+        # Unlocked branch: fully cleaned
+        assert "removed:" in result.stdout
+        assert not unlocked_wt.exists(), "unlocked worktree should be removed"
+        ref_unlocked = subprocess.run(
+            ["git", "rev-parse", "--verify", "refs/heads/feat/unlocked-mix"],
+            cwd=local, capture_output=True,
+        )
+        assert ref_unlocked.returncode != 0, "unlocked local branch should be deleted"


### PR DESCRIPTION
## Summary

- `cleanup-merged-branches.sh` was calling `git worktree remove --force`, which overrides git's per-worktree lock. Active subagent worktrees carry a `locked claude agent ... (pid ...)` lock in porcelain output — so running cleanup while agents are still live removed their worktrees out from under them.
- New parser detects locked status using a deferred-commit pattern (the `locked` line appears *after* `branch` in each porcelain record, so we finalise at record boundaries rather than at the moment the branch line matches).
- When a worktree is locked, the entire branch is skipped — worktree removal, local-branch deletion, and remote cleanup all bypassed. Output: `worktree: locked (skipped)`.
- `--force` dropped from `git worktree remove` as defense-in-depth; the echo is now conditional on the exit status.
- `--dry-run` annotates locked candidates with `[locked — will skip]` to avoid surprising the user.

## Test plan

- [ ] `pytest claude/.claude/scripts/tests/test_cleanup_merged_branches.py -v` — 24/24 pass
- [ ] `TestLockedWorktreeSkipped` — locked worktree + branch survive; output contains `locked (skipped)`
- [ ] `TestLockedWorktreeSkipped::test_locked_annotated_in_dry_run` — dry-run shows `[locked — will skip]`, no destructive action
- [ ] `TestLockedWorktreeMixedWithUnlocked` — locked branch skipped, unlocked branch fully cleaned in same run
- [ ] Existing `TestBranchWithWorktree` still passes (unlocked path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)