### PR TITLE
feat(hooks): allow .env.example reads via deny-env-reads hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,8 +397,10 @@ To make it the default, add to `~/.claude/settings.json`:
 | Rule | What it closes |
 |---|---|
 | `Bash(sudo *)`, `Bash(sudo)` | Privilege escalation — turns the `sudo` prohibition in `CLAUDE.md` into a hard block |
-| `Read(**/.env)`, `Read(**/.env.*)` | Local secret reads — the classifier won't flag in-working-directory reads as exfiltration |
+| `Read(**/.env)`, `Read(**/.env.local)`, `Read(**/.env.local.*)`, `Read(**/.env.production)`, `Read(**/.env.production.*)`, `Read(**/.env.development)`, `Read(**/.env.development.*)`, `Read(**/.env.staging)`, `Read(**/.env.staging.*)`, `Read(**/.env.test)`, `Read(**/.env.test.*)` | Local secret reads — hard floors on the well-known secret-bearing variants; the classifier won't flag in-working-directory reads as exfiltration |
 | `Read(**/credentials.json)` | Cloud provider credential files (AWS CLI, GCP service accounts, etc.) |
+
+The `deny-env-reads.sh` PreToolUse hook covers `.env.*` variants not listed above. It allows the three conventional non-secret template suffixes (`.env.example`, `.env.template`, `.env.sample`) while denying everything else, including symlinks whose resolved target's basename matches a denied pattern.
 
 These rules apply in all permission modes, not only auto mode.
 

--- a/claude/.claude/hooks/deny-env-reads.sh
+++ b/claude/.claude/hooks/deny-env-reads.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Gate: deny Claude's Read tool on .env* files that commonly hold secrets.
+# Allows the three conventional non-secret template suffixes:
+#   .env.example  .env.template  .env.sample
+# Denies .env and any .env.* not on that allowlist.
+#
+# Symlink defense: after an allowlist basename match, the hook resolves the
+# path with readlink -f and re-checks the target's basename. This defeats the
+# .env.example -> .env.production bypass. Broken-symlink or unresolvable
+# target fails closed. readlink -f requires GNU coreutils (standard on Linux;
+# on macOS pre-12.3 use greadlink via `brew install coreutils` if needed).
+# Without it, symlinked templates fail closed — safe but conservative.
+#
+# Known limitation: hard links are NOT defended. Two directory entries sharing
+# one inode would require lstat + inode comparison, which is overkill for the
+# threat model here (prompt-injection or accidental access, not a privileged
+# on-system attacker). Documented, not closed.
+#
+# Deliberate divergence from deny-private-project-refs.sh's "generic message"
+# invariant: the deny reason echoes FILE_PATH. Env paths are not user-flagged-
+# sensitive identifiers — naming the path helps the user see which Read was
+# blocked without leaking anything private.
+#
+# Scope: Read tool only. Bash(cat .env.*) is out of scope by design — CLAUDE.md
+# directs Claude to the ! shell-escape valve for non-Read inspection, which
+# depends on Bash being unrestricted for these paths.
+
+set -uo pipefail
+
+INPUT=$(cat)
+TOOL_NAME=$(printf '%s\n' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+JQ_EXIT=$?
+
+emit_deny() {
+  local reason="$1"
+  local reason_json
+  reason_json=$(printf '%s' "$reason" | jq -Rs .)
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' \
+    "$reason_json"
+}
+
+if [ "$JQ_EXIT" -ne 0 ]; then
+  emit_deny "Blocked: could not parse tool-input JSON for env-read gate."
+  exit 0
+fi
+
+# Defense-in-depth: only act on Read calls (settings.json already matches Read).
+if [ "$TOOL_NAME" != "Read" ]; then
+  exit 0
+fi
+
+FILE_PATH=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+[ -z "$FILE_PATH" ] && exit 0
+
+BASENAME=$(basename -- "$FILE_PATH")
+
+case "$BASENAME" in
+  .env.example|.env.template|.env.sample)
+    : ;;  # allowlist candidate — fall through to symlink-target check
+  .env|.env.*)
+    emit_deny "Read of '${FILE_PATH}' denied by env-read gate. Dotenv files commonly hold secrets; reading pulls them into Claude's conversation context. If this is a non-secret template, rename it to .env.example, .env.template, or .env.sample. Otherwise inspect it with a shell command (e.g. \`! cat ${FILE_PATH}\`) instead of the Read tool. (Allowlist: ~/.claude/hooks/deny-env-reads.sh)"
+    exit 0
+    ;;
+  *)
+    exit 0 ;;
+esac
+
+# Allowlist matched. Resolve symlinks before allowing — a .env.example that
+# symlinks to .env.production would pass the basename check and expose secrets.
+if [ -L "$FILE_PATH" ]; then
+  RESOLVED=$(readlink -f -- "$FILE_PATH" 2>/dev/null)
+  if [ -z "$RESOLVED" ] || [ ! -e "$RESOLVED" ]; then
+    emit_deny "Read of '${FILE_PATH}' denied: symlink target is unresolvable or missing. Fail-closed — the env-read gate cannot verify what file would actually be read."
+    exit 0
+  fi
+  RESOLVED_BASENAME=$(basename -- "$RESOLVED")
+  case "$RESOLVED_BASENAME" in
+    .env.example|.env.template|.env.sample)
+      exit 0 ;;
+    .env|.env.*)
+      emit_deny "Read of '${FILE_PATH}' denied: the symlink resolves to '${RESOLVED}', whose basename matches a denied env pattern."
+      exit 0
+      ;;
+    *)
+      exit 0 ;;
+  esac
+fi
+
+exit 0

--- a/claude/.claude/hooks/tests/test_deny_env_reads.py
+++ b/claude/.claude/hooks/tests/test_deny_env_reads.py
@@ -1,0 +1,198 @@
+"""Tests for deny-env-reads.sh."""
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+from helpers import (
+    HOOKS_DIR,
+    bash_input,
+    edit_input,
+    read_input,
+    run_hook,
+    run_hook_reason,
+    write_input,
+)
+
+DENY_ENV_READS_HOOK = HOOKS_DIR / "deny-env-reads.sh"
+
+
+class TestDenyEnvReads:
+    # ------------------------------------------------------------------ #
+    # Allow — safe template suffixes (regular files, no symlink)          #
+    # ------------------------------------------------------------------ #
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/foo/.env.example",
+            "/foo/.env.template",
+            "/foo/.env.sample",
+            ".env.example",
+            "~/proj/.env.example",
+        ],
+    )
+    def test_template_suffixes_allowed(self, path):
+        assert run_hook(DENY_ENV_READS_HOOK, read_input(path)) == "allow"
+
+    # ------------------------------------------------------------------ #
+    # Allow — non-env-shaped paths                                        #
+    # ------------------------------------------------------------------ #
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/foo/somefile.txt",
+            "/foo/env",
+            "/foo/.envrc",  # direnv config — out of scope; test documents current allow behavior
+            "/foo/README.md",
+        ],
+    )
+    def test_non_env_shaped_allowed(self, path):
+        assert run_hook(DENY_ENV_READS_HOOK, read_input(path)) == "allow"
+
+    # ------------------------------------------------------------------ #
+    # Allow — path edge cases that still produce a safe basename          #
+    # ------------------------------------------------------------------ #
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/foo/.env.example/",   # trailing slash stripped by basename
+            "//foo//.env.example",  # double slashes normalized
+        ],
+    )
+    def test_path_edge_cases_allowed(self, path):
+        assert run_hook(DENY_ENV_READS_HOOK, read_input(path)) == "allow"
+
+    # ------------------------------------------------------------------ #
+    # Deny — bare .env and well-known secret variants                     #
+    # ------------------------------------------------------------------ #
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/foo/.env",
+            "./.env",
+            "/foo/.env.local",
+            "/foo/.env.production",
+            "/foo/.env.development",
+            "/foo/.env.staging",
+            "/foo/.env.test",
+        ],
+    )
+    def test_secret_variants_denied(self, path):
+        assert run_hook(DENY_ENV_READS_HOOK, read_input(path)) == "deny"
+
+    # ------------------------------------------------------------------ #
+    # Deny — exact-match policy: close variants of allowlisted names      #
+    # ------------------------------------------------------------------ #
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/foo/.env.example.local",    # customized copy, not a template
+            "/foo/.env.local.example",    # suffix order matters
+            "/foo/.env.examples",         # plural — not the allowlist entry
+            "/foo/.env.example2",         # numeric suffix
+        ],
+    )
+    def test_close_variants_denied(self, path):
+        assert run_hook(DENY_ENV_READS_HOOK, read_input(path)) == "deny"
+
+    # ------------------------------------------------------------------ #
+    # Deny — basename traversal: basename of raw path still denied        #
+    # ------------------------------------------------------------------ #
+
+    def test_dotdot_traversal_denied(self):
+        # basename("/foo/sub/../.env.production") == ".env.production" — denied
+        assert run_hook(DENY_ENV_READS_HOOK, read_input("/foo/sub/../.env.production")) == "deny"
+
+    # ------------------------------------------------------------------ #
+    # Deny message content — allowlist named, path named                  #
+    # ------------------------------------------------------------------ #
+
+    def test_deny_message_names_allowlist(self):
+        reason = run_hook_reason(DENY_ENV_READS_HOOK, read_input("/foo/.env.local"))
+        assert reason is not None
+        assert ".env.example" in reason
+
+    def test_deny_message_names_path(self):
+        reason = run_hook_reason(DENY_ENV_READS_HOOK, read_input("/project/.env.production"))
+        assert reason is not None
+        assert ".env.production" in reason
+
+    # ------------------------------------------------------------------ #
+    # Symlink cases (require real filesystem symlinks)                    #
+    # ------------------------------------------------------------------ #
+
+    def test_symlink_to_denied_target_denied(self, tmp_path):
+        target = tmp_path / ".env.production"
+        target.write_text("SECRET=value\n")
+        link = tmp_path / ".env.example"
+        link.symlink_to(target)
+        assert run_hook(DENY_ENV_READS_HOOK, read_input(str(link))) == "deny"
+
+    def test_symlink_deny_message_names_resolved_path(self, tmp_path):
+        target = tmp_path / ".env.production"
+        target.write_text("SECRET=value\n")
+        link = tmp_path / ".env.example"
+        link.symlink_to(target)
+        reason = run_hook_reason(DENY_ENV_READS_HOOK, read_input(str(link)))
+        assert reason is not None
+        assert ".env.production" in reason
+
+    def test_symlink_to_template_target_allowed(self, tmp_path):
+        target = tmp_path / "shared.env.example"
+        target.write_text("PORT=3000\n")
+        link = tmp_path / ".env.example"
+        link.symlink_to(target)
+        assert run_hook(DENY_ENV_READS_HOOK, read_input(str(link))) == "allow"
+
+    def test_symlink_to_non_env_file_allowed(self, tmp_path):
+        target = tmp_path / "notes.txt"
+        target.write_text("just notes\n")
+        link = tmp_path / ".env.example"
+        link.symlink_to(target)
+        assert run_hook(DENY_ENV_READS_HOOK, read_input(str(link))) == "allow"
+
+    def test_broken_symlink_denied(self, tmp_path):
+        link = tmp_path / ".env.example"
+        link.symlink_to(tmp_path / "nonexistent")
+        assert run_hook(DENY_ENV_READS_HOOK, read_input(str(link))) == "deny"
+
+    # ------------------------------------------------------------------ #
+    # Defense-in-depth: non-Read tool names pass through                  #
+    # ------------------------------------------------------------------ #
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            bash_input("ls"),
+            edit_input("/foo/.env.production"),
+            write_input("/foo/.env.production"),
+        ],
+    )
+    def test_non_read_tools_pass_through(self, payload):
+        assert run_hook(DENY_ENV_READS_HOOK, payload) == "allow"
+
+    def test_unknown_read_variant_tool_name_passes_through(self):
+        payload = {"tool_name": "ReadFile", "tool_input": {"file_path": "/foo/.env.production"}}
+        assert run_hook(DENY_ENV_READS_HOOK, payload) == "allow"
+
+    # ------------------------------------------------------------------ #
+    # Fail-closed on malformed JSON                                       #
+    # ------------------------------------------------------------------ #
+
+    def test_malformed_json_denied(self):
+        result = subprocess.run(
+            [str(DENY_ENV_READS_HOOK)],
+            input="not valid json",
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.stdout.strip()
+        payload = json.loads(result.stdout)
+        assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -151,6 +151,16 @@
             "statusMessage": "Checking routing-read gate..."
           }
         ]
+      },
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/deny-env-reads.sh",
+            "statusMessage": "Checking env-file read gate..."
+          }
+        ]
       }
     ],
     "PostToolUse": [
@@ -201,7 +211,16 @@
       "Bash(sudo *)",
       "Bash(sudo)",
       "Read(**/.env)",
-      "Read(**/.env.*)",
+      "Read(**/.env.local)",
+      "Read(**/.env.local.*)",
+      "Read(**/.env.production)",
+      "Read(**/.env.production.*)",
+      "Read(**/.env.development)",
+      "Read(**/.env.development.*)",
+      "Read(**/.env.staging)",
+      "Read(**/.env.staging.*)",
+      "Read(**/.env.test)",
+      "Read(**/.env.test.*)",
       "Read(**/credentials.json)"
     ]
   }


### PR DESCRIPTION
## What changed

Replaces the catchall `Read(**/.env.*)` deny rule — which incorrectly blocked `.env.example` — with a PreToolUse hook that distinguishes secret-bearing files from committed non-secret templates.

**New:** `claude/.claude/hooks/deny-env-reads.sh`
- Allowlists `.env.example`, `.env.template`, `.env.sample` (exact basename match)
- Denies `.env` and any other `.env.*` suffix
- Resolves symlinks after an allowlist match to defeat the `.env.example -> .env.production` bypass; broken/unresolvable symlinks fail closed
- Known limitation documented in header: hard-link bypass not defended (requires inode-level checks, overkill for this threat model)

**Updated:** `settings.json`
- Removes the catchall `Read(**/.env.*)`
- Adds `Read` PreToolUse matcher wiring `deny-env-reads.sh`
- Adds hard-floor `permissions.deny` entries for well-known-secret variants (`.env.local`, `.env.production`, `.env.development`, `.env.staging`, `.env.test` and their `.*` sub-variants) so those stay protected even if the hook is broken or mis-wired

**New:** `claude/.claude/hooks/tests/test_deny_env_reads.py` — 35 tests covering allow/deny cases, exact-match policy, symlink resolution (allowed target, denied target, broken), path edge cases (trailing slash, `..` traversal), non-Read tool passthrough, and fail-closed on malformed JSON

**Updated:** `README.md` — "Hard-floor deny rules" table reflects the new split between hard floors and hook coverage

## Security properties

- `.env.example` reads: now allowed ✓
- `.env.local`, `.env.production`, etc.: hard-floor blocked (two layers: deny rule + hook) ✓
- Unknown `.env.*` suffixes: hook-blocked (default-deny) ✓
- Symlinked `.env.example` pointing to `.env.production`: hook-blocked via `readlink -f` resolution ✓
- Hard-linked `.env.example` → `.env.production`: not defended; documented as known limitation ✓

## Test plan

- [ ] `pytest claude/.claude/hooks/tests/test_deny_env_reads.py -v` — 35 tests pass
- [ ] `pytest claude/.claude/` — full suite (635 tests) still passes
- [ ] `ruff check claude/.claude/` — clean
- [ ] Live smoke: `Read(.env.example)` succeeds; `Read(.env.local)` hard-blocked; `Read(.env.unknown)` denied by hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)