### PR TITLE
chore: add agent-reviews/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,11 @@ __pycache__/
 .claude/settings.local.json
 .claude/worktrees/
 
+# Per-session findings written by /code-review specialist subagents. The skill
+# also adds this to .git/info/exclude as a fallback for repos where this line
+# isn't committed; both rules are harmless together.
+agent-reviews/
+
 # Belt-and-suspenders: the user-local private-projects blocklist read by
 # deny-private-project-refs.sh lives at ~/.claude/private-projects.md
 # directly, NOT inside the stowed claude/ subdir. If a user accidentally


### PR DESCRIPTION
## Summary

- `/code-review` already instructs agents to add `agent-reviews/` to `.git/info/exclude` before spawning specialists, but that only covers a local clone after the skill has run at least once
- Adding the pattern to the committed `.gitignore` ensures findings can't be accidentally staged in any clone from first checkout
- Consistent with `.claude/plans/` and `.claude/settings.local.json` already being excluded as per-session ephemera
- The skill's `info/exclude` step remains useful (and harmless) for other repos where this `.gitignore` doesn't apply

## Test plan

- [ ] `touch agent-reviews/test.md && git status --short` — directory should not appear as untracked
- [ ] Run `/code-review` and confirm findings still write to `agent-reviews/` as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)