### PR TITLE
docs(claude-md): interrupt flow on subagent permission denial; ban globs in allow rules

### DIFF
--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -21,6 +21,8 @@
 
 Verify-class runs (full test suites, lint, typecheck, build) should run via the `Agent` tool with `subagent_type: general-purpose` — not directly via `Bash` in the parent. The subagent writes full output to `${TMPDIR:-/tmp}/<command-slug>-<epoch-ms>.txt` and returns a structured verdict plus the file paths; the parent reads the file for more detail rather than re-running. This applies to suite-level runs; commands scoped to a single test file or single test name during interactive debugging can stay inline.
 
+If the subagent reports the verify command was blocked by permissions, do NOT fall back to running it directly in the parent — that defeats the dispatch (parent context inhales the output) and silently bypasses the permission gate. Stop, surface the exact missing allow-rule (e.g. `Bash(npm run verify)`), and wait for the user to either pre-approve it in the appropriate scope's `permissions.allow` or run the command themselves.
+
 ## Code Review
 
 - After writing or modifying code, run `/code-review` before presenting the code to the user. If the review finds issues, fix them first, then present the final version.
@@ -47,6 +49,7 @@ Verify-class runs (full test suites, lint, typecheck, build) should run via the 
 - Never commit secrets, credentials, API keys, or large binary assets to repositories.
 - Never use the Read tool on files likely to contain secrets (`.env`, `.claude.json`, `credentials.json`, similar). Reading pulls the secret into the conversation context. When you need to inspect such a file, give the user a shell command (`cat`, `grep`, `jq`) to run via `!` instead.
 - Never write `~/.claude/*-markers/*` by hand. Each review skill writes its own marker directory (`/code-review` → `review-markers/`, `/plan-review` → `plan-review-markers/`, etc.) when a review passes, and pre-commit hooks gate on their presence. If a commit is blocked, run the review skill the hook names; if the skill is harness-blocked, spawn a subagent that can run it. A general "ship it" instruction is not authorization to forge a marker.
+- Don't add globs (`Bash(pytest *)`, `Bash(npm run *)`) to `permissions.allow`. Globs widen the surface to flag injection, command chaining, and shell-expansion attacks — see `claude/.claude/skills/review-permissions/SKILL.md` checklist items 1–9. Use exact-match rules (`Bash(pytest)`, `Bash(npm run verify)`) instead.
 
 ## Code Comments
 


### PR DESCRIPTION
## Summary

- **Interrupt-flow rule for subagent permission denials**: when a general-purpose subagent dispatched for a verify-class run (`npm run verify`, `pytest`, etc.) has its Bash call blocked by `permissions.allow`, Claude must stop and surface the exact missing allow-rule — not silently re-run the command in the parent shell. That fallback defeats the dispatch (output lands in parent context) and bypasses the permission gate the user set.
- **No-globs rule for `permissions.allow`**: glob patterns (`Bash(pytest *)`, `Bash(npm run *)`) widen the attack surface to flag injection, command chaining, and shell-expansion attacks already enumerated in the `review-permissions` skill checklist items 1–9. Exact-match rules only going forward.

## Root cause (for context)

Subagents inherit the parent's merged `permissions.allow` and can only narrow it — never expand it. The `tools:` field in agent frontmatter is a capability gate, not a command-level permission rule. If a verify-class command isn't pre-approved in `permissions.allow`, the subagent hits the gate, can't surface an interactive prompt, and returns a denial to the parent. The prior behavior silently absorbed this and fell back to the parent shell, leaking output into context and bypassing the gate.

## Files changed

- `claude/.claude/CLAUDE.md` — two text additions:
  1. New paragraph appended to `### Heavy command output` specifying the interrupt-flow behavior on permission denial.
  2. New bullet in `## Safety` prohibiting globs in `permissions.allow` with a pointer to the `review-permissions` checklist.

## Test plan

- [ ] Start a fresh session in a project whose `permissions.allow` doesn't cover `Bash(npm run verify)`. Ask Claude to run the verify suite. Confirm: Claude dispatches via Agent → subagent reports denial → Claude surfaces the missing allow-rule string and waits, rather than running the command in the parent.
- [ ] Diff `claude/.claude/CLAUDE.md` against `main`. Confirm only the two intended additions appear; no other lines changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)