### PR TITLE
feat(permissions): add project-level settings.json with lint/test allow rules

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(ruff check claude/.claude/)",
+      "Bash(pytest claude/.claude/)",
+      "Bash(pytest claude/.claude/scripts/tests/test_cleanup_merged_branches.py)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Creates `.claude/settings.json` (committed, project-scoped) — this file did not previously exist; all prior project-level Claude Code settings lived only in the gitignored `settings.local.json`
- Adds 3 exact-match `permissions.allow` rules for the two commands contributors run most in this repo (`ruff check` and `pytest`), identified by scanning 50 recent session transcripts
- No globs — follows the CLAUDE.md prohibition on glob-style allow rules

## Rules added

| Rule | Hit count | Why |
|---|---:|---|
| `Bash(ruff check claude/.claude/)` | 17 | Repo lint; read-only static analysis |
| `Bash(pytest claude/.claude/)` | ~30 | Full hook/script test suite |
| `Bash(pytest claude/.claude/scripts/tests/test_cleanup_merged_branches.py)` | 6 | Targeted test file for cleanup script work |

## Why settings.json and not settings.local.json

Project-specific rules that any contributor would need belong in committed `settings.json`. User-only rules (tied to a specific local setup) belong in gitignored `settings.local.json`. These three rules are repo-specific commands, not user-specific — any engineer working in claude-config benefits from them.

## Security note (from /review-permissions)

`pytest` executes project-controlled Python test code — accepted risk at project scope. The tests in `claude/.claude/` are shell-execution hook tests with no external dependencies (no DB, no network). A malicious test would need to clear PR review before it could execute unattended.

## Test plan

- [ ] Run `ruff check claude/.claude/` in a fresh session — confirm no permission prompt
- [ ] Run `pytest claude/.claude/` in a fresh session — confirm no permission prompt for the bare form
- [ ] Confirm `git check-ignore -v .claude/settings.json` shows the file is not gitignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)