### PR TITLE
feat(permissions): allow conventional npm script names for subagent dispatch

### DIFF
--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -210,7 +210,11 @@
       "Bash(~/.claude/scripts/marker.sh deactivate ready-for-review)",
       "Bash(~/.claude/scripts/marker.sh deactivate respond-pr)",
       "Bash(~/.claude/scripts/cleanup-merged-branches.sh)",
-      "Bash(~/.claude/scripts/cleanup-merged-branches.sh --dry-run)"
+      "Bash(~/.claude/scripts/cleanup-merged-branches.sh --dry-run)",
+      "Bash(npm run verify)",
+      "Bash(npm run lint)",
+      "Bash(npm run typecheck)",
+      "Bash(npm run build)"
     ],
     "deny": [
       "Bash(sudo *)",


### PR DESCRIPTION
## Summary

- Adds four exact-match `Bash(npm run ...)` rules to the global `permissions.allow` so `general-purpose` subagents can execute verify-class commands without prompting, per the **Heavy command output** guidance in `~/.claude/CLAUDE.md`
- `Bash(npm test)` and `Bash(npm run test)` are intentionally excluded — they are project-defined wrappers that can invoke integration test suites with unpredictable behavior across projects; `npm run verify` already covers the dispatch use case
- Rules follow the exact-match-only convention (no globs); reviewed by `/review-permissions` + `staff-platform-engineer` before commit

## Test plan

- [ ] CI green
- [ ] `jq '.permissions.allow | map(select(startswith("Bash(npm")))' claude/.claude/settings.json` returns the four rules and only those four
- [ ] After merge + `git pull`: open a fresh Claude Code session in an npm project, ask a subagent to run `npm run verify` — confirm no permission prompt fires
- [ ] Confirm `npm test` still prompts (not in the allow list)

> **Note for merger:** Before running `git pull`, restore the main tree's settings.json if it has the old 6-rule unstaged change: `git restore claude/.claude/settings.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)