### PR TITLE
feat(marker): guard against empty-staged write before git add

### DIFF
--- a/claude/.claude/hooks/tests/test_marker_script.py
+++ b/claude/.claude/hooks/tests/test_marker_script.py
@@ -131,3 +131,124 @@ class TestMarkerScriptHappyPath:
     def test_help_exits_0(self, isolated_home, git_repo):
         result = _run(["--help"], cwd=git_repo, home=isolated_home)
         assert result.returncode == 0
+
+
+class TestMarkerScriptEmptyStagedGuard:
+    """Guard added to hash-based marker writes (code-review, skill-review):
+    exit 2 when the staged diff for the relevant pathspec is empty but
+    unstaged tracked changes exist — prevents recording an empty-hash marker
+    before `git add` is run, which would cause a require-* hook mismatch at
+    commit time."""
+
+    def _seed_session(self, home):
+        sessions_dir = home / ".claude" / "sessions"
+        sessions_dir.mkdir(parents=True, exist_ok=True)
+        sid = "test-session-guard"
+        (sessions_dir / str(os.getpid())).write_text(sid)
+        return sid
+
+    # ── code-review (whole-tree pathspec) ─────────────────────────────────
+
+    def test_code_review_staged_and_unstaged_writes_marker(
+        self, isolated_home, git_repo
+    ):
+        """Guard must NOT fire when something is staged — even with unstaged
+        changes alongside it."""
+        self._seed_session(isolated_home)
+        # Fixture has file.txt staged with "first\nsecond\n". Write an
+        # additional working-tree change without staging it — index has a
+        # staged change, working tree has a further unstaged change.
+        (git_repo / "file.txt").write_text("first\nsecond\nthird\n")
+        result = _run(["write", "code-review"], cwd=git_repo, home=isolated_home)
+        assert result.returncode == 0, result.stderr
+        marker_dir = isolated_home / ".claude" / "review-markers"
+        assert len(list(marker_dir.iterdir())) == 1
+
+    def test_code_review_empty_staged_unstaged_tracked_exits_2(
+        self, isolated_home, git_repo
+    ):
+        """Guard fires: staged diff is empty, unstaged tracked changes exist."""
+        self._seed_session(isolated_home)
+        # Unstage the fixture's pre-staged change, leaving it as an unstaged
+        # tracked modification.
+        subprocess.run(["git", "reset", "HEAD", "--", "file.txt"], cwd=git_repo, check=True)
+        result = _run(["write", "code-review"], cwd=git_repo, home=isolated_home)
+        assert result.returncode == 2
+        assert "git add" in result.stderr
+        assert "/code-review" in result.stderr
+        marker_dir = isolated_home / ".claude" / "review-markers"
+        stray = list(marker_dir.iterdir()) if marker_dir.exists() else []
+        assert stray == [], f"guard should not write a marker: {stray}"
+
+    def test_code_review_empty_staged_no_unstaged_writes_marker(
+        self, isolated_home, git_repo
+    ):
+        """Guard must NOT fire when staged is empty AND there are no unstaged
+        changes — the review-of-nothing escape hatch must stay open."""
+        self._seed_session(isolated_home)
+        # Unstage then discard the fixture's change so both index and working
+        # tree are clean. Order matters: reset the index first (HEAD → index),
+        # then checkout to align the working tree with the now-clean index.
+        subprocess.run(["git", "reset", "HEAD", "--", "file.txt"], cwd=git_repo, check=True)
+        subprocess.run(["git", "checkout", "--", "file.txt"], cwd=git_repo, check=True)
+        result = _run(["write", "code-review"], cwd=git_repo, home=isolated_home)
+        assert result.returncode == 0, result.stderr
+        marker_dir = isolated_home / ".claude" / "review-markers"
+        assert len(list(marker_dir.iterdir())) == 1
+
+    # ── skill-review (path-scoped to SKILL.md) ────────────────────────────
+
+    def _make_skill_md(self, repo):
+        """Create a tracked SKILL.md inside the repo at the expected pathspec."""
+        skill_dir = repo / "claude" / ".claude" / "skills" / "test-skill"
+        skill_dir.mkdir(parents=True)
+        skill_md = skill_dir / "SKILL.md"
+        skill_md.write_text("# test skill\n")
+        subprocess.run(["git", "add", str(skill_md)], cwd=repo, check=True)
+        subprocess.run(
+            ["git", "commit", "-q", "-m", "add test skill"],
+            cwd=repo,
+            check=True,
+        )
+        return skill_md
+
+    def test_skill_review_out_of_scope_unstaged_does_not_fire(
+        self, isolated_home, git_repo
+    ):
+        """Unstaged change outside the SKILL.md pathspec with nothing staged
+        must NOT trigger the guard — the guard is pathspec-scoped."""
+        self._seed_session(isolated_home)
+        # file.txt is staged from the fixture; reset it so staged is empty for
+        # the whole tree. The unstaged file.txt change is outside the SKILL.md
+        # pathspec — guard must pass through.
+        subprocess.run(["git", "reset", "HEAD", "--", "file.txt"], cwd=git_repo, check=True)
+        result = _run(["write", "skill-review"], cwd=git_repo, home=isolated_home)
+        assert result.returncode == 0, result.stderr
+        marker_dir = isolated_home / ".claude" / "skill-review-markers"
+        assert len(list(marker_dir.iterdir())) == 1
+
+    def test_skill_review_unstaged_skill_md_exits_2(self, isolated_home, git_repo):
+        """Guard fires when staged SKILL.md diff is empty but an unstaged
+        SKILL.md change exists."""
+        self._seed_session(isolated_home)
+        skill_md = self._make_skill_md(git_repo)
+        # Modify SKILL.md without staging it.
+        skill_md.write_text("# test skill\nmodified\n")
+        result = _run(["write", "skill-review"], cwd=git_repo, home=isolated_home)
+        assert result.returncode == 2
+        assert "git add" in result.stderr
+        assert "/skill-review" in result.stderr
+        marker_dir = isolated_home / ".claude" / "skill-review-markers"
+        stray = list(marker_dir.iterdir()) if marker_dir.exists() else []
+        assert stray == [], f"guard should not write a marker: {stray}"
+
+    def test_skill_review_staged_skill_md_writes_marker(self, isolated_home, git_repo):
+        """Guard must NOT fire when SKILL.md change is staged."""
+        self._seed_session(isolated_home)
+        skill_md = self._make_skill_md(git_repo)
+        skill_md.write_text("# test skill\nupdated\n")
+        subprocess.run(["git", "add", str(skill_md)], cwd=git_repo, check=True)
+        result = _run(["write", "skill-review"], cwd=git_repo, home=isolated_home)
+        assert result.returncode == 0, result.stderr
+        marker_dir = isolated_home / ".claude" / "skill-review-markers"
+        assert len(list(marker_dir.iterdir())) == 1

--- a/claude/.claude/scripts/marker.sh
+++ b/claude/.claude/scripts/marker.sh
@@ -54,6 +54,14 @@ _resolve_repo_hash() {
   _marker_lib_repo_hash "$(git rev-parse --show-toplevel | tr -d '\n')"
 }
 
+_guard_staged_vs_unstaged() {
+  local skill="$1"; shift
+  if git diff --cached --quiet -- "$@" && ! git diff --quiet -- "$@"; then
+    printf 'marker.sh: staged diff is empty but unstaged tracked changes exist — run `git add` before /%s.\n' "$skill" >&2
+    exit 2
+  fi
+}
+
 if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
   usage
   exit 0
@@ -73,6 +81,7 @@ case "$SUBCOMMAND" in
       code-review)
         SESSION_ID=$(_resolve_session_id) || exit 2
         REPO_HASH=$(_resolve_repo_hash) || exit 2
+        _guard_staged_vs_unstaged code-review
         mkdir -p "$HOME/.claude/review-markers"
         git diff --cached | sha256sum | awk '{print $1}' \
           > "$HOME/.claude/review-markers/$REPO_HASH.$SESSION_ID"
@@ -80,6 +89,7 @@ case "$SUBCOMMAND" in
       skill-review)
         SESSION_ID=$(_resolve_session_id) || exit 2
         REPO_HASH=$(_resolve_repo_hash) || exit 2
+        _guard_staged_vs_unstaged skill-review 'claude/.claude/skills/**/SKILL.md'
         mkdir -p "$HOME/.claude/skill-review-markers"
         # The pathspec is load-bearing: scopes the hash to SKILL.md diffs only,
         # matching what require-skill-review.sh checks at commit time.


### PR DESCRIPTION
## Summary

- Adds `_guard_staged_vs_unstaged` helper to the marker script that exits 2 when the staged diff for the relevant pathspec is empty but unstaged tracked changes exist
- Prevents an empty-hash marker from being recorded before `git add` runs, which would cause a require-\* hook mismatch at commit time
- Calls the guard in both `code-review` (whole-tree) and `skill-review` (`claude/.claude/skills/**/SKILL.md` pathspec) write arms

## Test plan

- [x] 643 existing tests pass (verified locally)
- [x] `ruff check` clean (verified locally)
- [x] `TestMarkerScriptEmptyStagedGuard` covers 6 new cases:
  - code-review: staged + unstaged → marker written (guard does not fire)
  - code-review: empty staged + unstaged tracked → exits 2, no marker written
  - code-review: empty staged + no unstaged → marker written (review-of-nothing escape hatch)
  - skill-review: unstaged non-SKILL.md file → marker written (pathspec scoping works)
  - skill-review: unstaged SKILL.md → exits 2, no marker written
  - skill-review: staged SKILL.md → marker written

🤖 Generated with [Claude Code](https://claude.com/claude-code)
