### PR TITLE
fix(permissions): drop Bash(npm run verify) from global allow list

### DIFF
--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -211,7 +211,6 @@
       "Bash(~/.claude/scripts/marker.sh deactivate respond-pr)",
       "Bash(~/.claude/scripts/cleanup-merged-branches.sh)",
       "Bash(~/.claude/scripts/cleanup-merged-branches.sh --dry-run)",
-      "Bash(npm run verify)",
       "Bash(npm run lint)",
       "Bash(npm run typecheck)",
       "Bash(npm run build)"


### PR DESCRIPTION
## Summary

Fixes an inconsistency introduced by PR #182.

PR #182 excluded `npm test` / `npm run test` on the grounds that they are "project-defined wrappers that can invoke integration test suites with unpredictable behavior across projects." By the same test, `Bash(npm run verify)` should have been excluded too:

- `npm test` follows the npm lifecycle convention (a standard script name, even if body is project-defined). `npm run verify` has no npm convention at all — the name is arbitrary and the body is fully project-defined; it is *more* idiosyncratic across projects than `npm test`, not less.
- `~/.claude/CLAUDE.md` defines "verify-class runs" as *"full test suites, lint, typecheck, build"* — i.e., `verify` is explicitly designed to be the meta-script that can include integration tests.
- The integration-test-safety stance (multiple sessions may share a DB; auto-allowing runners causes concurrent-session conflicts) applies to `verify` with the same force it applies to `test`.

The actual safety boundary is: don't globally auto-allow commands that commonly run integration tests. Under that rule, `verify` belongs with `test`, not with `lint` / `typecheck` / `build`.

Since `claude/` is stow-distributed to every consumer of this repo (not personal config), the default-safe direction is opt-in. Consuming projects whose `verify` is integration-free can add `Bash(npm run verify)` to their own `.claude/settings.local.json`.

## Rules after this change

Three exact-match npm rules remain in the global allow list:
- `Bash(npm run lint)`
- `Bash(npm run typecheck)`
- `Bash(npm run build)`

## Test plan

- [ ] CI green
- [ ] `jq '.permissions.allow | map(select(startswith("Bash(npm")))' claude/.claude/settings.json` returns exactly three rules: `lint`, `typecheck`, `build`
- [ ] In a fresh Claude Code session in an npm project, asking a subagent to run `npm run verify` now prompts for permission (no longer auto-allowed)
- [ ] `npm run lint` / `npm run typecheck` / `npm run build` still auto-allow without prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)