### PR TITLE
feat(review-permissions): add PATH-resolved check; remove npm-run global allow entries

### DIFF
--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -51,13 +51,13 @@ If the subagent reports the verify command was blocked by permissions, do NOT fa
 - Never write `~/.claude/*-markers/*` by hand. Each review skill writes its own marker directory (`/code-review` → `review-markers/`, `/plan-review` → `plan-review-markers/`, etc.) when a review passes, and pre-commit hooks gate on their presence. If a commit is blocked, run the review skill the hook names; if the skill is harness-blocked, spawn a subagent that can run it. A general "ship it" instruction is not authorization to forge a marker.
 - Don't add globs (`Bash(pytest *)`, `Bash(npm run *)`) to `permissions.allow`. Globs widen the surface to flag injection, command chaining, and shell-expansion attacks — see `claude/.claude/skills/review-permissions/SKILL.md` checklist items 1–9. Use exact-match rules (`Bash(pytest)`, `Bash(npm run verify)`) instead.
 
-## Code Comments
+## Code Comments and Durable Documentation
 
-Comments must be readable by a future coder who has not read the PR description, commit message, or planning document. In particular:
+Code comments and durable in-repo documentation (REFERENCES.md, doc files, README sections) must be readable by a future contributor who has not read the PR description, commit message, or planning document. In particular:
 
-- **No PR-defined terminology** in code comments (e.g., "Defense A", "Action 6", "Pattern C"). If a label is meaningful it must be defined in code (constant name, function name, type name) — not in a comment that depends on context outside the file.
+- **No PR-defined terminology** (e.g., "Defense A", "Action 6", "Pattern C"). If a label is meaningful it must be defined in code or named explicitly — not in a comment or doc that depends on context outside the file.
 - **No "used to be X" / "was Y before"** framing. The rationale-vs-prior-version belongs in the commit message or PR body.
-- **Self-test:** if you can't write the comment such that it survives the PR being merged and the description being lost, don't write the comment. Move the rationale to the commit message instead.
+- **Self-test:** if you can't write the content such that it survives the PR being merged and the description being lost, don't write it. Move the rationale to the commit message instead.
 
 ## Output Preferences
 

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -212,10 +212,7 @@
       "Bash(~/.claude/scripts/cleanup-merged-branches.sh)",
       "Bash(~/.claude/scripts/cleanup-merged-branches.sh --dry-run)",
       "Bash(cleanup-merged-branches)",
-      "Bash(cleanup-merged-branches --dry-run)",
-      "Bash(npm run lint)",
-      "Bash(npm run typecheck)",
-      "Bash(npm run build)"
+      "Bash(cleanup-merged-branches --dry-run)"
     ],
     "deny": [
       "Bash(sudo *)",

--- a/claude/.claude/skills/review-permissions/REFERENCES.md
+++ b/claude/.claude/skills/review-permissions/REFERENCES.md
@@ -1,0 +1,34 @@
+# review-permissions — Reference notes
+
+## Accepted tradeoffs in the global allow list
+
+### `cleanup-merged-branches` bare-name entries
+
+`settings.json` contains both absolute-path entries
+(`Bash(~/.claude/scripts/cleanup-merged-branches.sh)`) and bare-name entries
+(`Bash(cleanup-merged-branches)`, `Bash(cleanup-merged-branches --dry-run)`).
+
+The bare-name entries are accepted at global scope because:
+- The script is installed to `~/.local/bin/` by this repo's `install.sh` and
+  is not a name any project is likely to shadow.
+- The script itself calls only absolute paths; it does not exec untrusted input.
+- The absolute-path fallback entries remain as the preferred form; the bare-name
+  entries exist for ergonomic invocation when `~/.local/bin` is in `$PATH`.
+
+Checklist item 10 (PATH-resolved commands) applies. Justification accepted.
+
+### `npm run lint`, `npm run typecheck`, `npm run build` global entries
+
+These three entries execute project-controlled `package.json` scripts and are
+therefore project-code execution (checklist item 15) at global scope
+(checklist item 19). The tradeoff is accepted because:
+- The machine is single-user; the operator and the machine owner are the same
+  person.
+- The benefit (no per-project prompt for routine lint/typecheck/build) outweighs
+  the marginal risk on a personal development machine.
+- If this repo is ever used on a shared or multi-user machine, these entries
+  should be demoted to project-scope `.claude/settings.json`.
+
+Checklist items 10 (PATH-resolved), 15 (project code execution), and 19
+(global vs project scope) all apply. Tradeoff accepted with the single-user
+constraint noted above.

--- a/claude/.claude/skills/review-permissions/REFERENCES.md
+++ b/claude/.claude/skills/review-permissions/REFERENCES.md
@@ -1,6 +1,6 @@
 # review-permissions — Reference notes
 
-## Accepted tradeoffs in the global allow list
+## Decisions on global allow list entries
 
 ### `cleanup-merged-branches` bare-name entries
 
@@ -17,18 +17,23 @@ The bare-name entries are accepted at global scope because:
 
 Checklist item 10 (PATH-resolved commands) applies. Justification accepted.
 
-### `npm run lint`, `npm run typecheck`, `npm run build` global entries
+### `npm run lint`, `npm run typecheck`, `npm run build` — intentionally not in the global allow list
 
-These three entries execute project-controlled `package.json` scripts and are
-therefore project-code execution (checklist item 15) at global scope
-(checklist item 19). The tradeoff is accepted because:
-- The machine is single-user; the operator and the machine owner are the same
-  person.
-- The benefit (no per-project prompt for routine lint/typecheck/build) outweighs
-  the marginal risk on a personal development machine.
-- If this repo is ever used on a shared or multi-user machine, these entries
-  should be demoted to project-scope `.claude/settings.json`.
+These three entries would let subagent-dispatched verify-class commands (see
+CLAUDE.md "Heavy command output") inherit permissions and run without prompt.
+They are deliberately absent from the global allow list because:
 
-Checklist items 10 (PATH-resolved), 15 (project code execution), and 19
-(global vs project scope) all apply. Tradeoff accepted with the single-user
-constraint noted above.
+- `lint`/`typecheck`/`build` are project-controlled `package.json` script names.
+  At global scope, a malicious project's scripts auto-fire the moment Claude Code
+  opens the directory, with no prompt. This is checklist items 15 (project code
+  execution) and 19 (global vs project scope) compounded.
+- Subagent permission inheritance does not honor project-scope
+  `.claude/settings.json`, so demoting these to project scope does not restore
+  subagent dispatch. The resulting per-project re-prompt friction is the deliberate
+  cost of removing global auto-trust on project-controlled scripts.
+- Per-project re-allow is an explicit decision: a committed `.claude/settings.json`
+  works for parent-direct invocations on a trusted project; a gitignored
+  `~/.claude/settings.local.json` works for subagent dispatch on this machine only.
+
+Do not reintroduce these to the stowed global allow list without re-evaluating
+the trust boundary.

--- a/claude/.claude/skills/review-permissions/SKILL.md
+++ b/claude/.claude/skills/review-permissions/SKILL.md
@@ -89,14 +89,19 @@ assume `Bash(cmd:*)` matches the entire command string, not just arguments.
    and `git config --global`. `Bash(git status:*)` is vastly safer.
    Flag rules that glob on the binary name without a subcommand.
 
-10. **SSRF via registry/index flags** — Do npm/pip/cargo rules allow
+10. **PATH-resolved commands** — Does the rule name an unqualified binary
+    (no leading `/`, `~/`, or `./`)? A project prepending `./bin/` or
+    `./node_modules/.bin/` silently wins. Flag bare-name entries; require
+    justification (binary is OS-provided and unshadowable) or an absolute-path rule.
+
+11. **SSRF via registry/index flags** — Do npm/pip/cargo rules allow
     `--registry`, `--index-url`, or `--extra-index-url`? These redirect
     HTTP requests to attacker-controlled servers, leaking IP, auth
     tokens, and package queries.
 
 ### Data exfiltration and secret exposure
 
-11. **Sensitive file reads** — Do rules allowing `cat`, `head`, `tail`,
+12. **Sensitive file reads** — Do rules allowing `cat`, `head`, `tail`,
     `file`, `stat`, or `less` permit reading sensitive paths?
     `cat ~/.ssh/id_rsa`, `cat /proc/self/environ`,
     `head ~/.aws/credentials`, `cat .env` all expose secrets. Flag
@@ -104,14 +109,14 @@ assume `Bash(cmd:*)` matches the entire command string, not just arguments.
     (user/machine fingerprinting) and `env`, `printenv`, `set`,
     `export` (environment variable dumps).
 
-12. **Network exfiltration** — Do rules allow any network-capable
+13. **Network exfiltration** — Do rules allow any network-capable
     command? `curl`, `wget`, `git push`, `git remote add`, `ssh`,
     `scp`, `nc`, `dig`, `nslookup` can exfiltrate any data the AI has
     read in the session. A `cat` + `curl` combination allows
     read-then-exfiltrate. Flag any network-capable command in the
     allow list.
 
-13. **Chained multi-step exploitation** — Do any combinations of allowed
+14. **Chained multi-step exploitation** — Do any combinations of allowed
     rules create a dangerous chain? Common pairs:
     - Any file-read command + any network command = read-then-exfiltrate
     - Any write command + any execution command = write-then-execute
@@ -120,7 +125,7 @@ assume `Bash(cmd:*)` matches the entire command string, not just arguments.
 
 ### Code execution
 
-14. **Project code execution** — Do rules allow commands that execute
+15. **Project code execution** — Do rules allow commands that execute
     project-controlled code?
     - Test runners (`jest`, `vitest`, `pytest`, `go test`, etc.)
       execute config files, setup scripts, and test code
@@ -131,17 +136,14 @@ assume `Bash(cmd:*)` matches the entire command string, not just arguments.
     Flag any rule that auto-allows these without project-specific
     justification.
 
-15. **Arbitrary binary execution** — Do rules allow running any binary
+16. **Arbitrary binary execution** — Do rules allow running any binary
     with certain flags (e.g., `Bash(*:--version)`)? A malicious binary
     in `$PATH` ignores `--version` and runs its payload. Prefer
-    explicit binary names. Also check for PATH-relative shadowing:
-    a rule allowing `Bash(python:*)` executes whatever `python`
-    resolves to, which in a compromised project could be a trojan in
-    `./node_modules/.bin/` or `./bin/`.
+    explicit binary names.
 
 ### AI manipulation
 
-16. **Prompt injection exploiting permissions** — Could a malicious repo
+17. **Prompt injection exploiting permissions** — Could a malicious repo
     use prompt injection (via CLAUDE.md, README, code comments, issue
     bodies, or .gitattributes) to instruct the AI to craft commands
     that exploit these permission rules? For each allowed command,
@@ -153,7 +155,7 @@ assume `Bash(cmd:*)` matches the entire command string, not just arguments.
 
 ### Shared resource conflicts
 
-17. **Integration test runners** — Do rules allow test commands that may
+18. **Integration test runners** — Do rules allow test commands that may
     hit shared dependencies (databases, APIs)? Multiple concurrent
     sessions can conflict on shared test databases. Test runners that
     commonly run integration tests (`deno test`, `pytest`, `go test`,
@@ -163,27 +165,27 @@ assume `Bash(cmd:*)` matches the entire command string, not just arguments.
 
 ### Scope
 
-18. **Global vs project scope** — Are the rules in a global
+19. **Global vs project scope** — Are the rules in a global
     `~/.claude/settings.json` or a project `.claude/settings.json`?
     Global rules apply across all projects and should be maximally
     restrictive. Project-level rules can be more permissive because
     the risk context is known.
 
-19. **Blanket allows** — Are there unscoped rules like `"Bash"` (allows
+20. **Blanket allows** — Are there unscoped rules like `"Bash"` (allows
     all bash commands) or `"Edit"` (allows all file edits)? These
     defeat the permission system entirely. Flag and recommend scoped
     alternatives.
 
 ### Non-Bash tool permissions
 
-20. **Write/Edit to sensitive paths** — Do rules allow `Write` or `Edit`
+21. **Write/Edit to sensitive paths** — Do rules allow `Write` or `Edit`
     to paths outside the project directory? `Write(/etc/*)`,
     `Edit(~/.bashrc)`, or unscoped `Write` could overwrite system
     files, shell configs, or SSH keys. Scope to the project directory.
 
-21. **Read of secrets** — Do rules allow `Read` of sensitive paths?
+22. **Read of secrets** — Do rules allow `Read` of sensitive paths?
     `Read(~/.ssh/*)`, `Read(.env)`, `Read(/proc/*/environ)` expose
-    credentials. Same concern as checklist item 11 but for the Read
+    credentials. Same concern as checklist item 12 but for the Read
     tool.
 
 ## Output format


### PR DESCRIPTION
## Summary

- Adds checklist item 10 (PATH-resolved commands) to `review-permissions/SKILL.md` between items 9 and 10 (SSRF), with renumbering of old items 10–21 → 11–22
- Removes the now-redundant PATH-shadowing addendum from item 16 (arbitrary binary execution) — item 10's detection test subsumes it
- Creates `review-permissions/REFERENCES.md` with decision records for bare-name allow entries:
  - `cleanup-merged-branches` bare-name entries — accepted (binary in user-owned `~/.local/bin/`, not project-installable)
  - `npm run lint|typecheck|build` — intentionally absent (see below)
- Removes `Bash(npm run lint|typecheck|build)` from the stowed global `permissions.allow`
- Broadens CLAUDE.md "Code Comments" → "Code Comments and Durable Documentation"

## Why the npm-run entries were removed

`lint`/`typecheck`/`build` are project-controlled `package.json` script names. At global scope, a malicious project's scripts auto-fire the moment Claude Code opens the directory, with no prompt (checklist items 15 + 19 compounded). Subagent permission inheritance does not honor project-scope `.claude/settings.json`, so demoting to project scope does not restore subagent dispatch — the per-project re-prompt friction is the deliberate cost of removing global auto-trust.

Per-project re-allow is now an explicit decision: committed `.claude/settings.json` for parent-direct invocations on a trusted project, or gitignored `~/.claude/settings.local.json` for subagent dispatch on this machine only. REFERENCES.md records this so the next `/review-permissions` run cites the rationale rather than re-deriving it.

## Why CLAUDE.md was broadened

The code-comment freshness rule (no PR refs, no "used to be X before" framing, self-test for post-merge readability) applies equally to `REFERENCES.md`, doc files, and README sections — not only to inline code comments. The section heading and intro sentence now reflect this broader scope.

## Test plan

- [x] `pytest claude/.claude/` passes
- [x] `ruff check claude/.claude/` passes
- [x] `/skill-review` ran on cumulative diff — clean
- [x] `/code-review` ran on staged changes — clean
- [ ] `jq '.permissions.allow | map(select(test("npm run")))' claude/.claude/settings.json` returns `[]`
- [ ] Smoke test post-merge: verify-class subagent dispatch in any TS/JS project now surfaces the missing rule per CLAUDE.md "Heavy command output" (no inline fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)