### PR TITLE
fix(hook): fix two false-positives in enforce-marker-script-shape

### DIFF
--- a/claude/.claude/hooks/enforce-marker-script-shape.sh
+++ b/claude/.claude/hooks/enforce-marker-script-shape.sh
@@ -8,11 +8,13 @@
 # to fire this hook on ALL Bash commands. The internal grep is the actual
 # gate. The "if" field is a hint only.
 #
-# Any Bash command containing "marker.sh" must be one of the 12 valid
-# invocation shapes exactly. No chains, no env-var prefixes, no redirects,
-# no bash wrappers, no extra args. This prevents prompt-injection attacks
-# that chain marker.sh invocations with malicious commands and rely on the
-# settings.json allowlist to approve the first segment.
+# Commands that start directly with the marker.sh path (~/ or absolute) must
+# match one of the 12 valid invocation shapes exactly: no chains, no redirects,
+# no extra args. Wrapped forms (env-var prefix, bash wrapper, relative path,
+# subshell) are not gated here — they fast-exit at Stage 2 and are denied by
+# the permissions.allow layer, which does not list their wrapper executables.
+# Removing the permissions.allow gate without updating this hook would leave
+# those forms ungated.
 set -uo pipefail
 
 INPUT=$(cat)
@@ -25,22 +27,37 @@ if [ "$JQ_EXIT" -ne 0 ]; then
   exit 0
 fi
 
-# Fast-exit: no opinion on commands that don't involve marker.sh
-if ! printf '%s' "$COMMAND" | grep -qF 'marker.sh'; then
-  exit 0
-fi
+# Strip leading/trailing whitespace — computed before the activation guards so
+# both the fast-reject and anchored-path check share one computation.
+TRIMMED=$(printf '%s' "$COMMAND" | sed -E 's/^[[:space:]]+//')
 
-# Strip leading/trailing whitespace
-TRIMMED=$(printf '%s' "$COMMAND" | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//')
+# Stage 1: cheap substring fast-reject — most Bash calls have no marker mention.
+printf '%s' "$COMMAND" | grep -qF 'marker.sh' || exit 0
 
 # Reject path traversal sequences before the allowlist check. The VALID_PATTERN
 # character class permits '.' and '/', which together admit '../' segments.
-# An explicit '..' pre-check closes that gap cleanly.
-if printf '%s' "$TRIMMED" | grep -qF '..'; then
+# Match '..' only as a path segment (../foo, foo/.., foo/../bar) — not as
+# range notation (a..b), ellipses, or node_modules/.../foo. This check runs
+# before Stage 2 so that tilde-form traversal paths (e.g.
+# ~/.claude/scripts/../scripts/marker.sh) are caught even though Stage 2's
+# anchored regex does not match them.
+if printf '%s' "$TRIMMED" | grep -qE '(^|/)\.\.(/|$)'; then
   TRUNCATED=$(printf '%s' "$TRIMMED" | cut -c1-80)
   REASON="marker.sh invocation denied (path traversal '..' detected). Command (truncated): $TRUNCATED"
   REASON_JSON=$(printf '%s' "$REASON" | jq -Rs .)
   printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' "$REASON_JSON"
+  exit 0
+fi
+
+# Stage 2: anchored leading-path check. Bash =~ treats the subject as a single
+# string; `^` anchors at position 0 only — correct for multi-line $COMMAND
+# (heredocs) because grep -E with '^' matches per-line and would over-activate
+# on a heredoc body whose inner line starts with the script path.
+# Wrapped/chained forms (bash -c, env-var prefix, semicolons, subshells)
+# intentionally fast-exit here; permissions.allow is their gate — those wrapper
+# executables are not in the allow list, so the permission layer denies them
+# before this hook's deep validation would ever matter.
+if [[ ! "$TRIMMED" =~ ^(\~|\$HOME|/[A-Za-z0-9_./-]+)/\.claude/scripts/marker\.sh([[:space:]]|$) ]]; then
   exit 0
 fi
 
@@ -72,6 +89,7 @@ Valid shapes:
   ~/.claude/scripts/marker.sh deactivate respond-pr
   ~/.claude/scripts/marker.sh deactivate memory-skill
 
-No chains (&&, ||, ;), env-var prefixes, bash wrappers, redirects, or extra args."
+No chains (&&, ||, ;), redirects, or extra args. Env-var prefix, bash wrapper,
+and relative-path forms are not gated here — they are denied by permissions.allow."
 REASON_JSON=$(printf '%s' "$REASON" | jq -Rs .)
 printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' "$REASON_JSON"

--- a/claude/.claude/hooks/tests/test_enforce_marker_script_shape.py
+++ b/claude/.claude/hooks/tests/test_enforce_marker_script_shape.py
@@ -70,34 +70,12 @@ class TestEnforceMarkerScriptShape:
         assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "deny"
 
     # ------------------------------------------------------------------ #
-    # Env-var prefix — intentionally bypassed by Stage 2                 #
-    # ------------------------------------------------------------------ #
-
-    def test_env_var_prefix_allowed(self):
-        """The shape hook intentionally does not gate this form; permissions.allow denies the
-        wrapping executable. Do not change this test without first confirming the
-        permission-layer gate still applies."""
-        cmd = "FOO=1 ~/.claude/scripts/marker.sh write code-review"
-        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "allow"
-
-    # ------------------------------------------------------------------ #
     # Redirect                                                            #
     # ------------------------------------------------------------------ #
 
     def test_redirect_denied(self):
         cmd = "~/.claude/scripts/marker.sh write code-review > /tmp/out"
         assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "deny"
-
-    # ------------------------------------------------------------------ #
-    # Bash wrapper — intentionally bypassed by Stage 2                   #
-    # ------------------------------------------------------------------ #
-
-    def test_bash_wrapper_allowed(self):
-        """The shape hook intentionally does not gate this form; permissions.allow denies the
-        wrapping executable. Do not change this test without first confirming the
-        permission-layer gate still applies."""
-        cmd = "bash ~/.claude/scripts/marker.sh write code-review"
-        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "allow"
 
     # ------------------------------------------------------------------ #
     # Extra args                                                          #
@@ -148,17 +126,6 @@ class TestEnforceMarkerScriptShape:
 
     def test_absolute_path_form_allowed(self):
         cmd = "/home/jared/.claude/scripts/marker.sh write code-review"
-        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "allow"
-
-    # ------------------------------------------------------------------ #
-    # Relative path — intentionally bypassed by Stage 2                  #
-    # ------------------------------------------------------------------ #
-
-    def test_relative_path_allowed(self):
-        """The shape hook intentionally does not gate this form; permissions.allow denies the
-        wrapping executable. Do not change this test without first confirming the
-        permission-layer gate still applies."""
-        cmd = "./marker.sh write code-review"
         assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "allow"
 
     def test_path_traversal_denied(self):

--- a/claude/.claude/hooks/tests/test_enforce_marker_script_shape.py
+++ b/claude/.claude/hooks/tests/test_enforce_marker_script_shape.py
@@ -6,6 +6,7 @@ from helpers import (
     HOOKS_DIR,
     bash_input,
     run_hook,
+    run_hook_reason,
 )
 
 ENFORCE_MARKER_SCRIPT_SHAPE_HOOK = HOOKS_DIR / "enforce-marker-script-shape.sh"
@@ -69,12 +70,15 @@ class TestEnforceMarkerScriptShape:
         assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "deny"
 
     # ------------------------------------------------------------------ #
-    # Env-var prefix                                                      #
+    # Env-var prefix — intentionally bypassed by Stage 2                 #
     # ------------------------------------------------------------------ #
 
-    def test_env_var_prefix_denied(self):
+    def test_env_var_prefix_allowed(self):
+        """The shape hook intentionally does not gate this form; permissions.allow denies the
+        wrapping executable. Do not change this test without first confirming the
+        permission-layer gate still applies."""
         cmd = "FOO=1 ~/.claude/scripts/marker.sh write code-review"
-        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "deny"
+        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "allow"
 
     # ------------------------------------------------------------------ #
     # Redirect                                                            #
@@ -85,12 +89,15 @@ class TestEnforceMarkerScriptShape:
         assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "deny"
 
     # ------------------------------------------------------------------ #
-    # Bash wrapper                                                        #
+    # Bash wrapper — intentionally bypassed by Stage 2                   #
     # ------------------------------------------------------------------ #
 
-    def test_bash_wrapper_denied(self):
+    def test_bash_wrapper_allowed(self):
+        """The shape hook intentionally does not gate this form; permissions.allow denies the
+        wrapping executable. Do not change this test without first confirming the
+        permission-layer gate still applies."""
         cmd = "bash ~/.claude/scripts/marker.sh write code-review"
-        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "deny"
+        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "allow"
 
     # ------------------------------------------------------------------ #
     # Extra args                                                          #
@@ -144,13 +151,124 @@ class TestEnforceMarkerScriptShape:
         assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "allow"
 
     # ------------------------------------------------------------------ #
-    # Relative path — must be denied                                      #
+    # Relative path — intentionally bypassed by Stage 2                  #
     # ------------------------------------------------------------------ #
 
-    def test_relative_path_denied(self):
+    def test_relative_path_allowed(self):
+        """The shape hook intentionally does not gate this form; permissions.allow denies the
+        wrapping executable. Do not change this test without first confirming the
+        permission-layer gate still applies."""
         cmd = "./marker.sh write code-review"
-        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "deny"
+        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "allow"
 
     def test_path_traversal_denied(self):
         cmd = "/home/evil/../../home/jared/.claude/scripts/marker.sh write code-review"
+        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "deny"
+
+    # ------------------------------------------------------------------ #
+    # False-positive regressions — commands that must NOT be blocked      #
+    # ------------------------------------------------------------------ #
+
+    def test_heredoc_commit_mentioning_marker_sh_in_body_allowed(self):
+        """A git commit whose heredoc body mentions marker.sh must not be inspected.
+
+        The activation guard (Stage 2) uses bash =~ which anchors at
+        start-of-subject, so a heredoc body line starting with the script
+        path does NOT activate the deeper validator — only a command that
+        itself starts with the path does.
+        """
+        cmd = "git commit -m \"$(cat <<'EOF'\nfix: prevent marker.sh hook from blocking heredoc commits\nEOF\n)\""
+        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "allow"
+
+    def test_heredoc_inner_line_starting_with_marker_path_allowed(self):
+        """A heredoc body whose inner line starts with ~/.claude/scripts/marker.sh must allow.
+
+        Verifies that bash =~ anchors at start-of-subject (the entire
+        multi-line string), not at start-of-line. If grep -E were used
+        instead, the inner line would match '^...' and over-activate.
+        """
+        cmd = "git commit -m \"$(cat <<'EOF'\n~/.claude/scripts/marker.sh activate code-review\nEOF\n)\""
+        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "allow"
+
+    def test_git_log_range_two_dots_allowed(self):
+        """git log a..b must not trip the path-traversal check.
+
+        The traversal check matches '..' only as a path segment
+        (preceded or followed by '/'), not as a range operator.
+        """
+        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input("git log a..b")) == "allow"
+
+    def test_git_diff_triple_dot_allowed(self):
+        """git diff main...HEAD must not trip the path-traversal check."""
+        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input("git diff main...HEAD")) == "allow"
+
+    def test_gh_pr_create_with_marker_sh_in_body_allowed(self):
+        """gh pr create --body mentioning marker.sh inline must allow."""
+        cmd = 'gh pr create --body "mentions marker.sh inline"'
+        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "allow"
+
+    # ------------------------------------------------------------------ #
+    # Bypass shapes — intentionally allowed; pin the behavior             #
+    # ------------------------------------------------------------------ #
+
+    def test_wrapped_bash_c_intentionally_not_gated_relies_on_permissions_allow(self):
+        """The shape hook intentionally does not gate this form; permissions.allow denies the
+        wrapping executable. Do not change this test without first confirming the
+        permission-layer gate still applies."""
+        cmd = 'bash -c "~/.claude/scripts/marker.sh activate code-review"'
+        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "allow"
+
+    def test_env_var_prefix_bypass_intentionally_not_gated_relies_on_permissions_allow(self):
+        """The shape hook intentionally does not gate this form; permissions.allow denies the
+        wrapping executable. Do not change this test without first confirming the
+        permission-layer gate still applies."""
+        cmd = "FOO=bar ~/.claude/scripts/marker.sh activate code-review"
+        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "allow"
+
+    def test_semicolon_prefix_bypass_intentionally_not_gated_relies_on_permissions_allow(self):
+        """The shape hook intentionally does not gate this form; permissions.allow denies the
+        wrapping executable. Do not change this test without first confirming the
+        permission-layer gate still applies."""
+        cmd = "true; ~/.claude/scripts/marker.sh activate code-review"
+        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "allow"
+
+    def test_subshell_bypass_intentionally_not_gated_relies_on_permissions_allow(self):
+        """The shape hook intentionally does not gate this form; permissions.allow denies the
+        wrapping executable. Do not change this test without first confirming the
+        permission-layer gate still applies."""
+        cmd = "$(~/.claude/scripts/marker.sh write code-review somehash)"
+        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "allow"
+
+    def test_relative_path_bypass_intentionally_not_gated_relies_on_permissions_allow(self):
+        """The shape hook intentionally does not gate this form; permissions.allow denies the
+        wrapping executable. Do not change this test without first confirming the
+        permission-layer gate still applies."""
+        cmd = "./marker.sh activate code-review"
+        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "allow"
+
+    # ------------------------------------------------------------------ #
+    # Real invocations — must still reach deep validation                 #
+    # ------------------------------------------------------------------ #
+
+    def test_dollar_home_form_denied_by_deep_validator(self):
+        """$HOME literal activates Stage 2 (anchored-path check matches \\$HOME),
+        but VALID_PATTERN only accepts ~ and absolute /... paths. The deep
+        validator must deny it."""
+        cmd = "$HOME/.claude/scripts/marker.sh activate code-review"
+        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "deny"
+
+    def test_dollar_home_form_denied_has_shape_validation_reason(self):
+        """$HOME form reaches the deep validator, which emits the shape-validation deny reason."""
+        cmd = "$HOME/.claude/scripts/marker.sh activate code-review"
+        reason = run_hook_reason(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd))
+        assert reason is not None
+        assert "marker.sh invocation denied" in reason
+
+    def test_path_traversal_in_real_invocation_denied(self):
+        """~/.claude/scripts/../scripts/marker.sh must be denied via the traversal check.
+
+        The traversal check runs before Stage 2, so tilde-form paths with '../'
+        segments are caught even though Stage 2's anchored regex would not match them.
+        """
+        cmd = "~/.claude/scripts/../scripts/marker.sh activate code-review"
         assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "deny"


### PR DESCRIPTION
## Summary

- **Heredoc false-positive:** The activation guard used `grep -qF 'marker.sh'` — a bare substring match — so a `git commit` with a heredoc body mentioning `marker.sh` was inspected and denied. Fixed with a two-stage check: cheap substring fast-reject (Stage 1) followed by a bash `[[ =~ ]]` anchored leading-path check (Stage 2). Bash `=~` anchors at start-of-subject rather than per-line, so heredoc body lines don't activate the deep validator. Root cause behind PR #184's temp-file workaround.
- **Dot-range false-positive:** `grep -qF '..'` matched any two adjacent dots — `Bash(...)`, `git log a..b`, ellipses in commit messages. Replaced with a regex that matches `..` only as a path segment (preceded or followed by `/` or string boundary).
- **Traversal check ordering:** Moved before Stage 2 so tilde-form invocation paths containing a traversal segment are caught before Stage 2 can fast-exit them.
- **`$HOME` literal in Stage 2 alternation:** A literal `$HOME/.claude/scripts/marker.sh` invocation previously bypassed deep shape validation (fast-exit at Stage 2). It now reaches VALID_PATTERN and is correctly denied.
- **Header and deny message corrected:** Both previously claimed env-var prefix and bash wrapper forms were denied here — they're not. Those wrapper executables are not in `permissions.allow`, so the permission layer denies them before this hook's deep validation matters.

## Test plan

- [x] 653 tests passing (`pytest claude/.claude/ -q`)
- [x] `ruff check claude/.claude/` clean
- [ ] Manual: `git commit` with a heredoc body mentioning `marker.sh` — must succeed without temp-file workaround
- [ ] Manual: `gh pr create --body "marker.sh inline mention"` — must succeed
- [ ] Manual: `~/.claude/scripts/marker.sh bogus-verb skill` — must still deny
- [ ] Manual: confirm `bash -c "~/.claude/scripts/marker.sh activate code-review"` is denied at the permissions layer (not the hook)

## Security surface

Reviewed by CISO and staff-platform-engineer during planning. The narrowed activation guard creates a silent-allow path for wrapped/chained forms (`bash -c`, env-var prefix, semicolons, subshells) — previously caught by substring match and denied. Accepted: those wrapper executables are not in `permissions.allow`, so the permission layer denies them first. Bypass-shape tests pin this assumption with docstrings warning future editors to verify the permission-layer gate before widening.

## Follow-up

The traversal check still fires on any Bash command that (a) mentions `marker.sh` in its body AND (b) contains a traversal segment anywhere in the same command text. This PR's own body triggered it (temp-file workaround required here). Fixing this properly requires restructuring so the traversal check runs only after Stage 2 establishes it's an actual marker invocation, while still catching traversal-prefixed invocations that would otherwise slip past Stage 2 — filed as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
