### PR TITLE
feat(workflow): add foundation-critique gates to plan-review, plan-it, agents, and CLAUDE.md

### DIFF
--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -7,12 +7,14 @@
 - Avoid duplicating managed values across files where they can drift out of sync, but use judgment — sometimes a simple hardcoded value is better than an over-engineered abstraction.
 - Before taking any action that is destructive, irreversible, or has blast radius beyond the immediate change (data loss, breaking API changes, infrastructure modifications), flag the risk and confirm the approach.
 - When uncertain about a CLI flag, tool behavior, or API detail, verify rather than guessing.
+- **Default-suspect over-powered primitives.** When a design adopts a more powerful, invasive, or wider-scope mechanism than the task requires — a heavier abstraction, a more privileged execution context, a more complex coordination pattern, a more invasive integration — identify the lighter primitive in the source documentation/system that could solve the problem before adopting the heavier one. Re-read the source with the specific question "what mechanisms exist that do NOT require this heavier choice?" — first-pass reads miss the answer routinely.
 
 ## Working Style
 
 - Walk through your proposed approach and explain tradeoffs before writing code. When presenting options, evaluate them — state which you'd recommend and why, rather than listing choices without a judgment.
 - Be precise. Do not overstate severity, conflate distinct issues, or hand-wave. State the realistic impact and verify claims against actual code — not against what the code or a sensible design should do.
 - Always prefer minimal, targeted changes. Do not refactor entire files or expand scope beyond what was asked. If you see an opportunity for a broader improvement, mention it separately — do not bundle it in.
+- **Compounding defensive layers are a wrong-foundation tell.** When a design accumulates stacked defenses on a single mechanism — each new layer closing a gap that the prior layer's existence created — or starts citing its own prior findings, step back and ask whether a foundational change would dissolve them. Do not keep adding hardening. The right primitive usually has a simple shape; compounding complexity is a signal to question the foundation, not to defend it more carefully.
 - Before assuming anything about the environment, stack, or project conventions, check first. Read the actual config files rather than guessing defaults.
 - Use descriptive variable and function names. No generic names.
 - When a session crosses ~60% context usage (visible via statusline `.context_window.used_percentage`) AND the current task is incomplete, proactively suggest the user run `/handoff`. Do not run it yourself — it's a user-invoked slash command. If the user agrees, the command writes `/tmp/<slug>-handoff.md` and provides the resume incantation. Run `analyze-context` if unsure about the threshold. (See README's "Threshold reference" section for the why-60%.)

--- a/claude/.claude/agents/ciso-reviewer.md
+++ b/claude/.claude/agents/ciso-reviewer.md
@@ -47,6 +47,7 @@ If the change is bounded to cosmetic-only edits (typo fixes, formatting, copy po
 2. Demonstrate exploitability — don't assert it. Trace attacker-controlled input to the privileged operation, confirm each hop. If you can't construct the path, say "potential finding, couldn't confirm exploitability."
 3. Untested security controls are indistinguishable from absent ones — flag missing allow/deny test coverage for security invariants as a finding, not a nit.
 4. Do not propose implementations. Propose controls.
+5. **Foundation question first.** Before scoring controls, answer: does the design require this class of control at all, or does a lower-privilege primitive in the source documentation, framework, or system make the whole control category unnecessary? If a lower-privilege primitive exists, lead with **Foundation concern** — name the primitive, quote the source if available — before any per-finding output. The control is the finding, not the gaps in the control.
 
 ## Shared ownership
 
@@ -59,6 +60,8 @@ If the change is bounded to cosmetic-only edits (typo fixes, formatting, copy po
 ## Output format
 
 Start with one line: domains covered and how many files/plan sections reviewed.
+
+**Foundation concern (or N/A):** Does this design require this class of control at all? If a lower-privilege primitive in the source documentation or system makes the control category unnecessary, name it here. If N/A, proceed to per-finding output.
 
 For each finding:
 1. **Severity**: Critical / High / Medium / Low

--- a/claude/.claude/agents/staff-analytics-engineer.md
+++ b/claude/.claude/agents/staff-analytics-engineer.md
@@ -82,6 +82,7 @@ When in doubt, engage. Schema choices have long-tail downstream cost; missed rev
 2. For backend schema changes, evaluate ELT-readiness as a data-contract consumer. Frame as observations, not vetoes.
 3. For new models, verify materialization, partitioning, and tests.
 4. Do not propose model implementations. Name the modeling concern, the analytical impact, the required property.
+5. **Foundation question first.** Before scoring model complexity or materialization strategy, answer: does the design require this modeling approach at all, or does a simpler model shape (wide table vs snowflake, view vs materialized table, standard incremental vs custom SCD) make the whole approach unnecessary? If yes, lead with **Foundation concern** before any per-finding output. The over-modeled artifact is the finding, not the gaps in its implementation.
 
 ## Shared ownership
 
@@ -93,6 +94,8 @@ When in doubt, engage. Schema choices have long-tail downstream cost; missed rev
 ## Output format
 
 Start with one line: domains covered and how many files/sections reviewed.
+
+**Foundation concern (or N/A):** Does this design require this modeling approach at all? If a simpler model shape — wide table vs snowflake, view vs materialized table, standard incremental vs custom SCD — makes it unnecessary, name it here. If N/A, proceed to per-finding output.
 
 For each finding:
 1. **Angle** (e.g., "Modeling fidelity — fact grain", "ELT-readiness — column type", "Cost of query at warehouse scale")

--- a/claude/.claude/agents/staff-backend-engineer.md
+++ b/claude/.claude/agents/staff-backend-engineer.md
@@ -63,6 +63,7 @@ Schema is the query plan. Access patterns drive the design. `staff-data-engineer
 2. For contract changes, grep every consumer. List them.
 3. For external/SDK calls, verify retry/timeout/credential scoping. Cite the docs or source if non-obvious.
 4. Do not propose implementations. Name the contract, the breakage, the required property.
+5. **Foundation question first.** Before scoring API contracts, coordination patterns, or error-handling complexity, answer: does the design require this class of API/coordination approach at all, or does a simpler primitive in the source documentation or framework make the whole approach unnecessary? If yes, lead with **Foundation concern** before any per-finding output. The over-engineered contract is the finding, not the gaps in the contract.
 
 ## Shared ownership
 
@@ -97,6 +98,8 @@ format below.
 ### Inline output
 
 Start with one line: domains covered and how many files/sections reviewed.
+
+**Foundation concern (or N/A):** Does this design require this class of API contract, coordination pattern, or error-handling approach at all? If a simpler primitive in the framework or source documentation makes it unnecessary, name it here. If N/A, proceed to per-finding output.
 
 For each finding:
 1. **Checklist item or angle** (e.g., "K1 — Contract compatibility", "Timeouts/cancellation")

--- a/claude/.claude/agents/staff-data-engineer.md
+++ b/claude/.claude/agents/staff-data-engineer.md
@@ -57,6 +57,7 @@ Flag for backend's decision; do not block.
 3. For new tables, check policies are declared in the same migration and default grants match intent.
 4. For pipeline changes, verify resume-token, DLQ, and idempotency handling.
 5. Do not propose implementations. Name the operation, safety property violated, required control.
+6. **Foundation question first.** Before scoring migration complexity or pipeline approach, answer: does the design require this class of migration or pipeline at all, or does a simpler schema approach or lighter transport primitive make the whole pattern unnecessary? If yes, lead with **Foundation concern** before any per-finding output. The over-engineered migration is the finding, not the gaps in its execution.
 
 ## Shared ownership
 
@@ -70,6 +71,8 @@ Flag for backend's decision; do not block.
 ## Output format
 
 Start with one line: surface areas reviewed and how many files / sections.
+
+**Foundation concern (or N/A):** Does this design require this class of migration approach or pipeline complexity at all? If a simpler schema design or lighter transport primitive makes it unnecessary, name it here. If N/A, proceed to per-finding output.
 
 For each finding:
 1. **Angle** (e.g., "Migration safety — pipeline impact", "CDC config — resume token", "Catalog — lineage break")

--- a/claude/.claude/agents/staff-frontend-engineer.md
+++ b/claude/.claude/agents/staff-frontend-engineer.md
@@ -55,6 +55,7 @@ If the diff is purely backend, infrastructure, server-only types with no contrac
 2. For state/cache changes, trace cache keys. Missing invalidation is the most common optimistic-mutation bug.
 3. For accessibility findings, cite the specific interactive element.
 4. Do not propose implementations. Name the interaction, the broken state, the required behavior.
+5. **Foundation question first.** Before scoring component abstractions, state management layers, or data-fetching patterns, answer: does the design require this class of abstraction at all, or does a simpler built-in or lighter library primitive make the whole pattern unnecessary? If yes, lead with **Foundation concern** before any per-finding output. The heavier abstraction is the finding, not the gaps within it.
 
 ## Shared ownership
 
@@ -68,6 +69,8 @@ If the diff is purely backend, infrastructure, server-only types with no contrac
 ## Output format
 
 Start with one line: domains covered and how many files/sections reviewed.
+
+**Foundation concern (or N/A):** Does this design require this class of component abstraction or state management layer at all? If a simpler built-in or lighter primitive makes it unnecessary, name it here. If N/A, proceed to per-finding output.
 
 For each finding:
 1. **Checklist item or angle** (e.g., "F3 — Query contract mapping", "Web Vitals / CLS")

--- a/claude/.claude/agents/staff-platform-engineer.md
+++ b/claude/.claude/agents/staff-platform-engineer.md
@@ -62,6 +62,7 @@ If the diff is pure application logic with no operational surface delta, or a co
 3. For secrets, trace each reference to its exposure boundary.
 4. For application changes, ask: "if this breaks at 2am, can we see it and revert it?" If the answer requires infrastructure that doesn't exist yet, that's a finding.
 5. Do not propose rewrites. Name the pipeline behavior, the failure mode, the required property.
+6. **Foundation question first.** Before scoring CI/CD complexity, IAM scope, or infrastructure orchestration patterns, answer: does the design require this class of pipeline or permission scope at all, or does a simpler, narrower-permission primitive in the platform documentation make the whole approach unnecessary? If yes, lead with **Foundation concern** before any per-finding output. The over-scoped pipeline is the finding, not the gaps within it.
 
 ## Shared ownership
 
@@ -74,6 +75,8 @@ If the diff is pure application logic with no operational surface delta, or a co
 ## Output format
 
 Start with one line: surface areas reviewed and how many files/sections.
+
+**Foundation concern (or N/A):** Does this design require this class of CI/CD complexity or IAM/permission scope at all? If a simpler or narrower-permission primitive in the platform makes it unnecessary, name it here. If N/A, proceed to per-finding output.
 
 For each finding:
 1. **Checklist item or angle** (e.g., "I3 — Deployment ordering", "Pipeline observability — silent cron", "Cost footprint")

--- a/claude/.claude/agents/staff-product-engineer.md
+++ b/claude/.claude/agents/staff-product-engineer.md
@@ -63,6 +63,7 @@ When the spec and the user problem diverge, flag the divergence as a finding. Ci
 3. Critical reading of the spec — separate requirement (what the user needs) from implementation detail (how it's built). Flag entanglement.
 4. For plans, check whether the planned deliverable closes the user-facing gap or stops at a technical checkpoint.
 5. Do not propose UI designs. Name the flow, the drift from user intent, the required outcome.
+6. **Foundation question first.** Before scoring flow complexity, flag layers, or entitlement design, answer: does the design require this level of flow or entitlement complexity at all, or does a simpler user-facing primitive (direct default, single-step flow, standard entitlement model) deliver the same outcome? If yes, lead with **Foundation concern** before any per-finding output. The over-engineered user flow is the finding, not the gaps within it.
 
 ## Shared ownership
 
@@ -77,6 +78,8 @@ When the spec and the user problem diverge, flag the divergence as a finding. Ci
 ## Output format
 
 Start with one line: flows/surfaces reviewed and how many files/sections.
+
+**Foundation concern (or N/A):** Does this design require this level of flow or entitlement complexity at all? If a simpler user-facing primitive delivers the same outcome, name it here. If N/A, proceed to per-finding output.
 
 For each finding:
 1. **Angle** (e.g., "Spec fidelity — divergence from spec section 3.2", "Adjacent-behavior regression", "Analytics event semantics")

--- a/claude/.claude/agents/staff-sdet.md
+++ b/claude/.claude/agents/staff-sdet.md
@@ -54,6 +54,7 @@ The global `test-conventions` skill defines how tests should be written. The glo
 3. For plans proposing tests, verify the plan names the test layer, the risk covered, and the invariant. "Add tests" is not a test strategy.
 4. Cite conventions by section number when findings map (`test-conventions §6`, `test-evaluation §4`).
 5. Do not propose implementations. Name the risk, the layer, the untested invariant.
+6. **Foundation question first.** Before scoring test-class weight, fixture complexity, or mock design, answer: does this invariant require this level of test class at all, or does a lower-weight test class (unit over integration, integration over e2e, contract over live-service) verify the same invariant more cheaply? If yes, lead with **Foundation concern** before any per-finding output. The over-heavy test class is the finding, not the gaps within it.
 
 ## Shared ownership
 
@@ -66,6 +67,8 @@ The global `test-conventions` skill defines how tests should be written. The glo
 ## Output format
 
 Start with one line: test layers reviewed and how many files/sections.
+
+**Foundation concern (or N/A):** Does this test strategy require this test class at all, or does a lower-weight class (unit over integration, integration over e2e, contract over live-service) verify the same invariant more cheaply? If N/A, proceed to per-finding output.
 
 For each finding:
 1. **Checklist item or angle** (e.g., "B10 — Test realism", "Pyramid shape", "test-evaluation §4: tautological assertion")

--- a/claude/.claude/skills/plan-it/SKILL.md
+++ b/claude/.claude/skills/plan-it/SKILL.md
@@ -43,7 +43,13 @@ List every underspecified decision (edge cases, error handling, scope boundaries
 
 ## Step 5 — Architecture design
 
-Choose the approach. Always include brief rationale — what alternatives were weighed and why they were set aside. For trivial choices one sentence suffices; no separate alternatives section is needed. Consult `code-review`, `test-conventions`, and `verify-primary-sources` if their domains are implicated. Write the plan with these sections:
+Choose the approach. Always include brief rationale — what alternatives were weighed and why they were set aside. For trivial choices one sentence suffices; no separate alternatives section is needed. Consult `code-review`, `test-conventions`, and `verify-primary-sources` if their domains are implicated.
+
+**External-pattern grounding.** When the chosen approach invokes a pattern from external documentation (a library, framework, or vendor doc), quote the literal source lines that establish the pattern — not a paraphrase, not a summary, not the section heading. This extends Step 3's grep-the-population rule from in-codebase patterns to external sources. A capitalized pattern name ("the X pattern") lifted from prose without a verbatim source quote is a hazard: names crystallize an interpretation that may not match the source.
+
+**Lighter-alternatives subsection.** If the chosen approach adopts a more powerful, invasive, or wider-scope mechanism than the task requires — a heavier abstraction, a more privileged execution context, a more complex coordination pattern, a more invasive integration — include a **Lighter alternatives considered** subsection in the plan. Enumerate at least two lighter primitives from the source documentation/system; for each, state in one sentence why it does not solve the problem. If you cannot find two lighter alternatives in the source, that itself is the signal that you have not read the source carefully enough — re-read with the specific question "what mechanisms exist that do NOT require this heavier choice?" before continuing.
+
+Write the plan with these sections:
 
 1. **Context** — problem, why now, intended outcome (lead with a one-sentence goal)
 2. **Approach** — chosen design with rationale; note alternatives considered and why they were set aside (inline in this section, not a separate block)

--- a/claude/.claude/skills/plan-review/REFERENCES.md
+++ b/claude/.claude/skills/plan-review/REFERENCES.md
@@ -25,6 +25,12 @@ Post-extraction smoke test to verify ROUTING.md is reachable and substantively c
 
 **What this does not prove:** That the architecture is correct in general. It is evidence the extraction didn't break agent spawning on one realistic test case. Re-run this test when SKILL.md's Routing section is edited or when ROUTING.md content is modified.
 
+## Foundation-tripwire rules — surfacing incident
+
+Step 4's foundation tripwires (over-powered primitive, compounding layers, self-referential finding) were added after a session built elaborate scaffolding (PreToolUse validator + Write hook with `lstat` symlink-race checks + mktemp anchoring + cross-platform fixtures + staggered two-PR rollout) to harden a `bypassPermissions: true` foundation that was itself unnecessary — the source doc had a lower-privilege pre-approval primitive sitting in plain sight. A specialist `ciso-reviewer` pass surfaced three Critical findings, all real, all only present *because* the bypass design existed.
+
+The lesson the rules encode: gap-finding on a wrong foundation elaborates the wrong foundation. The tripwires anchor Step 4 to observable surface features (layer counts, self-references, heavier-than-needed mechanism) so they fire even when the AI's internal reasoning is coherent. See also `claude/.claude/CLAUDE.md` Engineering Judgment and Working Style for the global-level statement of the same heuristics.
+
 ## Hook enforcement — 2026-05-05
 
 Two hooks mechanically enforce ROUTING.md consultation during plan-review:

--- a/claude/.claude/skills/plan-review/SKILL.md
+++ b/claude/.claude/skills/plan-review/SKILL.md
@@ -61,20 +61,23 @@ A plan failing any of these is not ready to implement — return it to the autho
 
 ## Step 4 — Design-fitness gate
 
-Before evaluating gaps, answer two questions in order:
-
+Before evaluating gaps, answer three questions in order:
 1. **What user surface and threat model does this serve?** A line or two — production users, internal-only, dev-only, or whatever framing fits. Persona reviewers must scope findings to the declared surface, not default to a worst-case external-attacker model.
-
 2. **Is the design appropriately sized for the user pain it solves on that surface?** Gap-finding on an over-elaborate design elaborates it further (each finding closes a gap by adding more machinery), and the checklist won't surface "this whole design is the wrong shape."
 
 Markers of over-elaboration:
-
 - Defensive layers beyond the declared user surface and threat model; conditional logic for phases that may not arrive.
 - Layers duplicating an existing abstraction; granularity exceeding any consumer's need.
 - Captured outputs / fields with no downstream reader.
 - "Could be done in N lines" stays valid even after personas shaped the plan.
 
-If over-elaborated: stop. Surface the simpler design as the primary review output before any checklist findings. Otherwise proceed to Step 5 — gap-finding will surface what's missing.
+3. **Are foundation-correctness tripwires clean?** These fire on observable plan text, not on judgment calls. If any fire, stop — output "Foundation concern: [one sentence]" + "Lighter alternative: [one sentence pointing to source]" as the primary output; do not spawn specialists until the foundation question is resolved.
+
+   - **Over-powered primitive.** Plan uses a mechanism heavier, more invasive, or wider-scope than the task needs. Required: name the lighter primitive in the source documentation and justify why it fails. If not enumerated, the foundation is the finding, not the hardening on top of it.
+   - **Compounding layers.** Plan stacks multiple layers (validation, retry, fallback, defense, schema-drift handling, etc.), each closing a gap the prior layer's existence created. Required: ask "what foundational change dissolves these?" before scoring any layer individually.
+   - **Self-referential findings.** Plan cites its own prior findings ("addresses the gap from the previous draft," "closes the issue raised in the prior pass"). Required: treat each self-reference as evidence the foundation generates problems faster than patches close them.
+
+If over-elaborated or any foundation tripwire fires: stop. Surface the simpler design or the foundation question as the primary review output before any checklist findings. Otherwise proceed to Step 5 — gap-finding will surface what's missing.
 
 Question implementation choices, not feature scope — the ticket itself isn't reviewed here, that goes back to the author.
 


### PR DESCRIPTION
## Summary

Adds workflow infrastructure so Claude can catch wrong-foundation designs itself, rather than relying on user pushback after elaboration has already happened.

Motivated by a case study where a session built PreToolUse validator + Write hook with symlink-race checks + mktemp anchoring + cross-platform fixtures + staggered two-PR rollout to harden a `bypassPermissions: true` foundation that was itself unnecessary. A ciso-reviewer pass surfaced 3 Criticals — all real, all only present because the bypass design existed.

Three structural gaps corrected:

- **plan-review Step 4**: adds a third gate question — a concrete tripwire block — before domain checklists. Three tripwires fire on observable plan text (over-powered primitive, compounding layers, self-referential findings), not on judgment calls, so they catch wrong-foundation designs even when the AI's internal reasoning is coherent. When any fires, specialists are not spawned until the foundation question is resolved.

- **All 8 specialist agents**: each now has a domain-adapted "foundation question first" instruction and a "Foundation concern (or N/A)" output slot above per-finding output. Previously all 8 were structurally defense-auditors on a fixed foundation — no slot existed for "this artifact/control/contract/test shouldn't exist."

- **plan-it Step 5**: requires (a) literal source-line quotes for external-doc pattern claims (extends the existing Step 3 grep rule to external docs), and (b) a "Lighter alternatives considered" subsection when the chosen approach is heavier than the task needs.

Two ambient heuristics added to CLAUDE.md ("Default-suspect over-powered primitives," "Compounding defensive layers are a wrong-foundation tell") for coverage in all sessions independent of /plan-review or /plan-it.

Surfacing incident documented in plan-review/REFERENCES.md (load-on-demand, not in the skill body).

## Test plan

- [ ] Run `pytest claude/.claude/` — Step 4 changes are prose-only; hook-alignment tests for plan-review fixtures should pass unchanged
- [ ] Smoke test 1: Write a stub plan in `.claude/plans/` that proposes an over-powered approach (e.g., `bypassPermissions` where the source doc has a non-bypass alternative). Run `/plan-review`. Verify output leads with "Foundation concern" and no specialists are spawned.
- [ ] Smoke test 2: Trigger `ciso-reviewer` directly on a diff with a deliberate over-privileged scaffold. Verify output begins with "Foundation concern (or N/A):" line.
- [ ] Smoke test 3: Ask `/plan-it` to plan something whose chosen approach is heavier than needed. Verify plan includes "Lighter alternatives considered" subsection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)