### PR TITLE
perf(skills): compress 10 ambient descriptions to reclaim context budget

### DIFF
--- a/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
+++ b/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
@@ -1,23 +1,13 @@
 ---
 name: ai-instruction-and-memory-files
 description: >
-  How Claude Code loads CLAUDE.md (and AGENTS.md via the `@AGENTS.md`
-  import pattern); how AGENTS.md serves as the cross-agent standard
-  (also read by Codex, Cursor, Gemini CLI, Windsurf, Amp, Aider, etc.);
-  Claude Code auto-memory (MEMORY.md index + topic files); and general
-  principles for editing any of these surfaces — precedence, duplication
-  rules, length targets, lost-in-the-middle, the user-vs-Claude-written
-  split.
-  TRIGGER when: editing CLAUDE.md or AGENTS.md; creating, editing,
-  auditing, or pruning Claude Code auto-memory in
-  `~/.claude/projects/*/memory/`; deciding whether a rule belongs in
-  CLAUDE.md vs AGENTS.md vs auto-memory; debating file length or
-  context budget for these surfaces.
-  DO NOT TRIGGER when: editing `.lovable/*.md` (use `lovable-knowledge`);
-  editing agent-specific rules files like `.cursorrules` or
-  `.github/copilot-instructions.md` (out of current scope); editing
-  README.md or other project docs not loaded by AI coding agents; or
-  writing code.
+  Editing rules for CLAUDE.md, AGENTS.md, and Claude Code auto-memory
+  (MEMORY.md index + topic files): loading precedence, duplication
+  policy, length targets, user-vs-Claude-written split.
+  TRIGGER when editing or auditing CLAUDE.md, AGENTS.md, or
+  ~/.claude/projects/*/memory/, or deciding which surface a rule
+  belongs in. DO NOT TRIGGER for .lovable/*.md, .cursorrules,
+  .github/copilot-instructions.md, README.md, or writing code.
 user-invocable: false
 ---
 

--- a/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
+++ b/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
@@ -4,9 +4,9 @@ description: >
   Editing rules for CLAUDE.md, AGENTS.md, and Claude Code auto-memory
   (MEMORY.md index + topic files): loading precedence, duplication
   policy, length targets, user-vs-Claude-written split.
-  TRIGGER when editing or auditing CLAUDE.md, AGENTS.md, or
+  TRIGGER when: editing or auditing CLAUDE.md, AGENTS.md, or
   ~/.claude/projects/*/memory/, or deciding which surface a rule
-  belongs in. DO NOT TRIGGER for .lovable/*.md, .cursorrules,
+  belongs in. DO NOT TRIGGER when: editing .lovable/*.md, .cursorrules,
   .github/copilot-instructions.md, README.md, or writing code.
 user-invocable: false
 ---

--- a/claude/.claude/skills/claude-hook-review/SKILL.md
+++ b/claude/.claude/skills/claude-hook-review/SKILL.md
@@ -1,19 +1,12 @@
 ---
 name: claude-hook-review
 description: >
-  How to review Claude Code hook scripts (`claude/.claude/hooks/*.sh`)
-  and hook entries in `settings.json` (PreToolUse, PostToolUse,
-  SessionStart): event/matcher selection, dispatch design,
-  fail-open vs fail-closed posture, the `emit_deny` JSON shape,
-  performance budget, and test patterns.
-  TRIGGER when: reviewing a change to a hook script under
-  `.claude/hooks/`; reviewing a change to a hook entry in
-  `settings.json` (`hooks.PreToolUse`, `hooks.PostToolUse`,
-  `hooks.SessionStart`, etc.); designing a new hook.
-  DO NOT TRIGGER when: editing `permissions.allow` rules (use
-  `review-permissions`); editing other `settings.json` fields (env,
-  model, theme — use `update-config`); reviewing non-Claude hook
-  systems (git hooks, husky, lefthook).
+  Review and audit of Claude Code hooks (.claude/hooks/*.sh and
+  settings.json hook entries): matcher selection, fail-open vs
+  fail-closed posture, emit_deny shape, performance budget, test
+  patterns. TRIGGER when reviewing a hook script or settings.json hook
+  entry, or designing a new hook. DO NOT TRIGGER for permissions.allow
+  edits (use review-permissions) or non-Claude hook systems.
 allowed-tools: Read, Grep, Glob, Bash
 user-invocable: false
 ---

--- a/claude/.claude/skills/claude-hook-review/SKILL.md
+++ b/claude/.claude/skills/claude-hook-review/SKILL.md
@@ -4,9 +4,10 @@ description: >
   Review and audit of Claude Code hooks (.claude/hooks/*.sh and
   settings.json hook entries): matcher selection, fail-open vs
   fail-closed posture, emit_deny shape, performance budget, test
-  patterns. TRIGGER when reviewing a hook script or settings.json hook
-  entry, or designing a new hook. DO NOT TRIGGER for permissions.allow
-  edits (use review-permissions) or non-Claude hook systems.
+  patterns. TRIGGER when: reviewing a .claude/hooks/*.sh script or
+  settings.json hook entry, or designing a new hook.
+  DO NOT TRIGGER when: editing permissions.allow rules
+  (use review-permissions) or non-Claude hook systems.
 allowed-tools: Read, Grep, Glob, Bash
 user-invocable: false
 ---

--- a/claude/.claude/skills/config-environments/SKILL.md
+++ b/claude/.claude/skills/config-environments/SKILL.md
@@ -1,18 +1,12 @@
 ---
 name: config-environments
 description: >
-  Design and review configuration that differs across environments (dev,
-  staging, production): env var naming, credential isolation, secrets
-  provisioning, and the anti-patterns that reintroduce tight coupling.
-  TRIGGER when: designing new env-var schemes, reviewing code that branches
-  on environment to pick credentials/config, proposing or reviewing variable
-  names with environment suffixes (`_DEV`, `_PROD`, `_STAGING`), or planning
-  secret-isolation strategies across dev and prod.
-  DO NOT TRIGGER when: the config genuinely needs to hold both values
-  simultaneously in the same process (migrations reading `OLD_*` and `NEW_*`
-  at once, test harnesses stubbing real values, feature flags orthogonal to
-  environment), or when the task is a single-environment app with no
-  per-env variation.
+  Multi-environment config design: env-var naming, credential isolation,
+  and secrets provisioning across dev/staging/prod. TRIGGER when
+  designing or reviewing env-var schemes, branching-on-environment
+  credential selection, or secret-isolation strategies. DO NOT TRIGGER
+  when a process legitimately holds both env values simultaneously
+  (migrations, test harnesses) or for single-environment apps.
 user-invocable: false
 ---
 

--- a/claude/.claude/skills/config-environments/SKILL.md
+++ b/claude/.claude/skills/config-environments/SKILL.md
@@ -2,11 +2,11 @@
 name: config-environments
 description: >
   Multi-environment config design: env-var naming, credential isolation,
-  and secrets provisioning across dev/staging/prod. TRIGGER when
+  and secrets provisioning across dev/staging/prod. TRIGGER when:
   designing or reviewing env-var schemes, branching-on-environment
-  credential selection, or secret-isolation strategies. DO NOT TRIGGER
-  when a process legitimately holds both env values simultaneously
-  (migrations, test harnesses) or for single-environment apps.
+  credential selection, or secret-isolation strategies.
+  DO NOT TRIGGER when: a process legitimately holds both env values
+  simultaneously (migrations, test harnesses) or single-environment apps.
 user-invocable: false
 ---
 

--- a/claude/.claude/skills/git-feature-branch-sync/SKILL.md
+++ b/claude/.claude/skills/git-feature-branch-sync/SKILL.md
@@ -1,22 +1,13 @@
 ---
 name: git-feature-branch-sync
 description: >
-  Decision framework for keeping a feature branch up to date with the
-  repo's default branch: when to rebase-and-force-push vs merge-in,
-  how to force-push safely (`--force-with-lease` / `--force-if-includes`
-  / plain `--force`), and when the "never force-push" instinct is
-  correct vs overcautious. This is the global framework — per-project
-  policy (squash-merge vs merge-commit, rebase-after-review rules,
-  branch-protection specifics) lives in that repo's CLAUDE.md or a
-  project-scoped skill.
-  TRIGGER when: deciding how to integrate the default branch into a
-  feature branch, whether/how to force-push a feature branch, or
-  picking between `--force-with-lease` and `--force-if-includes`.
-  DO NOT TRIGGER when: routine work on a clean feature branch with no
-  integration question, operations on the default / release / other
-  shared branches (those are always protected — never force-push them),
-  or mid-merge / mid-rebase / mid-cherry-pick state (use
-  `git-state-safety` instead).
+  When to rebase vs merge a feature branch and force-push safety
+  (--force-with-lease / --force-if-includes / plain --force).
+  TRIGGER when syncing a feature branch with the default branch or
+  deciding whether and how to force-push. DO NOT TRIGGER for routine
+  work on a clean branch, operations on shared/default branches (those
+  are always protected — never force-push them), or
+  mid-merge/rebase/cherry-pick state (use git-state-safety instead).
 user-invocable: false
 ---
 

--- a/claude/.claude/skills/git-feature-branch-sync/SKILL.md
+++ b/claude/.claude/skills/git-feature-branch-sync/SKILL.md
@@ -3,10 +3,10 @@ name: git-feature-branch-sync
 description: >
   When to rebase vs merge a feature branch and force-push safety
   (--force-with-lease / --force-if-includes / plain --force).
-  TRIGGER when syncing a feature branch with the default branch or
-  deciding whether and how to force-push. DO NOT TRIGGER for routine
-  work on a clean branch, operations on shared/default branches (those
-  are always protected — never force-push them), or
+  TRIGGER when: syncing a feature branch with the default branch or
+  deciding whether and how to force-push. DO NOT TRIGGER when: doing
+  routine work on a clean branch, operating on shared/default branches
+  (always protected — never force-push them), or in
   mid-merge/rebase/cherry-pick state (use git-state-safety instead).
 user-invocable: false
 ---

--- a/claude/.claude/skills/git-state-safety/SKILL.md
+++ b/claude/.claude/skills/git-state-safety/SKILL.md
@@ -1,21 +1,13 @@
 ---
 name: git-state-safety
 description: >
-  How to inspect other branches / commits safely when the working tree is
-  in a fragile state: mid-merge, mid-rebase, mid-cherry-pick, or with
-  staged changes from a partially-resolved conflict. Prevents the
-  silently-corrupted-index failure mode where a diagnostic
-  `git checkout <ref> -- <path>` overwrites the mid-merge index and the
-  resulting commit is wrong.
-  TRIGGER when: examining another ref's content while the current tree
-  has merge/rebase/cherry-pick state, unresolved conflicts, or a
-  partially-staged merge resolution. Also when recovering from a bad
-  merge that was already committed.
-  DO NOT TRIGGER when: plain read-only git operations on a clean tree,
-  normal feature work without pending merges, writing new code
-  unrelated to git state, or rebase-vs-merge-main and force-push-safety
-  questions on a clean feature branch (use `git-feature-branch-sync`
-  instead).
+  Safe inspection of other refs while mid-merge, mid-rebase, or
+  mid-cherry-pick — avoids `git checkout <ref> -- <path>` which
+  silently corrupts the index in these states. TRIGGER when examining
+  another ref while the tree has merge/rebase/cherry-pick state or
+  unresolved conflicts, or when recovering from a bad merge that was
+  already committed. DO NOT TRIGGER on a clean tree or for force-push
+  safety questions (use git-feature-branch-sync instead).
 user-invocable: false
 ---
 

--- a/claude/.claude/skills/git-state-safety/SKILL.md
+++ b/claude/.claude/skills/git-state-safety/SKILL.md
@@ -3,11 +3,11 @@ name: git-state-safety
 description: >
   Safe inspection of other refs while mid-merge, mid-rebase, or
   mid-cherry-pick — avoids `git checkout <ref> -- <path>` which
-  silently corrupts the index in these states. TRIGGER when examining
+  silently corrupts the index in these states. TRIGGER when: examining
   another ref while the tree has merge/rebase/cherry-pick state or
-  unresolved conflicts, or when recovering from a bad merge that was
-  already committed. DO NOT TRIGGER on a clean tree or for force-push
-  safety questions (use git-feature-branch-sync instead).
+  unresolved conflicts, or recovering from a bad merge already committed.
+  DO NOT TRIGGER when: working on a clean tree or for force-push safety
+  questions (use git-feature-branch-sync instead).
 user-invocable: false
 ---
 

--- a/claude/.claude/skills/plan-it/SKILL.md
+++ b/claude/.claude/skills/plan-it/SKILL.md
@@ -1,18 +1,12 @@
 ---
 name: plan-it
 description: >
-  Produce an implementation plan in .claude/plans/<topic-slug>.md
-  through Discovery, Codebase Exploration, Clarifying Questions, and
-  Architecture Design, then hand off to /plan-review for QA.
-  TRIGGER when: the user asks for a plan, design doc, or implementation
-  strategy for non-trivial work; before starting a feature branch where
-  the change spans multiple files or domains.
-  Triggers in plan mode too — compose with plan mode per Steps 1 and 6
-  rather than following plan mode's built-in workflow.
-  DO NOT TRIGGER when: the change is a one-line config tweak, a
-  single-file refactor with obvious shape, or the user explicitly said
-  "just implement it"; on the default branch with no intent to branch;
-  when a plan already exists and needs QA (use /plan-review instead).
+  Produces an implementation plan in .claude/plans/<slug>.md via
+  discovery, exploration, and architecture design, then hands off to
+  /plan-review. TRIGGER when asked for a plan or implementation strategy
+  for work spanning multiple files or domains. DO NOT TRIGGER for
+  single-file tweaks, "just implement it" requests, or when a plan
+  already exists (use /plan-review instead).
 user-invocable: true
 argument-hint: "[optional topic or ticket id]"
 ---

--- a/claude/.claude/skills/ready-for-review/SKILL.md
+++ b/claude/.claude/skills/ready-for-review/SKILL.md
@@ -1,27 +1,14 @@
 ---
 name: ready-for-review
 description: >
-  Pre-handoff gate run before a human reviewer looks at an open PR:
-  verifies tests/lint/typecheck, runs /code-review against the
-  cumulative PR-vs-default-branch diff, syncs PR description against
-  branch state, checks CI, and confirms tree hygiene.
-  TRIGGER when: (a) the user signals work is reviewer-ready, OR Claude
-  is about to summarize what landed and implicitly hand back — fire on
-  the *intent* (work-is-done-for-now-and-the-user-is-the-next-actor),
-  not on specific phrases. Examples that should fire: "ready for
-  review", "ship it", "PR is up", "take a look", "your turn", "PR is
-  now full-scope X", "implementation pushed and reviewable"; (b) Claude
-  has just pushed (or is about to push) commits to a branch that
-  already has an open PR and is wrapping up rather than continuing to
-  iterate; (c) before spawning a multi-persona ripple review (CISO +
-  multiple staff-* engineers) via the Agent tool on a PR-stage diff
-  outside an active /ready-for-review or /pre-merge flow, or before
-  invoking /ultrareview.
-  DO NOT TRIGGER when: work is still being iterated (more commits
-  planned before handoff); only a diff review or single verification
-  step was requested; on the default branch; or when a project-specific
-  pre-merge-style skill already wraps these checks (let that skill
-  delegate here instead).
+  Pre-handoff gate for open PRs: verifies tests/lint/typecheck, runs
+  /code-review on the full PR diff, syncs PR description, and checks CI.
+  TRIGGER when handing off to a human reviewer — wrapping up work on a
+  branch with an open PR, "ship it" intent, or before spawning a
+  multi-persona review (CISO + staff-* engineers) or /ultrareview.
+  DO NOT TRIGGER during active iteration, on diff-only requests,
+  on the default branch, or when a project-specific pre-merge skill
+  already wraps these checks.
 argument-hint: "[optional scope note]"
 ---
 

--- a/claude/.claude/skills/skill-review/SKILL.md
+++ b/claude/.claude/skills/skill-review/SKILL.md
@@ -1,18 +1,13 @@
 ---
 name: skill-review
 description: >
-  How to review and audit Claude Code skill files
-  (`.claude/skills/**/SKILL.md`): frontmatter conventions, trigger
-  design, voice, length targets, the operational-vs-narrative content
-  test, and the cross-reference vs duplication framework.
-  TRIGGER when: reviewing a `.claude/skills/**/SKILL.md` change
-  (PR / diff / pre-commit audit); auditing trigger accuracy across a
-  skill set; restructuring or pruning skills.
-  DO NOT TRIGGER when: authoring, iterating on, or optimizing a skill
-  (use `skill-creator` for scaffolding, eval / benchmark loops, and
-  description tuning); editing CLAUDE.md or AGENTS.md (use
-  `ai-instruction-and-memory-files`); editing `.lovable/*.md` (use
-  `lovable-knowledge`); reviewing code that isn't a skill file.
+  Review and audit of SKILL.md files: frontmatter conventions, trigger
+  design, voice, length targets, and cross-reference vs duplication
+  policy. TRIGGER when reviewing a .claude/skills/**/SKILL.md change or
+  auditing trigger accuracy across a skill set. DO NOT TRIGGER when
+  authoring or iterating on a skill (use skill-creator), editing
+  CLAUDE.md/AGENTS.md (use ai-instruction-and-memory-files), or
+  reviewing non-skill files.
 user-invocable: false
 ---
 

--- a/claude/.claude/skills/skill-review/SKILL.md
+++ b/claude/.claude/skills/skill-review/SKILL.md
@@ -3,8 +3,8 @@ name: skill-review
 description: >
   Review and audit of SKILL.md files: frontmatter conventions, trigger
   design, voice, length targets, and cross-reference vs duplication
-  policy. TRIGGER when reviewing a .claude/skills/**/SKILL.md change or
-  auditing trigger accuracy across a skill set. DO NOT TRIGGER when
+  policy. TRIGGER when: reviewing a .claude/skills/**/SKILL.md change or
+  auditing trigger accuracy across a skill set. DO NOT TRIGGER when:
   authoring or iterating on a skill (use skill-creator), editing
   CLAUDE.md/AGENTS.md (use ai-instruction-and-memory-files), or
   reviewing non-skill files.

--- a/claude/.claude/skills/sql-query-conventions/SKILL.md
+++ b/claude/.claude/skills/sql-query-conventions/SKILL.md
@@ -3,11 +3,11 @@ name: sql-query-conventions
 description: >
   Read-path SQL conventions (raw SQL, PostgREST, SQL-shaped ORMs):
   explicit limits, pagination, N+1 avoidance, batch-size ceilings, and
-  explicit column selection. TRIGGER when writing or modifying a SELECT
+  explicit column selection. TRIGGER when: writing or modifying a SELECT
   query, PostgREST .from()/.select() chain, list-returning ORM call, or
-  query-shape / pagination design. DO NOT TRIGGER for write-path
-  (INSERT/UPDATE/DELETE), DDL-only migrations, test fixtures, or
-  document/KV stores.
+  query-shape / pagination design. DO NOT TRIGGER when: writing
+  write-path (INSERT/UPDATE/DELETE), DDL-only migrations, test fixtures,
+  or document/KV stores.
 user-invocable: false
 ---
 

--- a/claude/.claude/skills/sql-query-conventions/SKILL.md
+++ b/claude/.claude/skills/sql-query-conventions/SKILL.md
@@ -1,22 +1,13 @@
 ---
 name: sql-query-conventions
 description: >
-  Conventions for writing read-path queries against SQL / relational
-  stores (raw SQL, PostgREST/Supabase `.from(...).select(...)`,
-  SQL-shaped ORMs): pagination, limits, avoiding N+1, batch-size
-  ceilings, explicit column selection, and the AI anti-patterns that
-  silently scale badly. Write-path idempotency conventions live in
-  project-level guardrails and in `test-conventions`, not here.
-  TRIGGER when: writing or modifying a read-path SQL or PostgREST
-  query — adding a `SELECT`, a `.from(...)` / `.select(...)` chain, a
-  list-returning ORM call, raw read SQL, or data-access helper;
-  designing query shape, pagination, or batch size.
-  DO NOT TRIGGER when: writing INSERT/UPDATE/DELETE or other write-path
-  code, reading existing queries without modification, editing test
-  mocks or fixture seed data, purely-schema migrations (DDL only, no
-  DML), generated client code, or writing queries against document/KV
-  stores (DynamoDB, MongoDB, Cassandra, etc. — those have different
-  read-path conventions and belong in a separate skill).
+  Read-path SQL conventions (raw SQL, PostgREST, SQL-shaped ORMs):
+  explicit limits, pagination, N+1 avoidance, batch-size ceilings, and
+  explicit column selection. TRIGGER when writing or modifying a SELECT
+  query, PostgREST .from()/.select() chain, list-returning ORM call, or
+  query-shape / pagination design. DO NOT TRIGGER for write-path
+  (INSERT/UPDATE/DELETE), DDL-only migrations, test fixtures, or
+  document/KV stores.
 user-invocable: false
 ---
 

--- a/claude/.claude/skills/verify-primary-sources/SKILL.md
+++ b/claude/.claude/skills/verify-primary-sources/SKILL.md
@@ -3,10 +3,10 @@ name: verify-primary-sources
 description: >
   Fetch primary documentation directly rather than relying on agent
   summaries when web research drives a code or design decision.
-  TRIGGER when acting on a documentation claim from a subagent, blog
+  TRIGGER when: acting on a documentation claim from a subagent, blog
   post, or other secondary source for an architectural/API/library/
-  security decision. DO NOT TRIGGER for quick syntax lookups, error
-  decoding, or when the cited URL is already the primary source.
+  security decision. DO NOT TRIGGER when: doing quick syntax lookups,
+  error decoding, or when the cited URL is already the primary source.
 user-invocable: false
 ---
 

--- a/claude/.claude/skills/verify-primary-sources/SKILL.md
+++ b/claude/.claude/skills/verify-primary-sources/SKILL.md
@@ -1,22 +1,12 @@
 ---
 name: verify-primary-sources
 description: >
-  When web research will inform a code or design decision, fetch and
-  read the primary documentation directly rather than relying on
-  agent summaries or secondary sources. Read the surrounding
-  context — "the docs say X" and "the docs say X in the context of
-  Y" often point at opposite conclusions.
-  TRIGGER when: web research is informing an
-  architectural / API-behavior / library-choice / deprecation /
-  security-posture decision; you are about to relay or act on a
-  documentation claim from a secondary source (subagent, blog
-  post, forum answer, LLM summary); the user asks Claude to
-  research a technical question online before writing code.
-  DO NOT TRIGGER when: looking up syntax (jq operators, regex
-  flags), decoding an error string, fetching a single referenced
-  URL that IS the primary source (whether the user pasted it or a
-  subagent cited it), reading a CHANGELOG entry the user pointed
-  at — quick lookups that don't drive a strategic conclusion.
+  Fetch primary documentation directly rather than relying on agent
+  summaries when web research drives a code or design decision.
+  TRIGGER when acting on a documentation claim from a subagent, blog
+  post, or other secondary source for an architectural/API/library/
+  security decision. DO NOT TRIGGER for quick syntax lookups, error
+  decoding, or when the cited URL is already the primary source.
 user-invocable: false
 ---
 


### PR DESCRIPTION
## Summary

- 11 local skill descriptions were silently truncating to name-only in sessions because the total ambient payload (~13.6K chars) exceeded the harness budget cap
- The top 10 descriptions (900–1339 chars each) compressed by stripping example-phrase lists and elaboration that belong in the always-loaded body, keeping only the essential TRIGGER / DO NOT TRIGGER conditions
- Three behavioral N-rows caught and fixed during the mandatory skill-review audit (see details below)
- **Result:** ~5K chars saved (54% reduction on the 10 compressed skills; total local payload drops from ~13.6K to ~7.5K)

## What was dropped from each description

All dropped lines were either: (a) body-level elaboration that loads on-invoke anyway, or (b) phrase-example lists that belong in the skill body, not the ambient frontmatter.

| Skill | Before | After |
|---|---|---|
| ready-for-review | 1339 | 510 |
| sql-query-conventions | 1056 | 436 |
| ai-instruction-and-memory-files | 1012 | 445 |
| git-feature-branch-sync | 1004 | 457 |
| verify-primary-sources | 981 | 404 |
| git-state-safety | 900 | 464 |
| config-environments | 810 | 408 |
| plan-it | 790 | 387 |
| claude-hook-review | 765 | 397 |
| skill-review | 754 | 439 |

## Skill-review audit findings (3 N-rows, all fixed)

During the behavioral-equivalence audit per skill-review §11:

1. **git-feature-branch-sync** — `"(those are always protected — never force-push them)"` was a forbidden-action callout in DO NOT TRIGGER. Restored.
2. **git-state-safety** — `"Also when recovering from a bad merge that was already committed."` was a distinct trigger condition not covered by the remaining `"merge/rebase/cherry-pick state or unresolved conflicts"` text. Restored.
3. **skill-review** — `"iterating on, or optimizing"` removed from DO NOT TRIGGER left only `"authoring"` excluded, weakening the dual-fire guard against `skill-creator` on skill-improvement turns. Restored as `"authoring or iterating on"`.

## Test plan

- [ ] Restart Claude Code and verify `/skills` shows descriptions for all 11 previously-truncated skills: plan-it, branch-creation, read-docx-comments, config-environments, test-conventions, test-evaluation, sql-query-conventions, review-permissions, verify-primary-sources, git-feature-branch-sync, git-state-safety
- [ ] Verify key triggers still auto-fire: edit a hook script → claude-hook-review fires; write a SELECT query → sql-query-conventions fires
- [ ] `pytest claude/.claude/` and `ruff check claude/.claude/` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)