### PR TITLE
feat(hooks): replace TTL-based marker liveness with PID liveness

### DIFF
--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -51,6 +51,7 @@ If the subagent reports a check was blocked by permissions, do NOT fall back to 
 - Never commit secrets, credentials, API keys, or large binary assets to repositories.
 - Never use the Read tool on files likely to contain secrets (`.env`, `.claude.json`, `credentials.json`, similar). Reading pulls the secret into the conversation context. When you need to inspect such a file, give the user a shell command (`cat`, `grep`, `jq`) to run via `!` instead.
 - Never write `~/.claude/*-markers/*` by hand. Each review skill writes its own marker directory (`/code-review` → `review-markers/`, `/plan-review` → `plan-review-markers/`, etc.) when a review passes, and pre-commit hooks gate on their presence. If a commit is blocked, run the review skill the hook names; if the skill is harness-blocked, spawn a subagent that can run it. A general "ship it" instruction is not authorization to forge a marker.
+- If a skill's active-bypass gate refuses to release after the skill has finished, run `~/.claude/scripts/marker.sh clear-stale` to evict orphaned active markers from dead sessions.
 - Don't add globs (`Bash(pytest *)`, `Bash(npm run *)`) to `permissions.allow`. Globs widen the surface to flag injection, command chaining, and shell-expansion attacks — see `claude/.claude/skills/review-permissions/SKILL.md` checklist items 1–9. Use exact-match rules (`Bash(pytest)`, `Bash(npm run verify)`) instead.
 
 ## Code Comments and Durable Documentation

--- a/claude/.claude/hooks/capture-session-id.sh
+++ b/claude/.claude/hooks/capture-session-id.sh
@@ -55,4 +55,17 @@ if ! printf '%s\n' "$SESSION_ID" > "$HOME/.claude/sessions/$CLAUDE_PID" 2>/dev/n
   exit 0
 fi
 
+# Update any active.d entries for this session to the current PID. This
+# handles --continue: the session resumes under a new PID, but any active
+# markers written before the restart still carry the old PID. Hooks use
+# kill -0 <stored-pid> for liveness, so stale PIDs would cause them to
+# evict live markers. Rewriting here keeps bypass working after restart.
+for _active_dir in "$HOME/.claude"/.*-active.d; do
+  [ -d "$_active_dir" ] || continue
+  _entry="$_active_dir/$SESSION_ID"
+  if [ -f "$_entry" ]; then
+    printf '%s\n' "$CLAUDE_PID" > "$_entry" 2>/dev/null || true
+  fi
+done
+
 exit 0

--- a/claude/.claude/hooks/enforce-marker-script-shape.sh
+++ b/claude/.claude/hooks/enforce-marker-script-shape.sh
@@ -9,7 +9,7 @@
 # gate. The "if" field is a hint only.
 #
 # Commands that start directly with the marker.sh path (~/ or absolute) must
-# match one of the 12 valid invocation shapes exactly: no chains, no redirects,
+# match one of the 14 valid invocation shapes exactly: no chains, no redirects,
 # no extra args. Wrapped forms (env-var prefix, bash wrapper, relative path,
 # subshell) are not gated here — they fast-exit at Stage 2 and are denied by
 # the permissions.allow layer, which does not list their wrapper executables.
@@ -65,7 +65,7 @@ fi
 # path form (/home/<user>/.claude/scripts/marker.sh) are both accepted.
 # No bash wrapper, no env-var prefix, no chain operator, no redirect, no
 # extra args after the skill name.
-VALID_PATTERN='^(~|/[A-Za-z0-9_./-]+)/\.claude/scripts/marker\.sh[[:space:]]+(write[[:space:]]+(code-review|skill-review|plan-review|ready-for-review)|(activate|deactivate)[[:space:]]+(plan-review|ready-for-review|respond-pr|memory-skill))[[:space:]]*$'
+VALID_PATTERN='^(~|/[A-Za-z0-9_./-]+)/\.claude/scripts/marker\.sh[[:space:]]+(write[[:space:]]+(code-review|skill-review|plan-review|ready-for-review)|(activate|deactivate)[[:space:]]+(plan-review|ready-for-review|respond-pr|memory-skill)|clear-stale([[:space:]]+--dry-run)?)[[:space:]]*$'
 
 if printf '%s' "$TRIMMED" | grep -qE "$VALID_PATTERN"; then
   exit 0
@@ -88,6 +88,8 @@ Valid shapes:
   ~/.claude/scripts/marker.sh deactivate ready-for-review
   ~/.claude/scripts/marker.sh deactivate respond-pr
   ~/.claude/scripts/marker.sh deactivate memory-skill
+  ~/.claude/scripts/marker.sh clear-stale
+  ~/.claude/scripts/marker.sh clear-stale --dry-run
 
 No chains (&&, ||, ;), redirects, or extra args. Env-var prefix, bash wrapper,
 and relative-path forms are not gated here — they are denied by permissions.allow."

--- a/claude/.claude/hooks/require-memory-skill.sh
+++ b/claude/.claude/hooks/require-memory-skill.sh
@@ -21,10 +21,10 @@ set -uo pipefail
 # by the ai-instruction-and-memory-files skill at Step 0 via
 # `marker.sh activate memory-skill`, removed at its final step via
 # `marker.sh deactivate memory-skill`. While THIS session's marker exists AND
-# is fresh (<60 min old), the hook allows through so the skill's own
-# Write/Edit calls during the memory-write session are not re-blocked.
-# mtime is refreshed on each bypass to handle long sessions that span multiple
-# memory writes without hitting the staleness cutoff.
+# its stored PID is alive (kill -0), the hook allows through so the skill's
+# own Write/Edit calls during the memory-write session are not re-blocked.
+# Orphaned markers (session errored before cleanup) are evicted automatically:
+# dead PID → rm on next gate hit.
 #
 # Fail-open conditions (exit 0 without denying):
 #   - session_id absent from input — cannot key a per-session marker
@@ -86,12 +86,15 @@ if [ -z "$SESSION_ID" ]; then
   exit 0
 fi
 
-# Active-bypass: fresh marker for THIS session means the skill is active —
-# allow through and refresh the marker's mtime so long sessions don't time out.
+# Active-bypass: alive PID stored in the marker means the skill is active —
+# allow through. Dead or unreadable PID → evict the orphan.
 ACTIVE_MARKER="$HOME/.claude/.memory-skill-active.d/$SESSION_ID"
-if [ -f "$ACTIVE_MARKER" ] && [ -n "$(find "$ACTIVE_MARKER" -mmin -60 2>/dev/null)" ]; then
-  touch "$ACTIVE_MARKER" 2>/dev/null
-  exit 0
+if [ -f "$ACTIVE_MARKER" ]; then
+  STORED_PID=$(cat "$ACTIVE_MARKER" 2>/dev/null | tr -d '[:space:]')
+  if [[ "$STORED_PID" =~ ^[0-9]+$ ]] && kill -0 "$STORED_PID" 2>/dev/null; then
+    exit 0
+  fi
+  rm -f "$ACTIVE_MARKER" 2>/dev/null
 fi
 
 REASON="Memory write blocked by ai-instruction-and-memory-files gate. You are writing to $FILE_PATH, which is part of Claude Code's auto-memory file system (MEMORY.md index or a new topic file). Invoke the ai-instruction-and-memory-files skill via the Skill tool first — it covers MEMORY.md index format, topic-file frontmatter, length budgets, and the type classification (user / feedback / project / reference). The skill's Step 0 activates a bypass marker so all memory writes in the session pass through after the skill is loaded."

--- a/claude/.claude/hooks/require-plan-review.sh
+++ b/claude/.claude/hooks/require-plan-review.sh
@@ -9,10 +9,11 @@
 #
 # Two-marker pattern:
 # - Active marker (~/.claude/.plan-review-active.d/<session_id>):
-#   presence-only, fresh mtime <60 min. Written by /plan-review at step 0;
+#   content = Claude session PID. Written by /plan-review at step 0;
 #   removed at the deactivation step. Bypasses the gate so the skill's own
-#   Write/Edit calls during review don't self-deny. mtime refreshed on each
-#   bypass to handle long reviews.
+#   Write/Edit calls during review don't self-deny. The hook checks PID
+#   liveness (kill -0) on each gate hit; dead PIDs are evicted automatically,
+#   which handles orphaned markers from sessions that errored before cleanup.
 # - Completion marker (~/.claude/plan-review-markers/<repo-hash>.<session_id>):
 #   written by /plan-review when the review is clean. Existence-checked;
 #   allows Write/Edit until the next session.
@@ -61,9 +62,12 @@ SESSION_ID=$(printf '%s\n' "$INPUT" | jq -r '.session_id // empty')
 if [ -n "$SESSION_ID" ]; then
   # Active-marker bypass: the /plan-review skill is currently running.
   ACTIVE_MARKER="$HOME/.claude/.plan-review-active.d/$SESSION_ID"
-  if [ -f "$ACTIVE_MARKER" ] && [ -n "$(find "$ACTIVE_MARKER" -mmin -60 2>/dev/null)" ]; then
-    touch "$ACTIVE_MARKER" 2>/dev/null
-    exit 0
+  if [ -f "$ACTIVE_MARKER" ]; then
+    STORED_PID=$(cat "$ACTIVE_MARKER" 2>/dev/null | tr -d '[:space:]')
+    if [[ "$STORED_PID" =~ ^[0-9]+$ ]] && kill -0 "$STORED_PID" 2>/dev/null; then
+      exit 0
+    fi
+    rm -f "$ACTIVE_MARKER" 2>/dev/null
   fi
 
   # Completion-marker check.

--- a/claude/.claude/hooks/require-ready-for-review.sh
+++ b/claude/.claude/hooks/require-ready-for-review.sh
@@ -13,17 +13,12 @@
 #
 # Two-marker pattern:
 # - Active marker (~/.claude/.ready-for-review-active.d/<session_id>):
-#   content = unix epoch written at activation; fresh mtime <60 min;
-#   activation age <90 min (hard ceiling). Written by /ready-for-review
-#   at step 0; removed at step 7 (completion). Bypasses the gate so the
-#   skill's own iteration pushes (step 3 fix → push → loop) don't
-#   self-deny. mtime refreshed on each bypass to handle long runs.
-#   The 90-min ceiling caps the sliding window: cross-skill iteration
-#   pushes (e.g. /respond-pr landing review fixes) refresh the mtime
-#   without explicit user re-authorization — without a ceiling, a
-#   stuck-but-not-cleaned-up active marker bypasses indefinitely.
-#   Empty or non-numeric content fails closed (handles markers from
-#   before this version shipped, or any malformed write).
+#   content = Claude session PID. Written by /ready-for-review at step 0;
+#   removed at step 7 (completion). Bypasses the gate so the skill's own
+#   iteration pushes (step 3 fix → push → loop) don't self-deny. The hook
+#   checks PID liveness (kill -0) on each gate hit; dead PIDs are evicted
+#   automatically, which handles orphaned markers from sessions that errored
+#   before cleanup.
 # - Completion marker (~/.claude/ready-for-review-markers/<repo-hash>.<session_id>):
 #   contents are the local HEAD SHA at gate-completion time. Written at
 #   step 7 only when every halt-on-fail step passed. Pushes against the
@@ -127,17 +122,12 @@ fi
 # Active-marker bypass: the skill is currently running.
 if [ -n "$SESSION_ID" ]; then
   ACTIVE_MARKER="$HOME/.claude/.ready-for-review-active.d/$SESSION_ID"
-  if [ -f "$ACTIVE_MARKER" ] && [ -n "$(find "$ACTIVE_MARKER" -mmin -60 2>/dev/null)" ]; then
-    CREATED_TS=$(cat "$ACTIVE_MARKER" 2>/dev/null)
-    NOW_TS=$(date +%s 2>/dev/null)
-    # -ge 0 guards against a future-dated CREATED_TS: without it, a negative
-    # delta (e.g. -600) would still pass -lt 5400, incorrectly granting bypass.
-    if [[ "$CREATED_TS" =~ ^[0-9]+$ ]] && [[ "$NOW_TS" =~ ^[0-9]+$ ]] && \
-       [ "$((NOW_TS - CREATED_TS))" -ge 0 ] && \
-       [ "$((NOW_TS - CREATED_TS))" -lt 5400 ]; then
-      touch "$ACTIVE_MARKER" 2>/dev/null
+  if [ -f "$ACTIVE_MARKER" ]; then
+    STORED_PID=$(cat "$ACTIVE_MARKER" 2>/dev/null | tr -d '[:space:]')
+    if [[ "$STORED_PID" =~ ^[0-9]+$ ]] && kill -0 "$STORED_PID" 2>/dev/null; then
       exit 0
     fi
+    rm -f "$ACTIVE_MARKER" 2>/dev/null
   fi
 fi
 

--- a/claude/.claude/hooks/require-respond-pr.sh
+++ b/claude/.claude/hooks/require-respond-pr.sh
@@ -9,17 +9,15 @@
 #
 # Bypass: the /respond-pr skill writes a marker at
 # ~/.claude/.respond-pr-active.d/<session_id> at its start and removes it at
-# the end. While THIS session's marker exists AND is fresh (<60 min old),
-# this hook lets gh commands through so the skill itself doesn't recurse
-# into its own gate. Per-session keying (vs. a singleton path) prevents two
-# parallel respond-pr sessions from thrashing on cleanup, and prevents one
-# session's marker from leaking bypass to unrelated parallel sessions —
-# both of which the singleton design did not handle.
+# the end. While THIS session's marker exists AND its stored PID is alive
+# (kill -0), this hook lets gh commands through so the skill itself doesn't
+# recurse into its own gate. Per-session keying (vs. a singleton path)
+# prevents two parallel respond-pr sessions from thrashing on cleanup, and
+# prevents one session's marker from leaking bypass to unrelated parallel
+# sessions — both of which the singleton design did not handle.
 #
-# The hook refreshes the marker's mtime on each bypass so a long-running
-# skill invocation (large PR, many comments) doesn't hit the 60-min
-# staleness cutoff mid-run. The cutoff still applies to genuinely orphaned
-# markers from a session that errored before reaching the cleanup step.
+# Orphaned markers (from sessions that errored before cleanup) are evicted
+# automatically: the hook checks kill -0 on the stored PID; dead PID → rm.
 # The gate also covers `repos/{o}/{r}/(pulls|issues)/comments/{id}` (no
 # PR/issue-number segment) — the destructive PATCH endpoint that overwrites
 # a comment in place; gating it forces any edit to flow through
@@ -41,9 +39,12 @@ COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command // empty')
 SESSION_ID=$(printf '%s\n' "$INPUT" | jq -r '.session_id // empty')
 if [ -n "$SESSION_ID" ]; then
   MARKER="$HOME/.claude/.respond-pr-active.d/$SESSION_ID"
-  if [ -f "$MARKER" ] && [ -n "$(find "$MARKER" -mmin -60 2>/dev/null)" ]; then
-    touch "$MARKER" 2>/dev/null
-    exit 0
+  if [ -f "$MARKER" ]; then
+    STORED_PID=$(cat "$MARKER" 2>/dev/null | tr -d '[:space:]')
+    if [[ "$STORED_PID" =~ ^[0-9]+$ ]] && kill -0 "$STORED_PID" 2>/dev/null; then
+      exit 0
+    fi
+    rm -f "$MARKER" 2>/dev/null
   fi
 fi
 

--- a/claude/.claude/hooks/tests/test_enforce_marker_script_shape.py
+++ b/claude/.claude/hooks/tests/test_enforce_marker_script_shape.py
@@ -14,7 +14,7 @@ ENFORCE_MARKER_SCRIPT_SHAPE_HOOK = HOOKS_DIR / "enforce-marker-script-shape.sh"
 
 class TestEnforceMarkerScriptShape:
     # ------------------------------------------------------------------ #
-    # Valid shapes — all 12 must be allowed                               #
+    # Valid shapes — all 14 must be allowed                               #
     # ------------------------------------------------------------------ #
 
     @pytest.mark.parametrize(
@@ -32,6 +32,8 @@ class TestEnforceMarkerScriptShape:
             "~/.claude/scripts/marker.sh deactivate ready-for-review",
             "~/.claude/scripts/marker.sh deactivate respond-pr",
             "~/.claude/scripts/marker.sh deactivate memory-skill",
+            "~/.claude/scripts/marker.sh clear-stale",
+            "~/.claude/scripts/marker.sh clear-stale --dry-run",
         ],
     )
     def test_valid_shapes_allowed(self, command):

--- a/claude/.claude/hooks/tests/test_marker_script.py
+++ b/claude/.claude/hooks/tests/test_marker_script.py
@@ -81,18 +81,24 @@ class TestMarkerScriptHappyPath:
         assert len(files) == 1
         assert files[0].name.endswith(f".{sid}")
 
-    def test_activate_creates_active_marker(self, isolated_home, git_repo):
+    def test_activate_creates_active_marker_with_pid(self, isolated_home, git_repo):
+        """activate must write the Claude session PID to the active.d file body
+        so hooks can check liveness with kill -0."""
         sid = self._seed_session(isolated_home)
         result = _run(["activate", "plan-review"], cwd=git_repo, home=isolated_home)
         assert result.returncode == 0, result.stderr
         active_file = isolated_home / ".claude" / ".plan-review-active.d" / sid
         assert active_file.exists()
+        content = active_file.read_text().strip()
+        assert content.isdigit(), (
+            f"activate must write a numeric PID to the active marker, got: {content!r}"
+        )
+        stored_pid = int(content)
+        assert stored_pid > 0, f"stored PID must be positive, got: {stored_pid}"
 
-    def test_activate_ready_for_review_writes_epoch_timestamp(
-        self, isolated_home, git_repo
-    ):
-        """activate ready-for-review must write a unix epoch integer, not an
-        empty file — the hook reads the content to enforce the 90-min ceiling."""
+    def test_activate_ready_for_review_writes_pid(self, isolated_home, git_repo):
+        """activate ready-for-review writes the Claude session PID (same as
+        other skills) — hook now uses PID liveness, not epoch timestamp."""
         sid = self._seed_session(isolated_home)
         result = _run(["activate", "ready-for-review"], cwd=git_repo, home=isolated_home)
         assert result.returncode == 0, result.stderr
@@ -100,7 +106,7 @@ class TestMarkerScriptHappyPath:
         assert active_file.exists()
         content = active_file.read_text().strip()
         assert content.isdigit(), (
-            f"activate ready-for-review must write a unix epoch integer, got: {content!r}"
+            f"activate ready-for-review must write a numeric PID, got: {content!r}"
         )
 
     def test_deactivate_removes_active_marker(self, isolated_home, git_repo):
@@ -131,6 +137,54 @@ class TestMarkerScriptHappyPath:
     def test_help_exits_0(self, isolated_home, git_repo):
         result = _run(["--help"], cwd=git_repo, home=isolated_home)
         assert result.returncode == 0
+
+
+class TestMarkerScriptClearStale:
+    """Tests for `marker.sh clear-stale [--dry-run]`."""
+
+    def _make_active_dir(self, home, skill):
+        d = home / ".claude" / f".{skill}-active.d"
+        d.mkdir(parents=True)
+        return d
+
+    def test_clear_stale_removes_dead_pid_entry(self, isolated_home, git_repo):
+        """clear-stale evicts entries whose stored PID is dead."""
+        d = self._make_active_dir(isolated_home, "plan-review")
+        orphan = d / "orphan-session"
+        orphan.write_text("99999999")
+        result = _run(["clear-stale"], cwd=git_repo, home=isolated_home)
+        assert result.returncode == 0, result.stderr
+        assert not orphan.exists(), "clear-stale must remove dead-PID marker"
+        assert "evict" in result.stdout
+
+    def test_clear_stale_keeps_alive_pid_entry(self, isolated_home, git_repo):
+        """clear-stale preserves entries whose stored PID is alive."""
+        d = self._make_active_dir(isolated_home, "respond-pr")
+        alive = d / "live-session"
+        alive.write_text(str(os.getpid()))
+        result = _run(["clear-stale"], cwd=git_repo, home=isolated_home)
+        assert result.returncode == 0, result.stderr
+        assert alive.exists(), "clear-stale must not remove alive-PID marker"
+
+    def test_clear_stale_dry_run_does_not_remove(self, isolated_home, git_repo):
+        """--dry-run reports would-evict entries without removing them."""
+        d = self._make_active_dir(isolated_home, "memory-skill")
+        orphan = d / "dry-run-session"
+        orphan.write_text("99999999")
+        result = _run(["clear-stale", "--dry-run"], cwd=git_repo, home=isolated_home)
+        assert result.returncode == 0, result.stderr
+        assert orphan.exists(), "--dry-run must not remove markers"
+        assert "dry-run" in result.stdout or "would evict" in result.stdout
+
+    def test_clear_stale_no_active_dirs_exits_0(self, isolated_home, git_repo):
+        """When no active.d directories exist, exits 0 with zero evictions."""
+        result = _run(["clear-stale"], cwd=git_repo, home=isolated_home)
+        assert result.returncode == 0
+        assert "evicted 0" in result.stdout
+
+    def test_clear_stale_invalid_extra_arg_exits_2(self, isolated_home, git_repo):
+        result = _run(["clear-stale", "--unknown-flag"], cwd=git_repo, home=isolated_home)
+        assert result.returncode == 2
 
 
 class TestMarkerScriptEmptyStagedGuard:

--- a/claude/.claude/hooks/tests/test_require_memory_skill.py
+++ b/claude/.claude/hooks/tests/test_require_memory_skill.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import os
 import subprocess
-import time
 from pathlib import Path
 
 import pytest
@@ -47,11 +46,11 @@ def _memory_input(base_input: dict, session_id: str) -> dict:
 
 
 def _write_active_marker(isolated_home: Path, session_id: str) -> Path:
-    """Create a fresh active-bypass marker for the given session."""
+    """Create an active-bypass marker with the current process PID (alive)."""
     marker_dir = isolated_home / ".claude" / ".memory-skill-active.d"
     marker_dir.mkdir(parents=True, exist_ok=True)
     marker = marker_dir / session_id
-    marker.touch()
+    marker.write_text(str(os.getpid()))
     return marker
 
 
@@ -139,33 +138,17 @@ class TestRequireMemorySkill:
         payload = _memory_input(edit_input(memory_md), sid)
         assert run_hook(HOOK_PATH, payload) == "allow"
 
-    def test_active_marker_stale_denies(self, isolated_home, memory_tree):
-        """Marker older than 60 minutes does not bypass — gate re-fires."""
-        sid = "sess-stale"
-        marker = _write_active_marker(isolated_home, sid)
-        # Set mtime to 61 minutes ago.
-        stale_time = time.time() - 61 * 60
-        os.utime(marker, (stale_time, stale_time))
+    def test_dead_pid_active_marker_evicts_and_denies(self, isolated_home, memory_tree):
+        """Orphaned marker with a dead PID is evicted and the gate denies."""
+        sid = "sess-dead-pid"
+        marker_dir = isolated_home / ".claude" / ".memory-skill-active.d"
+        marker_dir.mkdir(parents=True, exist_ok=True)
+        marker = marker_dir / sid
+        marker.write_text("99999999")  # PID outside Linux/macOS max range → always dead
         memory_md = str(memory_tree / "MEMORY.md")
         payload = _memory_input(edit_input(memory_md), sid)
         assert run_hook(HOOK_PATH, payload) == "deny"
-
-    def test_active_marker_mtime_refreshed_on_bypass(self, isolated_home, memory_tree):
-        """Hook touches the marker on each bypass so long sessions stay alive."""
-        sid = "sess-refresh"
-        marker = _write_active_marker(isolated_home, sid)
-        # Set mtime to 55 minutes ago — still fresh but clearly in the past.
-        old_time = time.time() - 55 * 60
-        os.utime(marker, (old_time, old_time))
-        memory_md = str(memory_tree / "MEMORY.md")
-        payload = _memory_input(edit_input(memory_md), sid)
-        assert run_hook(HOOK_PATH, payload) == "allow"
-        # Mtime must now be within the last minute.
-        refreshed_mtime = marker.stat().st_mtime
-        assert (time.time() - refreshed_mtime) < 60, (
-            "Hook did not refresh the marker's mtime on bypass — "
-            "long sessions will hit the 60-min staleness cutoff mid-run."
-        )
+        assert not marker.exists(), "hook must evict the orphan marker on dead PID"
 
     def test_active_marker_other_session_does_not_bypass(self, isolated_home, memory_tree):
         """Active marker keyed to a different session_id does not bypass this session."""

--- a/claude/.claude/hooks/tests/test_require_plan_review.py
+++ b/claude/.claude/hooks/tests/test_require_plan_review.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import os
 import subprocess
-import time
 
 import pytest
 from helpers import (
@@ -210,11 +209,11 @@ class TestRequirePlanReview:
     # bypasses the gate so the skill's own Write/Edit calls don't self-deny.
 
     def test_fresh_active_marker_allows_write(self, plan_review_repo, plan_review_home):
-        """Active marker created by /plan-review Step 0 bypasses the gate."""
+        """Active marker with alive PID bypasses the gate for Write tool calls."""
         sid = "session-active-write"
         marker_dir = plan_review_home / ".claude" / ".plan-review-active.d"
         marker_dir.mkdir(parents=True)
-        (marker_dir / sid).touch()
+        (marker_dir / sid).write_text(str(os.getpid()))
         assert (
             run_hook(
                 REQUIRE_PLAN_REVIEW_HOOK,
@@ -228,7 +227,7 @@ class TestRequirePlanReview:
         sid = "session-active-edit"
         marker_dir = plan_review_home / ".claude" / ".plan-review-active.d"
         marker_dir.mkdir(parents=True)
-        (marker_dir / sid).touch()
+        (marker_dir / sid).write_text(str(os.getpid()))
         assert (
             run_hook(
                 REQUIRE_PLAN_REVIEW_HOOK,
@@ -242,7 +241,7 @@ class TestRequirePlanReview:
         sid = "session-active-multiedit"
         marker_dir = plan_review_home / ".claude" / ".plan-review-active.d"
         marker_dir.mkdir(parents=True)
-        (marker_dir / sid).touch()
+        (marker_dir / sid).write_text(str(os.getpid()))
         assert (
             run_hook(
                 REQUIRE_PLAN_REVIEW_HOOK,
@@ -264,17 +263,32 @@ class TestRequirePlanReview:
             == "deny"
         )
 
-    def test_stale_active_marker_falls_through_to_deny(
+    def test_alive_pid_active_marker_bypasses(
         self, plan_review_repo, plan_review_home
     ):
-        """>60min old active marker doesn't bypass; no completion marker → deny."""
-        sid = "session-stale-active"
+        """Active marker whose stored PID is alive bypasses the gate."""
+        sid = "session-alive-pid"
+        marker_dir = plan_review_home / ".claude" / ".plan-review-active.d"
+        marker_dir.mkdir(parents=True)
+        (marker_dir / sid).write_text(str(os.getpid()))
+        assert (
+            run_hook(
+                REQUIRE_PLAN_REVIEW_HOOK,
+                {**write_input(str(plan_review_repo / "src" / "foo.py")), "session_id": sid},
+                cwd=plan_review_repo,
+            )
+            == "allow"
+        )
+
+    def test_dead_pid_active_marker_evicts_and_denies(
+        self, plan_review_repo, plan_review_home
+    ):
+        """Active marker whose stored PID is dead is evicted; gate denies."""
+        sid = "session-dead-pid"
         marker_dir = plan_review_home / ".claude" / ".plan-review-active.d"
         marker_dir.mkdir(parents=True)
         marker = marker_dir / sid
-        marker.touch()
-        ninety_min_ago = time.time() - 90 * 60
-        os.utime(marker, (ninety_min_ago, ninety_min_ago))
+        marker.write_text("99999999")  # PID outside Linux/macOS max range → always dead
         assert (
             run_hook(
                 REQUIRE_PLAN_REVIEW_HOOK,
@@ -283,6 +297,7 @@ class TestRequirePlanReview:
             )
             == "deny"
         )
+        assert not marker.exists(), "hook must evict the orphan marker on dead PID"
 
     def test_other_sessions_active_marker_does_not_bypass(
         self, plan_review_repo, plan_review_home
@@ -298,31 +313,6 @@ class TestRequirePlanReview:
                 cwd=plan_review_repo,
             )
             == "deny"
-        )
-
-    def test_active_marker_mtime_refreshed_on_bypass(
-        self, plan_review_repo, plan_review_home
-    ):
-        """Long-running review mitigation: hook touches the active marker on each
-        bypass so a session approaching the 60-min cutoff doesn't get blocked."""
-        sid = "session-long-review"
-        marker_dir = plan_review_home / ".claude" / ".plan-review-active.d"
-        marker_dir.mkdir(parents=True)
-        marker = marker_dir / sid
-        marker.touch()
-        fifty_min_ago = time.time() - 50 * 60
-        os.utime(marker, (fifty_min_ago, fifty_min_ago))
-        pre_mtime = marker.stat().st_mtime
-        assert (
-            run_hook(
-                REQUIRE_PLAN_REVIEW_HOOK,
-                {**write_input("/tmp/foo.py"), "session_id": sid},
-                cwd=plan_review_repo,
-            )
-            == "allow"
-        )
-        assert marker.stat().st_mtime > pre_mtime, (
-            "active marker mtime must be refreshed on bypass to keep long reviews alive"
         )
 
     # -- SKILL.md fixture alignment -----------------------------------------

--- a/claude/.claude/hooks/tests/test_require_ready_for_review.py
+++ b/claude/.claude/hooks/tests/test_require_ready_for_review.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import hashlib
 import os
 import subprocess
-import time
 from pathlib import Path
 
 import pytest
@@ -226,7 +225,7 @@ class TestRequireReadyForReview:
         sid = "session-active"
         marker_dir = isolated_home / ".claude" / ".ready-for-review-active.d"
         marker_dir.mkdir(parents=True)
-        (marker_dir / sid).write_text(str(int(time.time())))
+        (marker_dir / sid).write_text(str(os.getpid()))
         assert (
             run_hook(
                 READY_FOR_REVIEW_HOOK,
@@ -236,17 +235,32 @@ class TestRequireReadyForReview:
             == "allow"
         )
 
-    def test_stale_active_marker_falls_through(
+    def test_alive_pid_active_marker_bypasses(
         self, isolated_home, repo_on_feature_branch, fake_gh_pr_exists
     ):
-        """>60min old marker doesn't bypass; with no completion marker, deny."""
-        sid = "session-stale"
+        """Active marker whose stored PID is alive bypasses the gate."""
+        sid = "session-alive-pid"
+        marker_dir = isolated_home / ".claude" / ".ready-for-review-active.d"
+        marker_dir.mkdir(parents=True)
+        (marker_dir / sid).write_text(str(os.getpid()))
+        assert (
+            run_hook(
+                READY_FOR_REVIEW_HOOK,
+                bash_input("git push origin feature", session_id=sid),
+                cwd=repo_on_feature_branch,
+            )
+            == "allow"
+        )
+
+    def test_dead_pid_active_marker_evicts_and_denies(
+        self, isolated_home, repo_on_feature_branch, fake_gh_pr_exists
+    ):
+        """Orphaned marker with a dead PID is evicted; gate denies."""
+        sid = "session-dead-pid"
         marker_dir = isolated_home / ".claude" / ".ready-for-review-active.d"
         marker_dir.mkdir(parents=True)
         marker = marker_dir / sid
-        marker.write_text(str(int(time.time())))
-        ninety_min_ago = time.time() - 90 * 60
-        os.utime(marker, (ninety_min_ago, ninety_min_ago))
+        marker.write_text("99999999")  # PID outside Linux/macOS max range → always dead
         assert (
             run_hook(
                 READY_FOR_REVIEW_HOOK,
@@ -255,6 +269,7 @@ class TestRequireReadyForReview:
             )
             == "deny"
         )
+        assert not marker.exists(), "hook must evict the orphan marker on dead PID"
 
     def test_other_sessions_active_marker_does_not_bypass(
         self, isolated_home, repo_on_feature_branch, fake_gh_pr_exists
@@ -262,7 +277,7 @@ class TestRequireReadyForReview:
         """Per-session keying: A's active marker must NOT authorize B's push."""
         marker_dir = isolated_home / ".claude" / ".ready-for-review-active.d"
         marker_dir.mkdir(parents=True)
-        (marker_dir / "session-A").write_text(str(int(time.time())))
+        (marker_dir / "session-A").write_text(str(os.getpid()))
         assert (
             run_hook(
                 READY_FOR_REVIEW_HOOK,
@@ -272,111 +287,14 @@ class TestRequireReadyForReview:
             == "deny"
         )
 
-    def test_active_marker_mtime_refreshed_on_bypass(
-        self, isolated_home, repo_on_feature_branch, fake_gh_pr_exists
-    ):
-        """Long-running skill mitigation: hook touches marker on each bypass
-        so a session approaching the 60-min cutoff doesn't get blocked.
-        Timestamp content must be within the 90-min ceiling."""
-        sid = "session-long"
-        marker_dir = isolated_home / ".claude" / ".ready-for-review-active.d"
-        marker_dir.mkdir(parents=True)
-        marker = marker_dir / sid
-        marker.write_text(str(int(time.time())))
-        fifty_min_ago = time.time() - 50 * 60
-        os.utime(marker, (fifty_min_ago, fifty_min_ago))
-        pre_mtime = marker.stat().st_mtime
-        assert (
-            run_hook(
-                READY_FOR_REVIEW_HOOK,
-                bash_input("git push origin feature", session_id=sid),
-                cwd=repo_on_feature_branch,
-            )
-            == "allow"
-        )
-        assert marker.stat().st_mtime > pre_mtime, (
-            "active marker mtime must be refreshed on bypass"
-        )
-
-    def test_active_marker_within_ceiling_allows(
-        self, isolated_home, repo_on_feature_branch, fake_gh_pr_exists
-    ):
-        """Marker activated 67 min ago (within 90-min ceiling) with fresh mtime
-        must allow bypass — ceiling is 90 min, not 0."""
-        sid = "session-within-ceiling"
-        marker_dir = isolated_home / ".claude" / ".ready-for-review-active.d"
-        marker_dir.mkdir(parents=True)
-        marker = marker_dir / sid
-        created_ts = int(time.time()) - 4000  # ~67 min ago, within 90-min ceiling
-        marker.write_text(str(created_ts))
-        assert (
-            run_hook(
-                READY_FOR_REVIEW_HOOK,
-                bash_input("git push origin feature", session_id=sid),
-                cwd=repo_on_feature_branch,
-            )
-            == "allow"
-        )
-
-    def test_active_marker_hard_ceiling_blocks_after_90min(
-        self, isolated_home, repo_on_feature_branch, fake_gh_pr_exists
-    ):
-        """90-min hard ceiling: a marker activated >90 min ago must be denied
-        even when mtime is fresh. Pins the design choice: cross-skill iteration
-        pushes refresh mtime, so mtime alone does not bound gate lifetime."""
-        sid = "session-ceiling"
-        marker_dir = isolated_home / ".claude" / ".ready-for-review-active.d"
-        marker_dir.mkdir(parents=True)
-        marker = marker_dir / sid
-        created_ts = int(time.time()) - 5500  # just past 90 min
-        marker.write_text(str(created_ts))
-        # mtime is now (fresh) — only the ceiling check should block
-        pre_mtime = marker.stat().st_mtime
-        assert (
-            run_hook(
-                READY_FOR_REVIEW_HOOK,
-                bash_input("git push origin feature", session_id=sid),
-                cwd=repo_on_feature_branch,
-            )
-            == "deny"
-        )
-        assert marker.stat().st_mtime == pre_mtime, (
-            "hook must NOT touch the marker when ceiling is exceeded (deny path)"
-        )
-
     def test_active_marker_empty_content_denies_bypass(
         self, isolated_home, repo_on_feature_branch, fake_gh_pr_exists
     ):
-        """Rollout backward compat: a marker written before the timestamp
-        change (empty content) fails closed — bypass denied, not allowed.
-        Prevents stale pre-upgrade markers from granting indefinite bypass."""
+        """Empty marker content (non-numeric) fails the PID regex — fails closed."""
         sid = "session-empty"
         marker_dir = isolated_home / ".claude" / ".ready-for-review-active.d"
         marker_dir.mkdir(parents=True)
-        marker = marker_dir / sid
-        marker.write_text("")  # empty — pre-upgrade shape
-        # mtime is now (fresh)
-        assert (
-            run_hook(
-                READY_FOR_REVIEW_HOOK,
-                bash_input("git push origin feature", session_id=sid),
-                cwd=repo_on_feature_branch,
-            )
-            == "deny"
-        )
-
-    def test_active_marker_future_timestamp_denies_bypass(
-        self, isolated_home, repo_on_feature_branch, fake_gh_pr_exists
-    ):
-        """Future-dated CREATED_TS yields a negative delta; without the -ge 0
-        guard that negative delta passes -lt 5400. Pins the guard as load-bearing."""
-        sid = "session-future"
-        marker_dir = isolated_home / ".claude" / ".ready-for-review-active.d"
-        marker_dir.mkdir(parents=True)
-        marker = marker_dir / sid
-        future_ts = int(time.time()) + 600  # 10 min in the future
-        marker.write_text(str(future_ts))
-        # mtime is now (fresh)
+        (marker_dir / sid).write_text("")
         assert (
             run_hook(
                 READY_FOR_REVIEW_HOOK,

--- a/claude/.claude/hooks/tests/test_require_respond_pr.py
+++ b/claude/.claude/hooks/tests/test_require_respond_pr.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import os
 import subprocess
-import time
 
 import pytest
 from helpers import (
@@ -98,21 +97,19 @@ class TestRequireRespondPr:
         sid = "test-session-fresh"
         marker_dir = isolated_home / ".claude" / ".respond-pr-active.d"
         marker_dir.mkdir(parents=True)
-        (marker_dir / sid).touch()
+        (marker_dir / sid).write_text(str(os.getpid()))
         assert (
             run_hook(RESPOND_PR_HOOK, bash_input(command, session_id=sid), cwd=current_repo_foo_bar)
             == "allow"
         )
 
-    def test_stale_bypass_marker_denies(self, isolated_home, current_repo_foo_bar):
-        sid = "test-session-stale"
+    def test_dead_pid_bypass_marker_evicts_and_denies(self, isolated_home, current_repo_foo_bar):
+        """Orphaned marker with a dead PID is evicted and the gate denies."""
+        sid = "test-session-dead-pid"
         marker_dir = isolated_home / ".claude" / ".respond-pr-active.d"
         marker_dir.mkdir(parents=True)
         marker = marker_dir / sid
-        marker.touch()
-        # Backdate 90 minutes — past the hook's 60-minute staleness cutoff.
-        ninety_min_ago = time.time() - 90 * 60
-        os.utime(marker, (ninety_min_ago, ninety_min_ago))
+        marker.write_text("99999999")  # PID outside Linux/macOS max range → always dead
         assert (
             run_hook(
                 RESPOND_PR_HOOK,
@@ -121,6 +118,7 @@ class TestRequireRespondPr:
             )
             == "deny"
         )
+        assert not marker.exists(), "hook must evict the orphan marker on dead PID"
 
     def test_other_sessions_marker_does_not_leak_bypass(self, isolated_home, current_repo_foo_bar):
         """Regression: a marker for session A must NOT bypass session B's
@@ -168,18 +166,12 @@ class TestRequireRespondPr:
             == "deny"
         )
 
-    def test_bypass_refreshes_marker_mtime(self, isolated_home, current_repo_foo_bar):
-        """Long-running skill mitigation: the hook touches the marker on
-        each bypass so a respond-pr session approaching the 60-minute
-        staleness cutoff doesn't get blocked mid-execution."""
+    def test_alive_pid_bypass_marker_allows(self, isolated_home, current_repo_foo_bar):
+        """Active marker with a live PID bypasses the gate for any session duration."""
         sid = "long-run-session"
         marker_dir = isolated_home / ".claude" / ".respond-pr-active.d"
         marker_dir.mkdir(parents=True)
-        marker = marker_dir / sid
-        marker.touch()
-        fifty_min_ago = time.time() - 50 * 60
-        os.utime(marker, (fifty_min_ago, fifty_min_ago))
-        pre_mtime = marker.stat().st_mtime
+        (marker_dir / sid).write_text(str(os.getpid()))
         assert (
             run_hook(
                 RESPOND_PR_HOOK,
@@ -187,10 +179,6 @@ class TestRequireRespondPr:
                 cwd=current_repo_foo_bar,
             )
             == "allow"
-        )
-        post_mtime = marker.stat().st_mtime
-        assert post_mtime > pre_mtime, (
-            "marker mtime must be refreshed on bypass to keep long skill runs alive"
         )
 
     def test_non_bash_tool_allowed(self, isolated_home):

--- a/claude/.claude/scripts/marker.sh
+++ b/claude/.claude/scripts/marker.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Write or remove review markers for Claude Code workflow skills.
 # Called from SKILL.md HOOK_TEST_FIXTURE fenced blocks.
-# Usage: marker.sh <write|activate|deactivate> <skill>
+# Usage: marker.sh <write|activate|deactivate|clear-stale> [<skill>|--dry-run]
 # _marker_lib_repo_hash is defined in the sourced library so the hash recipe
 # stays in sync with the read side (require-*.sh hooks) automatically.
 . "$HOME/.claude/hooks/_lib.sh"
@@ -10,12 +10,15 @@ set -u
 
 usage() {
   cat >&2 <<'EOF'
-Usage: ~/.claude/scripts/marker.sh <subcommand> <skill>
+Usage: ~/.claude/scripts/marker.sh <subcommand> [<skill>|--dry-run]
 
 Subcommands:
   write      Write a completion marker for the given skill
   activate   Write an active-bypass marker for the given skill
   deactivate Remove the active-bypass marker for the given skill
+  clear-stale [--dry-run]
+             Evict active-bypass markers whose originating session is no
+             longer alive. --dry-run reports without removing.
 
 Valid (subcommand, skill) combinations:
   write       code-review | skill-review | plan-review | ready-for-review
@@ -43,6 +46,25 @@ _resolve_session_id() {
   exit 2
 }
 
+_resolve_claude_pid_for_session() {
+  # Reverse-lookup: find the PID whose sessions file contains SESSION_ID.
+  # Returns the PID string, or "unknown" on failure (fails closed at hook time).
+  local session_id="$1"
+  local sessions_dir="$HOME/.claude/sessions"
+  local claude_pid=""
+  if [ -d "$sessions_dir" ]; then
+    local f
+    for f in "$sessions_dir"/*; do
+      [ -f "$f" ] || continue
+      if [ "$(cat "$f" 2>/dev/null)" = "$session_id" ]; then
+        claude_pid=$(basename "$f")
+        break
+      fi
+    done
+  fi
+  printf '%s' "${claude_pid:-unknown}"
+}
+
 _resolve_repo_hash() {
   if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
     printf 'marker.sh: not inside a git repository\n' >&2
@@ -67,13 +89,35 @@ if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
   exit 0
 fi
 
-if [ $# -ne 2 ]; then
+if [ $# -lt 1 ] || [ $# -gt 2 ]; then
   usage
   exit 2
 fi
 
 SUBCOMMAND="$1"
-SKILL="$2"
+ARG2="${2:-}"
+
+# Validate arg count per subcommand.
+case "$SUBCOMMAND" in
+  write|activate|deactivate)
+    if [ -z "$ARG2" ]; then
+      usage
+      exit 2
+    fi
+    SKILL="$ARG2"
+    ;;
+  clear-stale)
+    if [ -n "$ARG2" ] && [ "$ARG2" != "--dry-run" ]; then
+      usage
+      exit 2
+    fi
+    ;;
+  *)
+    printf "marker.sh: unknown subcommand '%s'\n" "$SUBCOMMAND" >&2
+    usage
+    exit 2
+    ;;
+esac
 
 case "$SUBCOMMAND" in
   write)
@@ -118,23 +162,27 @@ case "$SUBCOMMAND" in
     case "$SKILL" in
       plan-review)
         SESSION_ID=$(_resolve_session_id) || exit 2
+        CLAUDE_PID=$(_resolve_claude_pid_for_session "$SESSION_ID")
         mkdir -p "$HOME/.claude/.plan-review-active.d"
-        touch "$HOME/.claude/.plan-review-active.d/$SESSION_ID"
+        printf '%s\n' "$CLAUDE_PID" > "$HOME/.claude/.plan-review-active.d/$SESSION_ID"
         ;;
       ready-for-review)
         SESSION_ID=$(_resolve_session_id) || exit 2
+        CLAUDE_PID=$(_resolve_claude_pid_for_session "$SESSION_ID")
         mkdir -p "$HOME/.claude/.ready-for-review-active.d"
-        date +%s > "$HOME/.claude/.ready-for-review-active.d/$SESSION_ID"
+        printf '%s\n' "$CLAUDE_PID" > "$HOME/.claude/.ready-for-review-active.d/$SESSION_ID"
         ;;
       respond-pr)
         SESSION_ID=$(_resolve_session_id) || exit 2
+        CLAUDE_PID=$(_resolve_claude_pid_for_session "$SESSION_ID")
         mkdir -p "$HOME/.claude/.respond-pr-active.d"
-        touch "$HOME/.claude/.respond-pr-active.d/$SESSION_ID"
+        printf '%s\n' "$CLAUDE_PID" > "$HOME/.claude/.respond-pr-active.d/$SESSION_ID"
         ;;
       memory-skill)
         SESSION_ID=$(_resolve_session_id) || exit 2
+        CLAUDE_PID=$(_resolve_claude_pid_for_session "$SESSION_ID")
         mkdir -p "$HOME/.claude/.memory-skill-active.d"
-        touch "$HOME/.claude/.memory-skill-active.d/$SESSION_ID"
+        printf '%s\n' "$CLAUDE_PID" > "$HOME/.claude/.memory-skill-active.d/$SESSION_ID"
         ;;
       *)
         printf "marker.sh: 'activate %s' is not valid. 'activate' supports: plan-review, ready-for-review, respond-pr, memory-skill\n" "$SKILL" >&2
@@ -167,9 +215,36 @@ case "$SUBCOMMAND" in
         ;;
     esac
     ;;
-  *)
-    printf "marker.sh: unknown subcommand '%s'\n" "$SUBCOMMAND" >&2
-    usage
-    exit 2
+  clear-stale)
+    DRY_RUN=0
+    [ "$ARG2" = "--dry-run" ] && DRY_RUN=1
+    EVICTED=0
+    KEPT=0
+    for active_dir in "$HOME/.claude"/.*-active.d; do
+      [ -d "$active_dir" ] || continue
+      dir_name=$(basename "$active_dir")
+      for entry in "$active_dir"/*; do
+        [ -f "$entry" ] || continue
+        stored_pid=$(cat "$entry" 2>/dev/null | tr -d '[:space:]')
+        entry_name=$(basename "$entry")
+        if [[ "$stored_pid" =~ ^[0-9]+$ ]] && kill -0 "$stored_pid" 2>/dev/null; then
+          KEPT=$((KEPT + 1))
+          [ "$DRY_RUN" -eq 1 ] && printf '  keep: %s/%s (PID %s alive)\n' "$dir_name" "$entry_name" "$stored_pid"
+        else
+          EVICTED=$((EVICTED + 1))
+          if [ "$DRY_RUN" -eq 0 ]; then
+            rm -f "$entry"
+            printf '  evict: %s/%s (PID %s dead)\n' "$dir_name" "$entry_name" "${stored_pid:-empty}"
+          else
+            printf '  evict (dry-run): %s/%s (PID %s dead)\n' "$dir_name" "$entry_name" "${stored_pid:-empty}"
+          fi
+        fi
+      done
+    done
+    if [ "$DRY_RUN" -eq 1 ]; then
+      printf 'clear-stale: would evict %d orphan(s), keep %d active\n' "$EVICTED" "$KEPT"
+    else
+      printf 'clear-stale: evicted %d orphan(s), kept %d active\n' "$EVICTED" "$KEPT"
+    fi
     ;;
 esac

--- a/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
+++ b/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
@@ -197,4 +197,4 @@ time-sensitive project context, and references to external systems.
 ~/.claude/scripts/marker.sh deactivate memory-skill
 ```
 
-Removes this session's bypass marker. Orphaned markers (if the skill errors before reaching this step) expire automatically after 60 minutes.
+Removes this session's bypass marker. If the skill errors before reaching this step, the gate will evict the orphan automatically once the session's process ends — the hook checks PID liveness on each gate hit.

--- a/claude/.claude/skills/plan-review/SKILL.md
+++ b/claude/.claude/skills/plan-review/SKILL.md
@@ -231,16 +231,16 @@ End with a verdict: **Approve**, **Approve with changes** (list what), or **Requ
 
 ## Record review completion + deactivate
 
-Write the completion marker only when the verdict is **Approve** or **Approve with changes** and all required changes have been applied to the plan. Do not write it on **Request changes** — write it only after the plan author revises the plan and a clean re-review completes.
-
-<!-- HOOK_TEST_FIXTURE: record-completion — the hook-alignment test suite reads this exact fenced block from this file (claude/.claude/skills/plan-review/SKILL.md) to verify it matches require-plan-review.sh's completion-marker layout. Do not duplicate the recipe elsewhere; the test re-reads it from here. -->
-```
-~/.claude/scripts/marker.sh write plan-review
-```
-
-Then remove the active-session marker:
+Always remove the active-session marker at the end of the skill run, regardless of verdict — including **Request changes**, error, or user-cancel paths:
 
 <!-- HOOK_TEST_FIXTURE: deactivate-gate — the hook-alignment test suite reads this exact fenced block from this file (claude/.claude/skills/plan-review/SKILL.md) to verify it matches require-plan-review.sh's active-marker cleanup. Do not duplicate the recipe elsewhere; the test re-reads it from here. -->
 ```
 ~/.claude/scripts/marker.sh deactivate plan-review
+```
+
+Then write the completion marker, but only when the verdict is **Approve** or **Approve with changes** and all required changes have been applied to the plan. Do not write it on **Request changes** — write it only after the plan author revises the plan and a clean re-review completes.
+
+<!-- HOOK_TEST_FIXTURE: record-completion — the hook-alignment test suite reads this exact fenced block from this file (claude/.claude/skills/plan-review/SKILL.md) to verify it matches require-plan-review.sh's completion-marker layout. Do not duplicate the recipe elsewhere; the test re-reads it from here. -->
+```
+~/.claude/scripts/marker.sh write plan-review
 ```

--- a/claude/.claude/skills/ready-for-review/SKILL.md
+++ b/claude/.claude/skills/ready-for-review/SKILL.md
@@ -177,7 +177,7 @@ Then remove the active-session marker:
 ~/.claude/scripts/marker.sh deactivate ready-for-review
 ```
 
-Removes only this session's file; if the skill errors before this step, do not manually clean up — the hook's 60-minute staleness cutoff handles orphans.
+Removes only this session's file. If the skill errors before reaching this step, the gate will evict the orphan automatically once the session's process ends — the hook checks PID liveness on each gate hit.
 
 **Do NOT write the completion marker if:**
 

--- a/claude/.claude/skills/respond-pr/SKILL.md
+++ b/claude/.claude/skills/respond-pr/SKILL.md
@@ -15,7 +15,7 @@ Fetch all review comments on the current branch's open pull request and address 
    ```
    ~/.claude/scripts/marker.sh activate respond-pr
    ```
-   The `require-respond-pr.sh` PreToolUse hook bypasses while THIS session's marker is fresh (<60 min) and refreshes its mtime on each bypass so long runs don't hit the staleness cutoff. Per-session keying prevents parallel respond-pr sessions from thrashing on cleanup or leaking bypass to unrelated sessions. If the chain fails (empty `SESSION_ID`, etc.), the `capture-session-id.sh` SessionStart hook didn't run — abort and report; do not proceed without the marker, since every gated `gh` call below will be blocked.
+   The `require-respond-pr.sh` PreToolUse hook bypasses while THIS session's marker exists and its stored PID is alive (PID liveness check via `kill -0`). Per-session keying prevents parallel respond-pr sessions from thrashing on cleanup or leaking bypass to unrelated sessions. If the chain fails (empty `SESSION_ID`, etc.), the `capture-session-id.sh` SessionStart hook didn't run — abort and report; do not proceed without the marker, since every gated `gh` call below will be blocked.
 
    **Marker lifecycle:** this marker must stay active for the entire skill session — step 7 is the only step that removes it. If you run other skills as intermediate steps (e.g., `/ready-for-review` before pushing in step 6), their cleanup must not touch this marker. If the marker is accidentally removed mid-session, restore it in a standalone Bash call before any subsequent `gh` command — the hook fires before the shell executes, so you cannot create the marker and use it atomically in the same call.
 1. Identify the PR number for the current branch: `gh pr view --json number -q '.number'`
@@ -74,7 +74,7 @@ Fetch all review comments on the current branch's open pull request and address 
    ```
    ~/.claude/scripts/marker.sh deactivate respond-pr
    ```
-   Removes only this session's file. If the skill errors out before reaching this step, don't manually clean up — the hook's 60-minute staleness cutoff handles the orphan automatically.
+   Removes only this session's file. If the skill errors out before reaching this step, the gate will evict the orphan automatically once the session's process ends — the hook checks PID liveness on each gate hit.
 
 ## Attribution
 


### PR DESCRIPTION
## Summary

- **Root fix**: Active-bypass markers now store the originating Claude session PID; hooks check liveness with `kill -0` instead of a 60-minute mtime window. Dead PID → orphan evicted on next gate hit. Alive PID → bypass.
- **`--continue` edge case**: `capture-session-id.sh` sweeps `.*-active.d` entries for the current session on `SessionStart` and rewrites their PID body, so resumed sessions don't lose bypass on the new liveness check.
- **Recovery utility**: `marker.sh clear-stale [--dry-run]` walks all `.*-active.d` dirs and evicts dead-PID entries manually.
- **Authorial fix**: `plan-review` SKILL.md now calls `deactivate` unconditionally before the conditional `write`, covering Request-changes / error / user-cancel exits.
- **Removed**: The entire TTL compensation stack — 60-min mtime check, mtime-refresh on bypass, 90-min hard ceiling, future-timestamp guard, empty/non-numeric guards in `require-ready-for-review.sh`.

## What this dissolves

Five compounding layers existed because `marker.sh activate` had no termination signal. Each layer closed a gap created by the prior layer. Replacing the TTL guess with PID liveness detection makes all five layers redundant and removes them.

## Test plan

- [x] 668 tests pass (`pytest claude/.claude/`)
- [x] `ruff check claude/.claude/` clean
- [ ] Manual smoke: `marker.sh activate plan-review` → check active.d entry has numeric PID → kill that PID → trigger any gated Write → confirm orphan evicted and gate denies
- [ ] Manual smoke: `marker.sh clear-stale` with a live session → reports kept, not evicted
- [ ] Manual smoke: `claude --continue` resumes session → `capture-session-id.sh` rewrites PID in existing active.d entries → bypass still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)