### PR TITLE
docs(readme): surface design docs and notable patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,22 @@ A CLAUDE.md instruction says "you should run code-review before committing." A P
 
 `claude-config` is a **workflow-enforcement layer** — hooks that gate what Claude can do until explicit review steps are satisfied. It wires in the `anthropics/claude-plugins-official` marketplace but ships official plugins disabled by default; stow users can enable any of them via `enabledPlugins` in their settings. `claude-config` ships the enforcement harness; hand-rolled `~/.claude/` configs improvise the patterns `claude-config` systematizes: per-session marker keying, specialist reviewer routing, and three-tier redaction.
 
+## Docs
+
+- [`docs/design-decisions.md`](docs/design-decisions.md) — eight non-obvious choices (hook-enforced gates, per-session sha256 marker keying, no shared skill partials, project-layer composition via prose-pointer + glob, etc.) and the reasoning behind each.
+- [`docs/walkthrough.md`](docs/walkthrough.md) — one full contribution cycle: plan → plan-review → code → code-review → commit → ready-for-review → push → respond-pr, showing each hook firing in sequence.
+- **Two `CLAUDE.md` files.** The repo-root [`CLAUDE.md`](CLAUDE.md) is contributor workflow for this repo (what GitHub renders by default). The stowed [`claude/.claude/CLAUDE.md`](claude/.claude/CLAUDE.md) is the global engineering instructions applied to every Claude Code session on the machine after `./install.sh`.
+
+### Notable patterns
+
+The README below is organized by feature surface (hooks, skills, plugins, scripts). If you came looking for transferable ideas, these are the load-bearing ones:
+
+- **Per-session sha256 marker keying** — review markers key on `<repo-hash>.<session-id>` plus the staged-diff sha256, so a re-staged line auto-invalidates the gate without timers or manual reset, and parallel sessions can't clear each other's markers. See [Hooks](#hooks) (`require-code-review.sh`) and `docs/design-decisions.md` decision 2.
+- **Compaction-aware marker re-injection** — `session-marker-dashboard.sh` matches `startup|clear|compact`, restoring active-bypass marker visibility after auto-compact fires. See [Context management](#context-management).
+- **Read-before-dispatch routing gate** — `require-routing-read.sh` blocks subagent spawn during `/plan-review` until `ROUTING.md` is read; a PostToolUse companion records the read per session. See [Hooks](#hooks).
+- **Project-layer composition by glob + Skill-tool dispatch** — `/plan-review` and `/code-review` glob for `.claude/skills/<parent>-<project>/SKILL.md` at runtime; consuming repos extend the base checklist without forking. Description-based auto-trigger was empirically tested and rejected (it doesn't fire from inside a running skill). See [Project-specific layers](#project-specific-layers) and `docs/design-decisions.md` decision 8.
+- **Three-tier redaction** — always-on tracker-ID regex, opt-in user-local blocklist, reviewer discipline for structural fingerprints. See [Private-project redaction](#private-project-redaction).
+
 ## Requirements
 
 - **Operating system:** Linux, macOS, or WSL2. Native Windows (PowerShell / cmd.exe) is not supported — every hook is a bash script and `install.sh` uses GNU `stow` with symlinks. If you're on Windows, install inside [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) instead.
@@ -178,7 +194,7 @@ Eight stack-agnostic reviewer personas in `claude/.claude/agents/`, spawned by `
 - **`staff-product-engineer`** — spec-to-user-problem fidelity, critical spec reading, telemetry semantics, adjacent-regression, backward compat, accessibility-as-spec-fidelity.
 - **`staff-sdet`** — testability of the design, pyramid shape, edge cases, mock design, fixture realism, security-invariant coverage, production code that lacks tests.
 
-Schema-change diffs nominally route three ways — `staff-backend-engineer` (designs), `staff-data-engineer` (operational / pipeline impact, DDL shape), `staff-analytics-engineer` (ELT-readiness). Trigger discipline in the skill bodies prevents three-persona fire on trivial additive changes.
+Schema-change diffs nominally route three ways — `staff-backend-engineer` (designs), `staff-data-engineer` (operational / pipeline impact, DDL shape), `staff-analytics-engineer` (ELT-readiness). Trigger discipline in the skill bodies prevents three-persona fire on trivial additive changes. The decision criteria for adding, splitting, or excluding a persona — including why DBRE, data platform engineer, and data steward are deliberately not in the roster — are in [Designing reviewer personas](#designing-reviewer-personas) below.
 
 ### Other
 
@@ -255,9 +271,9 @@ Claude Code compresses conversation history when the context window fills up. Th
 
 ## Worktree enforcement
 
-Concurrent Claude Code sessions that share a working tree can race: one session's `git reset --hard`, `git stash`, or `git checkout` silently wipes another session's uncommitted edits. See [Claude Code issue #34327](https://github.com/anthropics/claude-code/issues/34327) for examples of this failure mode in the wild.
+`require-worktree-for-git-writes.sh` denies non-read-only git operations (`commit`, `push`, `rebase`, `reset`, `merge`, `checkout`, etc.) unless the session runs inside a linked git worktree. Read-only commands (`status`, `log`, `diff`, `fetch`, `show`, `blame`, etc.) are always allowed. The hook is opt-in per repo via a committed sentinel file.
 
-`require-worktree-for-git-writes.sh` mitigates by denying non-read-only git operations (`commit`, `push`, `rebase`, `reset`, `merge`, `checkout`, etc.) unless the session runs inside a linked git worktree. Read-only commands (`status`, `log`, `diff`, `fetch`, `show`, `blame`, etc.) are always allowed. The hook is opt-in per repo via a committed sentinel file.
+The race it prevents: concurrent Claude Code sessions sharing a working tree can step on each other — one session's `git reset --hard`, `git stash`, or `git checkout` silently wipes another session's uncommitted edits. See [Claude Code issue #34327](https://github.com/anthropics/claude-code/issues/34327) for examples of this failure mode in the wild.
 
 ### Activating enforcement on a repo
 


### PR DESCRIPTION
## Summary

- Adds a **Docs section** (right after Philosophy) linking `docs/design-decisions.md` and `docs/walkthrough.md` — both were unreachable from the README for cold readers (`walkthrough.md` unlinked anywhere; `design-decisions.md` only in a parenthetical at line 155).
- Adds a **Notable patterns subsection** with anchor-linked bullets pointing to the five most transferable ideas: per-session sha256 marker keying, compaction-aware re-injection, read-before-dispatch routing gate, project-layer composition, and three-tier redaction.
- Appends a **forward-pointer** from the Reviewer subagents section to "Designing reviewer personas," surfacing the principled-non-inclusion rationale (DBRE, data platform engineer, data steward) from where the roster is introduced.
- Adds a **two-CLAUDE.md disambiguation** note clarifying which file GitHub renders by default vs. which is the stowed global instructions.
- **Inverts the Worktree enforcement intro**: solution-first, problem-statement second.

## Motivation

A portfolio assessment of the repo identified that the strongest engineering-craft signals — `docs/design-decisions.md` (8 non-obvious choices with reasoning) and `docs/walkthrough.md` (full contribution cycle) — were invisible to cold readers. The novel patterns are scattered across feature-organized sections; a skimmer bounces before reaching the first interesting pattern. These changes surface the depth without restructuring or relocating any voice sections.

## Test plan

- [ ] Click each anchor link in Notable patterns — `#hooks`, `#context-management`, `#project-specific-layers`, `#private-project-redaction`, `#designing-reviewer-personas` — and verify they land on the named sections
- [ ] Click `docs/design-decisions.md` and `docs/walkthrough.md` links and verify both files render
- [ ] Read Philosophy → Docs → Notable patterns → Requirements top-to-bottom and verify clean flow with no redundancy against the existing What-this-installs intro
- [ ] Read the inverted Worktree enforcement section in isolation and verify the solution-first paragraph is self-explanatory
- [ ] Confirm `deny-private-project-refs` hook does not fire (no tracker IDs, no private-project names in the diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)