### PR TITLE
fix(hooks): close 7 command-shape gaps in ready-for-review gate

### DIFF
--- a/claude/.claude/hooks/_lib.sh
+++ b/claude/.claude/hooks/_lib.sh
@@ -11,3 +11,67 @@
 _marker_lib_repo_hash() {
   printf '%s' "$1" | sha256sum | awk '{print $1}'
 }
+
+# Decide whether a shell fragment actually invokes `git`, not just mentions it
+# as a substring of a path or URL. Walks whitespace-separated words; returns
+# success iff any word equals `git` or ends in `/git`. Env-var prefixes
+# (GIT_DIR=... git ...), wrapper commands (eval, sudo, xargs), and `git` as a
+# non-first word are all handled by scanning every word, not just the first.
+#
+# Rejects: `ls .github/`, `cat .gitignore`, `grep github.com`, `./git-foo`.
+# Accepts: `git log`, `sudo git commit`, `GIT_DIR=x git push`, `/usr/bin/git status`.
+_lib_fragment_invokes_git() {
+  local fragment="$1"
+  local saved_opts=$-
+  set -f
+  local found=false word
+  for word in $fragment; do
+    if [[ "$word" == "git" || "$word" == */git ]]; then
+      found=true
+      break
+    fi
+  done
+  if [[ "$saved_opts" != *f* ]]; then set +f; fi
+  $found
+}
+
+# Extract the git subcommand from a fragment like "git -C path push -u origin"
+# or "GIT_DIR=x git push". Walks words to find the `git` command word (same
+# logic as _lib_fragment_invokes_git), then continues from there — skipping
+# global flags that consume the next word and other flags — to return the first
+# bare word (the subcommand). Strips trailing non-alnum characters so that
+# `push)` from paren-group splitting yields `push`. Globbing disabled to
+# prevent expansion of wildcards in the command text.
+_lib_extract_git_subcmd() {
+  local fragment="$1"
+  local saved_opts=$-
+  set -f
+  local past_git=false skip_next=false subcmd="" word
+  for word in $fragment; do
+    if ! $past_git; then
+      if [[ "$word" == "git" || "$word" == */git ]]; then
+        past_git=true
+      fi
+      continue
+    fi
+    if $skip_next; then skip_next=false; continue; fi
+    case "$word" in
+      -C|-c|--git-dir|--work-tree|--namespace|--super-prefix|--config-env)
+        skip_next=true ;;
+      -*) ;;
+      *) subcmd="${word%%[^a-zA-Z0-9_-]*}"; break ;;
+    esac
+  done
+  if [[ "$saved_opts" != *f* ]]; then set +f; fi
+  printf '%s' "$subcmd"
+}
+
+# Split a shell command string into fragments on shell operators (;, &&, ||, |,
+# $(...), backticks). Each fragment may invoke a distinct command. Leading/
+# trailing parentheses are stripped from each fragment so that `(cd /x; git push)`
+# yields `git push` as a clean fragment rather than `git push)`.
+_lib_split_fragments() {
+  printf '%s' "$1" \
+    | sed -E 's/;/\n/g; s/&&/\n/g; s/\|\|/\n/g; s/\|/\n/g; s/\$\(/\n/g; s/`/\n/g' \
+    | sed -E 's/^[[:space:]]*\(//; s/\)[[:space:]]*$//'
+}

--- a/claude/.claude/hooks/require-ready-for-review.sh
+++ b/claude/.claude/hooks/require-ready-for-review.sh
@@ -45,20 +45,26 @@ fi
 
 COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command // empty')
 SESSION_ID=$(printf '%s\n' "$INPUT" | jq -r '.session_id // empty')
+CWD=$(printf '%s\n' "$INPUT" | jq -r '.cwd // empty')
+[ -z "$CWD" ] && CWD="$PWD"
 
-# Match the gated commands: `git push` and `gh pr ready`.
-# - `(^|&&?|;|\|\|?)\s*git\s+push(\s|$)` — git push at start or after a
-#   shell separator, ensuring `git push-other-thing` and `git pushd` don't
-#   match (no such commands today, but defensive).
-# - `(^|&&?|;|\|\|?)\s*gh\s+pr\s+ready(\s|$)` — gh pr ready, same shape.
+# Detect gated commands by tokenizing fragments, not regex. This handles:
+# git -C <path> push, git --git-dir=... push, GIT_DIR=... git push,
+# eval git push, xargs git push, git push; (trailing semicolon),
+# (cd /wt; git push) (paren group).
 is_git_push=false
 is_gh_pr_ready=false
-if printf '%s\n' "$COMMAND" | grep -qE '(^|&&?|;|\|\|?)\s*git\s+push(\s|$)'; then
-  is_git_push=true
-fi
-if printf '%s\n' "$COMMAND" | grep -qE '(^|&&?|;|\|\|?)\s*gh\s+pr\s+ready(\s|$)'; then
-  is_gh_pr_ready=true
-fi
+FRAGMENTS=$(_lib_split_fragments "$COMMAND")
+while IFS= read -r frag; do
+  [ -z "$frag" ] && continue
+  if _lib_fragment_invokes_git "$frag"; then
+    subcmd=$(_lib_extract_git_subcmd "$frag")
+    [ "$subcmd" = "push" ] && is_git_push=true
+  fi
+  if printf '%s\n' "$frag" | grep -qE '(^|\s)gh\s+pr\s+ready(\s|;|$)'; then
+    is_gh_pr_ready=true
+  fi
+done <<< "$FRAGMENTS"
 if ! $is_git_push && ! $is_gh_pr_ready; then
   exit 0
 fi
@@ -93,7 +99,7 @@ if $is_git_push; then
 fi
 
 # Are we in a git repo?
-REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+REPO_ROOT=$(cd "$CWD" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null)
 if [ -z "$REPO_ROOT" ]; then
   exit 0
 fi
@@ -105,11 +111,11 @@ fi
 # `rev-parse --abbrev-ref origin/HEAD`: the latter outputs the literal
 # string "origin/HEAD" (not empty) when origin/HEAD isn't a symbolic ref,
 # which defeats the fallback path.
-CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
-DEFAULT_BRANCH=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null | sed 's|^refs/remotes/origin/||')
+CURRENT_BRANCH=$(cd "$CWD" 2>/dev/null && git rev-parse --abbrev-ref HEAD 2>/dev/null)
+DEFAULT_BRANCH=$(cd "$CWD" 2>/dev/null && git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null | sed 's|^refs/remotes/origin/||')
 if [ -z "$DEFAULT_BRANCH" ]; then
   for candidate in main master develop; do
-    if git rev-parse --verify "origin/$candidate" >/dev/null 2>&1; then
+    if cd "$CWD" 2>/dev/null && git rev-parse --verify "origin/$candidate" >/dev/null 2>&1; then
       DEFAULT_BRANCH="$candidate"
       break
     fi
@@ -135,7 +141,7 @@ fi
 # Network call — wrap in `timeout` so a hanging gh doesn't stall the
 # tool-call. On error/timeout, fail-open: the skill's prose triggers
 # still fire, and we don't want to brick offline / flaky-network work.
-PR_NUMBER=$(timeout 5 gh pr view --json number --jq '.number' 2>/dev/null)
+PR_NUMBER=$(cd "$CWD" 2>/dev/null && timeout 5 gh pr view --json number --jq '.number' 2>/dev/null)
 if [ -z "$PR_NUMBER" ]; then
   exit 0
 fi
@@ -146,7 +152,7 @@ if [ -n "$SESSION_ID" ]; then
   MARKER="$HOME/.claude/ready-for-review-markers/$REPO_HASH.$SESSION_ID"
   if [ -f "$MARKER" ]; then
     MARKER_HEAD=$(tr -d '[:space:]' < "$MARKER")
-    CURRENT_HEAD=$(git rev-parse HEAD 2>/dev/null)
+    CURRENT_HEAD=$(cd "$CWD" 2>/dev/null && git rev-parse HEAD 2>/dev/null)
     if [ -n "$MARKER_HEAD" ] && [ -n "$CURRENT_HEAD" ] && [ "$MARKER_HEAD" = "$CURRENT_HEAD" ]; then
       exit 0
     fi

--- a/claude/.claude/hooks/require-worktree-for-git-writes.sh
+++ b/claude/.claude/hooks/require-worktree-for-git-writes.sh
@@ -21,6 +21,22 @@
 # Workaround: write prose-containing files via the Write/Edit tool, not
 # Bash heredocs.
 
+# emit_deny is defined before sourcing _lib.sh so it is available even if
+# _lib.sh is absent (e.g. mid-stow). The guarded source below ensures a
+# missing _lib.sh emits a deny rather than a silent allow or a bare exit 1.
+emit_deny() {
+  local reason="$1"
+  local reason_json
+  reason_json=$(printf '%s' "$reason" | jq -Rs .)
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}' \
+    "$reason_json"
+}
+
+if ! . "$(dirname "$0")/_lib.sh" 2>/dev/null; then
+  emit_deny "Blocked by worktree-enforcement hook: could not source _lib.sh — hook cannot evaluate git discipline safely."
+  exit 0
+fi
+
 # Defensive: prevent GIT_DIR / GIT_WORK_TREE env overrides from making the
 # main tree impersonate a linked worktree via rev-parse output.
 unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE
@@ -30,14 +46,6 @@ COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/n
 JQ_EXIT=$?
 CWD=$(printf '%s\n' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)
 [ -z "$CWD" ] && CWD="$PWD"
-
-emit_deny() {
-  local reason="$1"
-  local reason_json
-  reason_json=$(printf '%s' "$reason" | jq -Rs .)
-  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}' \
-    "$reason_json"
-}
 
 # Returns success when the command chains `cd ... <op> ... git ...`. The
 # hook reads cwd from Claude Code's session-persisted bash state (set by
@@ -197,32 +205,7 @@ readonly ALLOWED_SUBCMDS=(
 )
 ALLOWED_RE=$(IFS='|'; echo "${ALLOWED_SUBCMDS[*]}")
 
-# Decide whether a fragment actually invokes `git`, not just mentions it
-# as a substring of a path or URL. Scans whitespace-separated words and
-# returns success iff any word equals `git` or ends in `/git` (absolute
-# path form, e.g. `/usr/bin/git`). Env-var prefixes (`FOO=1 git ...`),
-# `env`/`sudo` prefixes, and `git` as the nth word are all handled by
-# walking every word rather than just the first.
-#
-# Rejects: `ls .github/workflows/`, `cat .gitignore`, `grep github.com`,
-# `./git-foo` (not `git` and not `*/git`). Accepts: `git log`, `sudo git
-# commit`, `FOO=1 git push`, `/usr/bin/git status`.
-fragment_invokes_git() {
-  local fragment="$1"
-  local saved_opts=$-
-  set -f
-  local found=false word
-  for word in $fragment; do
-    if [[ "$word" == "git" || "$word" == */git ]]; then
-      found=true
-      break
-    fi
-  done
-  if [[ "$saved_opts" != *f* ]]; then
-    set +f
-  fi
-  $found
-}
+fragment_invokes_git() { _lib_fragment_invokes_git "$@"; }
 
 # Extract the git subcommand from a fragment like "git -C path commit -m foo".
 # Strips global flags that consume the next word, skips other flags, returns
@@ -231,6 +214,13 @@ fragment_invokes_git() {
 #
 # Globbing is explicitly disabled for the loop so that an input like
 # "git * log" can't glob against cwd contents to hide the real subcommand.
+#
+# Intentionally NOT delegating to _lib_extract_git_subcmd: this hook is
+# fail-closed — an unrecognized or malformed subcommand is denied.
+# _lib_extract_git_subcmd strips trailing non-alnum chars (e.g. `push)` →
+# `push`) for the ready-for-review hook's "is this a push?" detection;
+# stripping here would silently allow `log)` after paren-group splitting
+# when `log` happens to be allowlisted.
 extract_git_subcmd() {
   local fragment="$1"
   local after_git="${fragment#*git}"
@@ -259,9 +249,7 @@ extract_git_subcmd() {
   printf '%s' "$subcmd"
 }
 
-# Split on shell operators so chained commands get inspected fragment by
-# fragment. Replace operators with newlines, then walk the list.
-FRAGMENTS=$(printf '%s' "$COMMAND" | sed -E 's/;/\n/g; s/&&/\n/g; s/\|\|/\n/g; s/\|/\n/g; s/\$\(/\n/g; s/`/\n/g')
+FRAGMENTS=$(_lib_split_fragments "$COMMAND")
 
 while IFS= read -r fragment; do
   [ -z "$fragment" ] && continue

--- a/claude/.claude/hooks/tests/test_require_ready_for_review.py
+++ b/claude/.claude/hooks/tests/test_require_ready_for_review.py
@@ -514,6 +514,59 @@ class TestRequireReadyForReview:
             == "allow"
         )
 
+    # -- Command-shape coverage (regex-gap fixes) -------------------------
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "git -C /some/wt push origin feature",
+            "git --git-dir=/some/wt/.git --work-tree=/some/wt push",
+            "GIT_DIR=/some/wt/.git git push",
+            "eval git push",
+            "xargs git push",
+            "git push;",
+            "(cd /wt; git push)",
+        ],
+    )
+    def test_command_shapes_that_escaped_old_regex_are_denied(
+        self, isolated_home, repo_on_feature_branch, fake_gh_pr_exists, command
+    ):
+        """Command forms that the old regex missed must now be detected and gated."""
+        assert (
+            run_hook(
+                READY_FOR_REVIEW_HOOK,
+                bash_input(command, session_id="s"),
+                cwd=repo_on_feature_branch,
+            )
+            == "deny"
+        )
+
+    def test_cwd_json_field_used_for_branch_resolution(
+        self, isolated_home, repo_on_feature_branch, fake_gh_pr_exists
+    ):
+        """Hook must read .cwd from the JSON payload, not the inherited process CWD,
+        for branch detection. When the payload's cwd points at a feature-branch
+        repo but the hook process runs from an unrelated directory, the gate
+        must still fire (not bypass via the default-branch check)."""
+        import tempfile
+
+        sid = "s"
+        payload = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "git push origin feature"},
+            "session_id": sid,
+            "cwd": str(repo_on_feature_branch),
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            assert (
+                run_hook(
+                    READY_FOR_REVIEW_HOOK,
+                    payload,
+                    cwd=Path(tmpdir),
+                )
+                == "deny"
+            )
+
     def test_skill_deactivate_command_removes_active_marker(
         self, isolated_home, repo_on_feature_branch
     ):


### PR DESCRIPTION
## Summary

- Replaces the regex-based push detector in `require-ready-for-review.sh` with the same tokenized fragment parser already used in `require-worktree-for-git-writes.sh`, shared via `_lib.sh`. Closes seven command forms the old regex missed silently.
- Reads `.cwd` from the tool-input JSON for all git/gh operations instead of relying on the inherited hook process CWD, matching the existing pattern in the worktree hook.
- Guards the new `_lib.sh` source in `require-worktree-for-git-writes.sh` so a missing `_lib.sh` emits a deny rather than exiting non-zero with no output.

**Command shapes now gated (all were silent-allow before):**

| Shape | Why it escaped the old regex |
|---|---|
| `git -C /wt push origin feature` | flags break adjacency between `git` and `push` |
| `git --git-dir=... --work-tree=... push` | same |
| `GIT_DIR=... git push` | env-var prefix has no leading separator |
| `eval git push` / `xargs git push` | wrapper lacks separator |
| `(cd /wt; git push)` | trailing `)` defeated the `(\s\|$)` anchor |
| `git push;` | `;` is not whitespace and not `$` |

## Test plan

- [x] `pytest claude/.claude/` — 676 tests, all passing
- [x] `ruff check claude/.claude/` — clean
- [ ] New parametrized test `test_command_shapes_that_escaped_old_regex_are_denied` covers all 7 gap shapes
- [ ] New test `test_cwd_json_field_used_for_branch_resolution` verifies `.cwd` JSON field is used for branch detection when hook process CWD differs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
