### PR TITLE
feat(skills): add draft-PR step to plan-it for design-doc and cross-team contract changes

### DIFF
--- a/claude/.claude/skills/plan-it/SKILL.md
+++ b/claude/.claude/skills/plan-it/SKILL.md
@@ -58,3 +58,5 @@ Effort sections optional; if present, describe review surface (file count, domai
 Invoke `/plan-review` against the written plan file. Address any findings before presenting the plan to the user.
 
 **If plan mode is active:** after `/plan-review` is clean and findings are addressed, call `ExitPlanMode` to request approval. The harness shows the plan file's contents in the approval UI; do not also ask conversationally.
+
+**Draft-PR handoff for design-doc or cross-team contract changes.** If the plan introduces a new design document (e.g., a new file under `docs/design/`) or defines a cross-team data contract (a schema shape, enum, or API surface that downstream teams or analytical pipelines depend on), after `ExitPlanMode` is approved and the plan + doc are committed on the implementation branch, push the branch and open a **draft** PR before starting implementation. Async comments on the rendered diff are easier to thread than prose in a plan file, and downstream reviewers may need lead time. Skip this for plans that are implementation-only (no new design doc, no cross-team contract).


### PR DESCRIPTION
## Summary

- Appends a new paragraph to `/plan-it` Step 6 instructing Claude to push the branch and open a **draft** PR before starting implementation, when a plan introduces a new design document or cross-team data contract
- Trigger is concrete and binary (new file in `docs/design/`, or schema/enum/API surface consumed by downstream teams/pipelines); explicitly excludes implementation-only plans
- Co-located with the workflow it modifies — fires only when `/plan-it` runs, not every session

## Why here, not CLAUDE.md

A prior session proposed adding this rule to a project `CLAUDE.md` ("applies to all agents"), but that framing failed on inspection: not all AI agents in that project author plans in `.claude/plans/`, CLAUDE.md is loaded every session (a rule that fires rarely shouldn't pay that cost), and the need is workflow-shaped rather than project-rule-shaped — Step 6 is the right home.

## Test plan

- [ ] Read Step 6 post-merge: trigger, action, and non-trigger are self-contained with no external context required
- [ ] Next `/plan-it` on a plan with no new design doc should **not** prompt a draft PR
- [ ] Next `/plan-it` introducing a new design doc or cross-team contract should prompt push + draft PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)