### PR TITLE
perf(skills): second-pass description trim to close /doctor listing deficit

### DIFF
--- a/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
+++ b/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
@@ -1,9 +1,7 @@
 ---
 name: ai-instruction-and-memory-files
 description: >
-  Editing rules for CLAUDE.md, AGENTS.md, and Claude Code auto-memory
-  (MEMORY.md index + topic files): loading precedence, duplication
-  policy, length targets, user-vs-Claude-written split.
+  Editing rules for CLAUDE.md, AGENTS.md, and Claude Code auto-memory files.
   TRIGGER when: editing or auditing CLAUDE.md, AGENTS.md, or
   ~/.claude/projects/*/memory/, or deciding which surface a rule
   belongs in. DO NOT TRIGGER when: editing .lovable/*.md, .cursorrules,

--- a/claude/.claude/skills/branch-creation/SKILL.md
+++ b/claude/.claude/skills/branch-creation/SKILL.md
@@ -2,10 +2,6 @@
 name: branch-creation
 description: >
   How to name new feature branches and start them from a clean base.
-  Covers ticket-system naming (Linear, Jira, GitHub Issues) vs
-  ticket-less projects, anti-patterns to reject (tracker `<user>/`
-  defaults), and the pre-creation step of branching from a fresh
-  default-branch tip.
   TRIGGER when: creating a new feature branch, picking a branch name,
   deciding whether to use a tracker-provided default branch name.
   DO NOT TRIGGER when: on an existing branch, syncing a branch with

--- a/claude/.claude/skills/claude-hook-review/SKILL.md
+++ b/claude/.claude/skills/claude-hook-review/SKILL.md
@@ -1,10 +1,8 @@
 ---
 name: claude-hook-review
 description: >
-  Review and audit of Claude Code hooks (.claude/hooks/*.sh and
-  settings.json hook entries): matcher selection, fail-open vs
-  fail-closed posture, emit_deny shape, performance budget, test
-  patterns. TRIGGER when: reviewing a .claude/hooks/*.sh script or
+  Review and audit of Claude Code hooks (.claude/hooks/*.sh and settings.json hook entries).
+  TRIGGER when: reviewing a .claude/hooks/*.sh script or
   settings.json hook entry, or designing a new hook.
   DO NOT TRIGGER when: editing permissions.allow rules
   (use review-permissions) or non-Claude hook systems.

--- a/claude/.claude/skills/config-environments/SKILL.md
+++ b/claude/.claude/skills/config-environments/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: config-environments
 description: >
-  Multi-environment config design: env-var naming, credential isolation,
-  and secrets provisioning across dev/staging/prod. TRIGGER when:
+  Multi-environment config design, credential isolation, and secrets provisioning.
+  TRIGGER when:
   designing or reviewing env-var schemes, branching-on-environment
   credential selection, or secret-isolation strategies.
   DO NOT TRIGGER when: a process legitimately holds both env values

--- a/claude/.claude/skills/git-feature-branch-sync/SKILL.md
+++ b/claude/.claude/skills/git-feature-branch-sync/SKILL.md
@@ -1,8 +1,7 @@
 ---
 name: git-feature-branch-sync
 description: >
-  When to rebase vs merge a feature branch and force-push safety
-  (--force-with-lease / --force-if-includes / plain --force).
+  When to rebase vs merge a feature branch and how to force-push safely.
   TRIGGER when: syncing a feature branch with the default branch or
   deciding whether and how to force-push. DO NOT TRIGGER when: doing
   routine work on a clean branch, operating on shared/default branches

--- a/claude/.claude/skills/git-state-safety/SKILL.md
+++ b/claude/.claude/skills/git-state-safety/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: git-state-safety
 description: >
-  Safe inspection of other refs while mid-merge, mid-rebase, or
-  mid-cherry-pick — avoids `git checkout <ref> -- <path>` which
-  silently corrupts the index in these states. TRIGGER when: examining
+  Ref inspection while mid-merge/rebase/cherry-pick without corrupting the index.
+  TRIGGER when: examining
   another ref while the tree has merge/rebase/cherry-pick state or
   unresolved conflicts, or recovering from a bad merge already committed.
   DO NOT TRIGGER when: working on a clean tree or for force-push safety

--- a/claude/.claude/skills/plan-it/SKILL.md
+++ b/claude/.claude/skills/plan-it/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: plan-it
 description: >
-  Produces an implementation plan in .claude/plans/<slug>.md via
-  discovery, exploration, and architecture design, then hands off to
-  /plan-review. TRIGGER when asked for a plan or implementation strategy
+  Produces an implementation plan and hands off to /plan-review.
+  TRIGGER when asked for a plan or implementation strategy
   for work spanning multiple files or domains. DO NOT TRIGGER for
   single-file tweaks, "just implement it" requests, or when a plan
   already exists (use /plan-review instead).

--- a/claude/.claude/skills/plan-review/SKILL.md
+++ b/claude/.claude/skills/plan-review/SKILL.md
@@ -1,9 +1,7 @@
 ---
 name: plan-review
 description: >
-  Review implementation plans before presenting to the user. Evaluates against
-  domain-specific checklists (backend, frontend, security, infrastructure, data)
-  based on which domains the plan touches.
+  Review implementation plans before presenting to the user.
   TRIGGER when: an implementation plan has been written or updated in .claude/plans/
   or is about to be presented to the user for review.
   DO NOT TRIGGER when: the plan is a trivial one-liner (single migration, config

--- a/claude/.claude/skills/ready-for-review/SKILL.md
+++ b/claude/.claude/skills/ready-for-review/SKILL.md
@@ -1,8 +1,7 @@
 ---
 name: ready-for-review
 description: >
-  Pre-handoff gate for open PRs: verifies tests/lint/typecheck, runs
-  /code-review on the full PR diff, syncs PR description, and checks CI.
+  Pre-handoff gate for open PRs before human review.
   TRIGGER when handing off to a human reviewer — wrapping up work on a
   branch with an open PR, "ship it" intent, or before spawning a
   multi-persona review (CISO + staff-* engineers) or /ultrareview.

--- a/claude/.claude/skills/skill-review/SKILL.md
+++ b/claude/.claude/skills/skill-review/SKILL.md
@@ -40,6 +40,10 @@ The harness loads only the description at startup; the body is fetched
 on demand. Description text is always-loaded context budget; body
 text is conditional. Frontmatter overspend hurts more than body overspend.
 
+Target description shape: one summary sentence (≤80 chars), then `TRIGGER when:` and
+`DO NOT TRIGGER when:` clauses. Enumerating body-topic headings in the summary is the
+anti-pattern — body sections already enumerate; the summary routes.
+
 ## 2. Trigger design
 
 Format the description with two parallel lists:

--- a/claude/.claude/skills/skill-review/SKILL.md
+++ b/claude/.claude/skills/skill-review/SKILL.md
@@ -41,8 +41,8 @@ on demand. Description text is always-loaded context budget; body
 text is conditional. Frontmatter overspend hurts more than body overspend.
 
 Target description shape: one summary sentence (≤80 chars), then `TRIGGER when:` and
-`DO NOT TRIGGER when:` clauses. Enumerating body-topic headings in the summary is the
-anti-pattern — body sections already enumerate; the summary routes.
+`DO NOT TRIGGER when:` clauses. Do not enumerate body-topic headings in the summary —
+body sections already enumerate; the summary routes.
 
 ## 2. Trigger design
 

--- a/claude/.claude/skills/sql-query-conventions/SKILL.md
+++ b/claude/.claude/skills/sql-query-conventions/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: sql-query-conventions
 description: >
-  Read-path SQL conventions (raw SQL, PostgREST, SQL-shaped ORMs):
-  explicit limits, pagination, N+1 avoidance, batch-size ceilings, and
-  explicit column selection. TRIGGER when: writing or modifying a SELECT
+  Read-path SQL conventions for raw SQL, PostgREST, and SQL-shaped ORMs.
+  TRIGGER when: writing or modifying a SELECT
   query, PostgREST .from()/.select() chain, list-returning ORM call, or
   query-shape / pagination design. DO NOT TRIGGER when: writing
   write-path (INSERT/UPDATE/DELETE), DDL-only migrations, test fixtures,

--- a/claude/.claude/skills/test-conventions/SKILL.md
+++ b/claude/.claude/skills/test-conventions/SKILL.md
@@ -1,9 +1,7 @@
 ---
 name: test-conventions
 description: >
-  Testing conventions for writing tests in any codebase: test pyramid layers,
-  test-first discipline, design for testability, test isolation, naming, test
-  data, coverage judgment, and mock design.
+  Testing conventions for writing tests in any codebase.
   TRIGGER when: planning tests for new code, writing test infrastructure
   (mocks, helpers, fixtures), or discussing test strategy for new features.
   DO NOT TRIGGER when: a project-level test skill is already loaded, the task

--- a/claude/.claude/skills/test-evaluation/SKILL.md
+++ b/claude/.claude/skills/test-evaluation/SKILL.md
@@ -1,8 +1,7 @@
 ---
 name: test-evaluation
 description: >
-  Evaluate and debug existing test suites: diagnose inverted pyramids, identify
-  wrong-layered tests, root-cause flaky tests, and spot common anti-patterns.
+  Evaluate and debug existing test suites.
   TRIGGER when: reviewing or evaluating an existing test suite, debugging slow
   or flaky tests, assessing test coverage quality, or reviewing test code.
   DO NOT TRIGGER when: writing new tests (use test-conventions), or the task is

--- a/claude/.claude/skills/verify-primary-sources/SKILL.md
+++ b/claude/.claude/skills/verify-primary-sources/SKILL.md
@@ -1,8 +1,7 @@
 ---
 name: verify-primary-sources
 description: >
-  Fetch primary documentation directly rather than relying on agent
-  summaries when web research drives a code or design decision.
+  Fetch primary documentation directly rather than relying on agent summaries.
   TRIGGER when: acting on a documentation claim from a subagent, blog
   post, or other secondary source for an architectural/API/library/
   security decision. DO NOT TRIGGER when: doing quick syntax lookups,


### PR DESCRIPTION
## Summary

- `/doctor` reported 6 skill descriptions dropped at 1.3%/1% of context after PR 194. Because this is a stow-distributed repo, the fix needed to work for all users, not just locally.
- Second-pass compression: collapsed the pre-TRIGGER enumeration sentence (body-topic headings repackaged as a summary) into a ≤80-char one-liner across all eligible skill descriptions. TRIGGER and DO NOT TRIGGER content left verbatim.
- Added the canonical description shape rule to `skill-review/SKILL.md` so future skills land at the right size and the deficit can't re-accumulate silently.

## What changed

- 13 frontmatter `description:` blocks trimmed (lead enumeration → single-sentence summary); no TRIGGER / DO NOT TRIGGER content removed.
- `skill-review/SKILL.md` body: one paragraph added codifying the target description shape as a rule (`Do not enumerate body-topic headings in the summary — body sections already enumerate; the summary routes.`). Imperative voice per skill-review item 7.
- No other skill body content modified.

## Behavioral-equivalence audit

All 13 removed enumerations were body-topic headings whose routing signal is fully covered by the unchanged TRIGGER conditions. Skill-review item 11 audit: 13/13 rows Y, no behavioral regressions.

## Test plan

- [x] `pytest claude/.claude/` — 676 tests pass (trigger-block contract enforced)
- [x] `ruff check claude/.claude/` — clean
- [x] `/skill-review` — clean, behavioral-equivalence table all Y, voice fix applied
- [x] `/code-review` — clean (cumulative)
- [ ] Post-merge: start a fresh session → `/doctor` → confirm no "descriptions dropped" warning and all skills appear with full descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)