### PR TITLE
fix(scripts): add reachability-based merge detection to cleanup-merged-branches

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,9 @@
     "allow": [
       "Bash(ruff check claude/.claude/)",
       "Bash(pytest claude/.claude/)",
-      "Bash(pytest claude/.claude/scripts/tests/test_cleanup_merged_branches.py)"
+      "Bash(pytest claude/.claude/scripts/tests/test_cleanup_merged_branches.py)",
+      "Bash(~/.claude/scripts/cleanup-merged-branches.sh --yes)",
+      "Bash(cleanup-merged-branches --yes)"
     ]
   }
 }

--- a/README.md
+++ b/README.md
@@ -226,10 +226,11 @@ Utility scripts in `claude/.claude/scripts/` (stowed to `~/.claude/scripts/`).
 
 - **`marker.sh`** — write and remove review markers on behalf of workflow skills. `/code-review`, `/skill-review`, `/plan-review`, `/ready-for-review`, `/respond-pr`, and `/ai-instruction-and-memory-files` write or activate markers via `~/.claude/scripts/marker.sh`. The 12 valid invocation shapes are allowlisted in `settings.json` for silent auto-approval; shape validation is enforced by `enforce-marker-script-shape.sh` (see [`docs/hooks.md`](docs/hooks.md)).
 
-- **`cleanup-merged-branches.sh`** — discovers all local branches whose PRs are merged (queried via `gh pr list --head <branch> --state merged`) and cleans them up: removes the worktree, force-deletes the local branch, prunes the remote tracking ref, deletes the remote branch if not auto-deleted, and fast-forwards the default branch. Auto-approved by the paired `permissions.allow` entries.
+- **`cleanup-merged-branches.sh`** — discovers local branches that are safe to delete and cleans them up: removes the worktree, force-deletes the local branch, prunes the remote tracking ref, deletes the remote branch if not auto-deleted, and fast-forwards the default branch. Two signals are used: `gh pr list --head <branch> --state merged` (confirmed merged PR for this exact branch name), and `git merge-base --is-ancestor` to catch branches whose commits are reachable from `origin/<default>` even when the PR shipped under a different head name (renamed branch, worktree-prefixed name, etc.). Branches confirmed via gh are deleted without prompting; branches detected only via reachability prompt for confirmation. `--yes` skips the prompt and auto-confirms reachability-only branches — required when invoking from a non-interactive shell (including the Claude Code Bash tool, which does not allocate a TTY) — without it, probable-merge branches are skipped with a warning. Auto-approved by the paired `permissions.allow` entries.
 
   ```bash
-  cleanup-merged-branches          # run cleanup
+  cleanup-merged-branches          # run cleanup (prompts for reachability-only branches)
+  cleanup-merged-branches --yes    # run cleanup, auto-confirm all candidates
   cleanup-merged-branches --dry-run  # preview without acting
   ```
 

--- a/claude/.claude/scripts/cleanup-merged-branches.sh
+++ b/claude/.claude/scripts/cleanup-merged-branches.sh
@@ -307,6 +307,11 @@ for BRANCH in "${TO_DELETE[@]}"; do
 
   echo "  ${BRANCH}:"
 
+  # Use --porcelain to get the exact path; do NOT construct from branch name
+  # (slashes in branch names would break path interpolation).
+  # The `locked` line appears after `branch` in a porcelain record, so we
+  # use a deferred-commit pattern: finalize path + lock state at each record
+  # boundary rather than at the moment the branch line is matched.
   WORKTREE_PATH=""
   WORKTREE_LOCKED=0
   WORKTREE_LOCK_PID=""
@@ -371,6 +376,8 @@ for BRANCH in "${TO_DELETE[@]}"; do
     echo "    worktree:       not found"
   fi
 
+  # After --prune, check the tracking ref directly; substring grep on fetch output
+  # can't distinguish "origin/feat/foo" from "origin/feat/foo-v2".
   FETCH_OUTPUT=$(git fetch --prune 2>&1 || true)
   REMOTE_AUTO_PRUNED=0
   if echo "$FETCH_OUTPUT" | grep -qF "[deleted]" && \
@@ -414,6 +421,9 @@ elif [ "$LOCAL_DEFAULT_SHA" = "$REMOTE_DEFAULT_SHA" ]; then
   echo "Default branch: already current"
 else
   COMMIT_COUNT=$(git rev-list --count "${DEFAULT_BRANCH}..origin/${DEFAULT_BRANCH}" 2>/dev/null || echo 0)
+  # When on the default branch, merge --ff-only updates both the ref and the
+  # working tree. When on a feature branch, use a fetch refspec to update the
+  # default branch ref without touching the currently checked-out branch.
   CURRENT_HEAD_FOR_FF=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
   if [ "$CURRENT_HEAD_FOR_FF" = "$DEFAULT_BRANCH" ]; then
     FF_CMD=(git merge --ff-only "origin/${DEFAULT_BRANCH}" -q)

--- a/claude/.claude/scripts/cleanup-merged-branches.sh
+++ b/claude/.claude/scripts/cleanup-merged-branches.sh
@@ -1,20 +1,28 @@
 #!/usr/bin/env bash
 # cleanup-merged-branches.sh — discover and clean up merged branches.
 #
-# Queries gh pr list for every local branch to find branches whose PRs
-# have merged, then removes each one: worktree (if any), local branch,
-# remote tracking ref, remote branch (if not auto-pruned), and finally
-# fast-forwards the default branch.
+# Uses two signals to detect merged branches:
+#   Tier A — gh pr list confirms a merged PR for this branch name.
+#   Tier B — the branch tip is reachable from origin/<default> but no
+#             merged PR was found for this name (branch renamed before
+#             merge, worktree-prefixed name, etc.).
+#   Tier C — not reachable, no merged PR; never touched.
+#
+# Tier A branches are deleted without prompting. Tier B branches prompt
+# interactively; --yes auto-confirms them. When stdin is not a TTY and
+# --yes is not set, Tier B branches are skipped with a warning.
 #
 # No user-controlled branch-name argument means no argument-injection
 # attack surface against the destructive git ops. The exact-string
-# permissions.allow entries in settings.json admit only the two
-# invocation shapes below — no PreToolUse hook is needed because no
+# permissions.allow entries in settings.json admit only the enumerated
+# invocation shapes — no PreToolUse hook is needed because no
 # wildcard is in play.
 #
 # Usage:
 #   cleanup-merged-branches.sh
 #   cleanup-merged-branches.sh --dry-run
+#   cleanup-merged-branches.sh --yes
+#   cleanup-merged-branches.sh --dry-run --yes
 #
 # Exit codes:
 #   0  success (including no-op)
@@ -43,15 +51,19 @@ clear_progress() {
 # ---------------------------------------------------------------------------
 
 usage() {
-  echo "Usage: $(basename "$0") [--dry-run]" >&2
+  echo "Usage: $(basename "$0") [--dry-run] [--yes]" >&2
 }
 
 DRY_RUN=0
-case "$#:${1:-}" in
-  "0:"|"1:--dry-run") ;;
-  *) usage; exit 2 ;;
-esac
-[ "${1:-}" = "--dry-run" ] && DRY_RUN=1
+ASSUME_YES=0
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1 ;;
+    --yes)     ASSUME_YES=1 ;;
+    *)         usage; exit 2 ;;
+  esac
+  shift
+done
 
 # ---------------------------------------------------------------------------
 # Prerequisites
@@ -80,11 +92,9 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 
 DEFAULT_BRANCH=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || true)
 if [ -z "$DEFAULT_BRANCH" ]; then
-  # origin/HEAD unset — try to populate it once
   git remote set-head origin --auto &>/dev/null || true
   DEFAULT_BRANCH=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || true)
 fi
-# Strip the "origin/" prefix if present
 DEFAULT_BRANCH="${DEFAULT_BRANCH#origin/}"
 if [ -z "$DEFAULT_BRANCH" ]; then
   echo "WARNING: could not resolve default branch from origin/HEAD; falling back to 'main'." >&2
@@ -97,15 +107,14 @@ fi
 
 CURRENT_HEAD=$(git rev-parse --abbrev-ref HEAD)
 
-# Collect candidates: all local branches except default and current HEAD.
 mapfile -t ALL_BRANCHES < <(
   git for-each-ref --format='%(refname:short)' refs/heads
 )
 
-# Query gh for each candidate branch and collect merged ones.
 declare -a MERGED_BRANCHES=()
-declare -A MERGED_PR_INFO=()   # branch -> "PR #N, merged DATE"
-declare -a SKIPPED_BRANCHES=() # checked-out candidates
+declare -A MERGED_PR_INFO=()
+declare -A TIER=()
+declare -a SKIPPED_BRANCHES=()
 
 CANDIDATE_COUNT=0
 for _B in "${ALL_BRANCHES[@]}"; do
@@ -118,25 +127,22 @@ if [ -t 2 ] && [ "$CANDIDATE_COUNT" -gt 0 ]; then
   printf 'Scanning %d branch(es) for merged PRs...\n' "$CANDIDATE_COUNT" >&2
 fi
 
+git fetch origin "$DEFAULT_BRANCH" --quiet 2>/dev/null || true
+
 _PROGRESS_I=0
 for BRANCH in "${ALL_BRANCHES[@]}"; do
-  # Skip the default branch
   [ "$BRANCH" = "$DEFAULT_BRANCH" ] && continue
-  # Skip the currently checked-out branch (will recheck per-branch below)
   [ "$BRANCH" = "$CURRENT_HEAD" ] && continue
   _PROGRESS_I=$(( _PROGRESS_I + 1 ))
   progress "$_PROGRESS_I" "$CANDIDATE_COUNT" "$BRANCH"
 
-  # Query for a merged PR targeting this branch name
   PR_JSON=$(gh pr list \
     --head "$BRANCH" \
     --state merged \
     --limit 1 \
-    --json number,headRefName,state,mergedAt \
+    --json number,mergedAt \
     2>/dev/null || true)
 
-  # A non-empty array with at least one entry means this branch was merged.
-  # Parse number, mergedAt, and count in a single python3 invocation.
   PR_PARSED=$(echo "$PR_JSON" | python3 -c "
 import json, sys
 data = json.load(sys.stdin)
@@ -150,9 +156,19 @@ else:
 " 2>/dev/null || printf '\n\n')
   PR_NUMBER=$(echo "$PR_PARSED" | sed -n '1p')
   PR_MERGED_AT=$(echo "$PR_PARSED" | sed -n '2p')
+
   if [ -n "$PR_NUMBER" ]; then
     MERGED_BRANCHES+=("$BRANCH")
     MERGED_PR_INFO["$BRANCH"]="PR #${PR_NUMBER}, merged ${PR_MERGED_AT}"
+    TIER["$BRANCH"]="A"
+    continue
+  fi
+
+  if git merge-base --is-ancestor "$BRANCH" \
+       "refs/remotes/origin/${DEFAULT_BRANCH}" 2>/dev/null; then
+    MERGED_BRANCHES+=("$BRANCH")
+    MERGED_PR_INFO["$BRANCH"]="reachable from origin/${DEFAULT_BRANCH}; no merged PR for this name"
+    TIER["$BRANCH"]="B"
   fi
 done
 clear_progress
@@ -162,50 +178,73 @@ clear_progress
 # ---------------------------------------------------------------------------
 
 if [ "$DRY_RUN" -eq 1 ]; then
-  if [ "${#MERGED_BRANCHES[@]}" -eq 0 ] && [ "${#SKIPPED_BRANCHES[@]}" -eq 0 ]; then
+  declare -a _DRY_TIER_A=()
+  declare -a _DRY_TIER_B=()
+  for BRANCH in "${MERGED_BRANCHES[@]}"; do
+    if [ "${TIER[$BRANCH]}" = "A" ]; then
+      _DRY_TIER_A+=("$BRANCH")
+    else
+      _DRY_TIER_B+=("$BRANCH")
+    fi
+  done
+
+  if [ "${#_DRY_TIER_A[@]}" -eq 0 ] && [ "${#_DRY_TIER_B[@]}" -eq 0 ] && [ "${#SKIPPED_BRANCHES[@]}" -eq 0 ]; then
     if [ -t 1 ]; then
       echo "nothing to clean"
     fi
     exit 0
   fi
 
-  if [ "${#MERGED_BRANCHES[@]}" -gt 0 ]; then
-    echo "Would clean up:"
-    for BRANCH in "${MERGED_BRANCHES[@]}"; do
-      _DRY_LOCKED=0
-      _DRY_MATCHED=0
-      while IFS= read -r _line; do
-        if [[ "$_line" == "worktree "* ]]; then
-          _DRY_MATCHED=0
-        elif [[ "$_line" == "branch refs/heads/${BRANCH}" ]]; then
-          _DRY_MATCHED=1
-        elif [ "$_DRY_MATCHED" -eq 1 ] && [[ "$_line" == "locked"* ]]; then
-          _DRY_LOCKED=1
-        elif [ -z "$_line" ]; then
-          _DRY_MATCHED=0
-        fi
-      done < <(git worktree list --porcelain)
-      if [ "$_DRY_LOCKED" -eq 1 ]; then
-        echo "  ${BRANCH} (${MERGED_PR_INFO[$BRANCH]}) [locked — will unlock and remove]"
-      else
-        echo "  ${BRANCH} (${MERGED_PR_INFO[$BRANCH]})"
+  _dry_print_branch_with_lock() {
+    local _branch="$1"
+    local _locked=0
+    local _matched=0
+    while IFS= read -r _line; do
+      if [[ "$_line" == "worktree "* ]]; then
+        _matched=0
+      elif [[ "$_line" == "branch refs/heads/${_branch}" ]]; then
+        _matched=1
+      elif [ "$_matched" -eq 1 ] && [[ "$_line" == "locked"* ]]; then
+        _locked=1
+      elif [ -z "$_line" ]; then
+        _matched=0
       fi
+    done < <(git worktree list --porcelain)
+    if [ "$_locked" -eq 1 ]; then
+      echo "  ${_branch} (${MERGED_PR_INFO[$_branch]}) [locked — will unlock and remove]"
+    else
+      echo "  ${_branch} (${MERGED_PR_INFO[$_branch]})"
+    fi
+  }
+
+  if [ "${#_DRY_TIER_A[@]}" -gt 0 ]; then
+    echo "Would clean up (confirmed merged):"
+    for BRANCH in "${_DRY_TIER_A[@]}"; do
+      _dry_print_branch_with_lock "$BRANCH"
     done
   fi
 
-  # Re-check for currently checked-out candidates (those skipped during enumeration)
+  if [ "${#_DRY_TIER_B[@]}" -gt 0 ]; then
+    echo "Probable merges (would prompt; --yes to auto-confirm):"
+    for BRANCH in "${_DRY_TIER_B[@]}"; do
+      _dry_print_branch_with_lock "$BRANCH"
+    done
+  fi
+
   for BRANCH in "${ALL_BRANCHES[@]}"; do
     [ "$BRANCH" = "$DEFAULT_BRANCH" ] && continue
     [ "$BRANCH" = "$CURRENT_HEAD" ] || continue
-    # This branch is currently checked out — query to see if it was merged
     PR_JSON=$(gh pr list \
       --head "$BRANCH" \
       --state merged \
       --limit 1 \
-      --json number,headRefName,state,mergedAt \
+      --json number,mergedAt \
       2>/dev/null || true)
     PR_COUNT=$(echo "$PR_JSON" | python3 -c "import json,sys; data=json.load(sys.stdin); print(len(data))" 2>/dev/null || echo 0)
-    if [ "$PR_COUNT" -gt 0 ]; then
+    REACHABLE=0
+    git merge-base --is-ancestor "$BRANCH" \
+      "refs/remotes/origin/${DEFAULT_BRANCH}" 2>/dev/null && REACHABLE=1 || true
+    if [ "$PR_COUNT" -gt 0 ] || [ "$REACHABLE" -eq 1 ]; then
       echo "Skipped: ${BRANCH} (currently checked out)"
     fi
   done
@@ -213,13 +252,41 @@ if [ "$DRY_RUN" -eq 1 ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# No candidates
+# Pre-cleanup confirmation pass
 # ---------------------------------------------------------------------------
 
-if [ "${#MERGED_BRANCHES[@]}" -eq 0 ]; then
+declare -a TO_DELETE=()
+declare -a SKIPPED_NEEDS_PROMPT=()
+
+for BRANCH in "${MERGED_BRANCHES[@]}"; do
+  if [ "${TIER[$BRANCH]}" = "A" ]; then
+    TO_DELETE+=("$BRANCH")
+  elif [ "${TIER[$BRANCH]}" = "B" ]; then
+    if [ "$ASSUME_YES" -eq 1 ]; then
+      TO_DELETE+=("$BRANCH")
+    elif [ -t 0 ]; then
+      printf "delete '%s' (reachable from origin/%s; no merged PR for this name)? [y/N]: " \
+        "$BRANCH" "$DEFAULT_BRANCH"
+      read -r _REPLY
+      if [[ "$_REPLY" == "y" || "$_REPLY" == "Y" ]]; then
+        TO_DELETE+=("$BRANCH")
+      fi
+    else
+      SKIPPED_NEEDS_PROMPT+=("$BRANCH")
+    fi
+  fi
+done
+
+if [ "${#TO_DELETE[@]}" -eq 0 ] && [ "${#SKIPPED_NEEDS_PROMPT[@]}" -eq 0 ]; then
   if [ -t 1 ]; then
     echo "nothing to clean"
   fi
+  exit 0
+fi
+
+if [ "${#TO_DELETE[@]}" -eq 0 ] && [ "${#SKIPPED_NEEDS_PROMPT[@]}" -gt 0 ]; then
+  printf 'Skipped %d probable-merge branch(es) (no TTY for prompt; rerun with --yes or from a terminal): %s\n' \
+    "${#SKIPPED_NEEDS_PROMPT[@]}" "${SKIPPED_NEEDS_PROMPT[*]}"
   exit 0
 fi
 
@@ -227,10 +294,11 @@ fi
 # Per-branch cleanup
 # ---------------------------------------------------------------------------
 
+declare -a SKIPPED_LIVE_LOCK=()
+
 echo "Cleaned up:"
 
-for BRANCH in "${MERGED_BRANCHES[@]}"; do
-  # Re-check HEAD immediately before destructive ops (race guard)
+for BRANCH in "${TO_DELETE[@]}"; do
   CURRENT_HEAD_NOW=$(git rev-parse --abbrev-ref HEAD)
   if [ "$BRANCH" = "$CURRENT_HEAD_NOW" ]; then
     SKIPPED_BRANCHES+=("$BRANCH")
@@ -239,21 +307,18 @@ for BRANCH in "${MERGED_BRANCHES[@]}"; do
 
   echo "  ${BRANCH}:"
 
-  # Step 1: Remove worktree (if present)
-  # Use --porcelain to get the exact path; do NOT construct from branch name
-  # (slashes in branch names would break path interpolation).
-  # The `locked` line appears after `branch` in a porcelain record, so we
-  # use a deferred-commit pattern: finalize path + lock state at each record
-  # boundary rather than at the moment the branch line is matched.
   WORKTREE_PATH=""
   WORKTREE_LOCKED=0
+  WORKTREE_LOCK_PID=""
   _CANDIDATE_PATH=""
   _CANDIDATE_LOCKED=0
+  _CANDIDATE_LOCK_PID=""
   _CANDIDATE_MATCHED=0
   _commit_wt_candidate() {
     if [ "$_CANDIDATE_MATCHED" -eq 1 ]; then
       WORKTREE_PATH="$_CANDIDATE_PATH"
       WORKTREE_LOCKED="$_CANDIDATE_LOCKED"
+      WORKTREE_LOCK_PID="$_CANDIDATE_LOCK_PID"
     fi
   }
   while IFS= read -r line; do
@@ -261,19 +326,36 @@ for BRANCH in "${MERGED_BRANCHES[@]}"; do
       _commit_wt_candidate
       _CANDIDATE_PATH="${line#worktree }"
       _CANDIDATE_LOCKED=0
+      _CANDIDATE_LOCK_PID=""
       _CANDIDATE_MATCHED=0
     elif [[ "$line" == "branch refs/heads/${BRANCH}" ]]; then
       _CANDIDATE_MATCHED=1
     elif [[ "$line" == "locked"* ]]; then
       _CANDIDATE_LOCKED=1
+      if [[ "$line" =~ pid[[:space:]]+([0-9]+) ]]; then
+        _CANDIDATE_LOCK_PID="${BASH_REMATCH[1]}"
+      fi
     fi
   done < <(git worktree list --porcelain)
-  _commit_wt_candidate  # finalize the last record
+  _commit_wt_candidate
 
   if [ -n "$WORKTREE_PATH" ] && [ "$WORKTREE_PATH" != "$REPO_ROOT" ]; then
     if [ "$WORKTREE_LOCKED" -eq 1 ]; then
+      WORKTREE_LOCK_ALIVE=0
+      if [ -n "$WORKTREE_LOCK_PID" ]; then
+        kill -0 "$WORKTREE_LOCK_PID" 2>/dev/null && WORKTREE_LOCK_ALIVE=1
+      else
+        WORKTREE_LOCK_ALIVE=1
+      fi
+
+      if [ "$WORKTREE_LOCK_ALIVE" -eq 1 ]; then
+        echo "    worktree:       skipped (locked by live pid ${WORKTREE_LOCK_PID:-unknown})"
+        SKIPPED_LIVE_LOCK+=("$BRANCH")
+        continue
+      fi
+
       if git worktree unlock "$WORKTREE_PATH" 2>/dev/null; then
-        echo "    worktree:       unlocked stale lock"
+        echo "    worktree:       unlocked stale lock (pid ${WORKTREE_LOCK_PID} dead)"
       fi
     fi
     if git worktree remove "$WORKTREE_PATH" 2>/dev/null; then
@@ -289,9 +371,6 @@ for BRANCH in "${MERGED_BRANCHES[@]}"; do
     echo "    worktree:       not found"
   fi
 
-  # Step 2: Fetch and prune — detect auto-deleted remote branches.
-  # After --prune, check the tracking ref directly; substring grep on fetch output
-  # can't distinguish "origin/feat/foo" from "origin/feat/foo-v2".
   FETCH_OUTPUT=$(git fetch --prune 2>&1 || true)
   REMOTE_AUTO_PRUNED=0
   if echo "$FETCH_OUTPUT" | grep -qF "[deleted]" && \
@@ -299,18 +378,15 @@ for BRANCH in "${MERGED_BRANCHES[@]}"; do
     REMOTE_AUTO_PRUNED=1
   fi
 
-  # Step 3: Delete local branch (force-delete handles squash merges)
   if git branch -D "$BRANCH" 2>/dev/null; then
     echo "    local branch:   deleted"
   else
     echo "    local branch:   not found"
   fi
 
-  # Step 4: Delete remote branch (if not auto-pruned)
   if [ "$REMOTE_AUTO_PRUNED" -eq 1 ]; then
     echo "    remote branch:  auto-pruned"
   else
-    # Check whether the remote ref still exists before attempting deletion
     if git ls-remote --heads origin "$BRANCH" 2>/dev/null | grep -q .; then
       if git push origin --delete "$BRANCH" 2>/dev/null; then
         echo "    remote branch:  deleted"
@@ -327,7 +403,6 @@ done
 # Fast-forward default branch (once, after all per-branch cleanup)
 # ---------------------------------------------------------------------------
 
-# Fetch any remaining changes to update origin/<DEFAULT_BRANCH>
 git fetch origin "$DEFAULT_BRANCH" &>/dev/null || true
 
 LOCAL_DEFAULT_SHA=$(git rev-parse "$DEFAULT_BRANCH" 2>/dev/null || true)
@@ -339,9 +414,6 @@ elif [ "$LOCAL_DEFAULT_SHA" = "$REMOTE_DEFAULT_SHA" ]; then
   echo "Default branch: already current"
 else
   COMMIT_COUNT=$(git rev-list --count "${DEFAULT_BRANCH}..origin/${DEFAULT_BRANCH}" 2>/dev/null || echo 0)
-  # When on the default branch, merge --ff-only updates both the ref and the working tree.
-  # When on a feature branch, use a fetch refspec to update the default branch ref
-  # without touching the currently checked-out branch.
   CURRENT_HEAD_FOR_FF=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
   if [ "$CURRENT_HEAD_FOR_FF" = "$DEFAULT_BRANCH" ]; then
     FF_CMD=(git merge --ff-only "origin/${DEFAULT_BRANCH}" -q)
@@ -356,6 +428,19 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# End-of-run summary
+# ---------------------------------------------------------------------------
+
+for BRANCH in "${SKIPPED_LIVE_LOCK[@]+"${SKIPPED_LIVE_LOCK[@]}"}"; do
+  echo "Skipped (live agent lock): ${BRANCH}"
+done
+
+if [ "${#SKIPPED_NEEDS_PROMPT[@]}" -gt 0 ]; then
+  printf 'Skipped %d probable-merge branch(es) (no TTY for prompt; rerun with --yes or from a terminal): %s\n' \
+    "${#SKIPPED_NEEDS_PROMPT[@]}" "${SKIPPED_NEEDS_PROMPT[*]}"
+fi
+
+# ---------------------------------------------------------------------------
 # Skipped branches
 # ---------------------------------------------------------------------------
 
@@ -363,19 +448,20 @@ for BRANCH in "${SKIPPED_BRANCHES[@]}"; do
   echo "Skipped: ${BRANCH} (currently checked out)"
 done
 
-# Also check branches that were checked-out at enumeration time
 for BRANCH in "${ALL_BRANCHES[@]}"; do
   [ "$BRANCH" = "$DEFAULT_BRANCH" ] && continue
   [ "$BRANCH" = "$CURRENT_HEAD" ] || continue
-  # Check if this checked-out branch also had a merged PR
   PR_JSON=$(gh pr list \
     --head "$BRANCH" \
     --state merged \
     --limit 1 \
-    --json number,headRefName,state,mergedAt \
+    --json number,mergedAt \
     2>/dev/null || true)
   PR_COUNT=$(echo "$PR_JSON" | python3 -c "import json,sys; data=json.load(sys.stdin); print(len(data))" 2>/dev/null || echo 0)
-  if [ "$PR_COUNT" -gt 0 ]; then
+  REACHABLE=0
+  git merge-base --is-ancestor "$BRANCH" \
+    "refs/remotes/origin/${DEFAULT_BRANCH}" 2>/dev/null && REACHABLE=1 || true
+  if [ "$PR_COUNT" -gt 0 ] || [ "$REACHABLE" -eq 1 ]; then
     echo "Skipped: ${BRANCH} (currently checked out)"
   fi
 done

--- a/claude/.claude/scripts/tests/test_cleanup_merged_branches.py
+++ b/claude/.claude/scripts/tests/test_cleanup_merged_branches.py
@@ -6,8 +6,10 @@ against temporary repos created per-test.
 """
 from __future__ import annotations
 
+import contextlib
 import json
 import os
+import pty
 import subprocess
 import textwrap
 from pathlib import Path
@@ -69,6 +71,13 @@ def _make_worktree(repo: Path, branch_name: str, wt_path: Path) -> None:
         cwd=repo,
         check=True,
     )
+
+
+def _dead_pid() -> int:
+    """Return a pid that is guaranteed not to be running."""
+    proc = subprocess.Popen(["true"])
+    proc.wait()
+    return proc.pid
 
 
 # ---------------------------------------------------------------------------
@@ -528,7 +537,6 @@ class TestInvalidArgs:
         ["foo"],
         ["--bar"],
         ["--dry-run", "x"],
-        ["--dry-run", "--dry-run"],
     ])
     def test_invalid_args_exit_2(self, tmp_path, fake_gh, bad_args):
         local, _ = _make_repo_with_remote(tmp_path)
@@ -536,6 +544,17 @@ class TestInvalidArgs:
         result = _run_script(local, env, args=bad_args)
         assert result.returncode == 2
         assert "Usage" in result.stderr
+
+    @pytest.mark.parametrize("valid_dup_args", [
+        ["--dry-run", "--dry-run"],
+        ["--yes", "--yes"],
+        ["--dry-run", "--yes", "--dry-run"],
+    ])
+    def test_duplicate_flags_are_idempotent(self, tmp_path, fake_gh, valid_dup_args):
+        local, _ = _make_repo_with_remote(tmp_path)
+        env = fake_gh({})
+        result = _run_script(local, env, args=valid_dup_args)
+        assert result.returncode == 0
 
 
 class TestGhMissing:
@@ -579,8 +598,9 @@ class TestLockedWorktreeUnlockedAndRemoved:
 
         wt_path = tmp_path / "locked-tree"
         _make_worktree(local, "feat/locked-wt", wt_path)
+        dead = _dead_pid()
         subprocess.run(
-            ["git", "worktree", "lock", str(wt_path), "--reason", "test lock"],
+            ["git", "worktree", "lock", str(wt_path), "--reason", f"test (pid {dead})"],
             cwd=local, check=True, capture_output=True,
         )
 
@@ -604,8 +624,9 @@ class TestLockedWorktreeUnlockedAndRemoved:
 
         wt_path = tmp_path / "locked-dry-tree"
         _make_worktree(local, "feat/locked-dry", wt_path)
+        dead = _dead_pid()
         subprocess.run(
-            ["git", "worktree", "lock", str(wt_path), "--reason", "test lock"],
+            ["git", "worktree", "lock", str(wt_path), "--reason", f"test (pid {dead})"],
             cwd=local, check=True, capture_output=True,
         )
 
@@ -636,8 +657,9 @@ class TestLockedWorktreeMixedWithUnlocked:
         subprocess.run(["git", "branch", "-D", "feat/locked-mix"], cwd=bare, check=True)
         locked_wt = tmp_path / "locked-mix-tree"
         _make_worktree(local, "feat/locked-mix", locked_wt)
+        dead = _dead_pid()
         subprocess.run(
-            ["git", "worktree", "lock", str(locked_wt), "--reason", "test lock"],
+            ["git", "worktree", "lock", str(locked_wt), "--reason", f"test (pid {dead})"],
             cwd=local, check=True, capture_output=True,
         )
 
@@ -685,8 +707,9 @@ class TestLockedWorktreeRemoveFailsCleanly:
         _make_worktree(local, "feat/locked-dirty", wt_path)
         # Untracked file causes git worktree remove to refuse without --force
         (wt_path / "leftover.txt").write_text("in-progress work")
+        dead = _dead_pid()
         subprocess.run(
-            ["git", "worktree", "lock", str(wt_path), "--reason", "test lock"],
+            ["git", "worktree", "lock", str(wt_path), "--reason", f"test (pid {dead})"],
             cwd=local, check=True, capture_output=True,
         )
 
@@ -717,3 +740,255 @@ class TestLockedWorktreeRemoveFailsCleanly:
             for record in records
         )
         assert wt_is_locked, "worktree should be relocked after failed remove"
+
+
+# ---------------------------------------------------------------------------
+# Tier B helpers and tests (reachable from origin/main, no merged PR)
+# ---------------------------------------------------------------------------
+
+def _make_tier_b_branch(repo: Path, remote: Path, branch_name: str) -> None:
+    """Feature branch whose commits are reachable from origin/main, but gh returns no PR."""
+    subprocess.run(["git", "checkout", "-q", "-b", branch_name], cwd=repo, check=True)
+    _commit(repo, f"work on {branch_name}")
+    subprocess.run(["git", "checkout", "-q", "main"], cwd=repo, check=True)
+    subprocess.run(["git", "merge", "-q", "--ff-only", branch_name], cwd=repo, check=True)
+    subprocess.run(["git", "push", "-q", "origin", "main"], cwd=repo, check=True)
+
+
+class TestTierBReachableNoMergedPR:
+    """Branches reachable from origin/main but with no merged PR for this name."""
+
+    def test_reachable_but_no_merged_pr_prompts(self, fake_gh, tmp_path):
+        """Tier B branch: interactive y via pty stdin → deleted."""
+        local, remote = _make_repo_with_remote(tmp_path)
+        _make_tier_b_branch(local, remote, "tier-b-branch")
+        env = fake_gh({})
+
+        master_fd, slave_fd = pty.openpty()
+        try:
+            proc = subprocess.Popen(
+                [str(_SCRIPT)], cwd=local,
+                env=env,
+                stdin=slave_fd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            )
+            os.close(slave_fd)
+            os.write(master_fd, b"y\n")
+            proc.wait(timeout=30)
+            os.close(master_fd)
+        except Exception:
+            with contextlib.suppress(OSError):
+                os.close(master_fd)
+            with contextlib.suppress(OSError):
+                os.close(slave_fd)
+            raise
+
+        assert proc.returncode == 0
+        branches = subprocess.run(
+            ["git", "branch"], cwd=local, capture_output=True, text=True
+        ).stdout
+        assert "tier-b-branch" not in branches
+
+    def test_reachable_but_no_merged_pr_skipped_on_n(self, fake_gh, tmp_path):
+        """Tier B branch: interactive n via pty stdin → branch survives."""
+        local, remote = _make_repo_with_remote(tmp_path)
+        _make_tier_b_branch(local, remote, "tier-b-branch")
+        env = fake_gh({})
+
+        master_fd, slave_fd = pty.openpty()
+        try:
+            proc = subprocess.Popen(
+                [str(_SCRIPT)], cwd=local,
+                env=env,
+                stdin=slave_fd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            )
+            os.close(slave_fd)
+            os.write(master_fd, b"n\n")
+            proc.wait(timeout=30)
+            os.close(master_fd)
+        except Exception:
+            with contextlib.suppress(OSError):
+                os.close(master_fd)
+            with contextlib.suppress(OSError):
+                os.close(slave_fd)
+            raise
+
+        assert proc.returncode == 0
+        branches = subprocess.run(
+            ["git", "branch"], cwd=local, capture_output=True, text=True
+        ).stdout
+        assert "tier-b-branch" in branches
+
+    def test_reachable_no_pr_non_tty_no_yes_skips(self, fake_gh, tmp_path):
+        """Tier B branch, non-TTY stdin, no --yes: branch skipped with warning."""
+        local, remote = _make_repo_with_remote(tmp_path)
+        _make_tier_b_branch(local, remote, "tier-b-branch")
+        env = fake_gh({})
+        result = subprocess.run(
+            [str(_SCRIPT)], cwd=local,
+            env=env,
+            stdin=subprocess.DEVNULL, capture_output=True,
+        )
+        assert result.returncode == 0
+        branches = subprocess.run(
+            ["git", "branch"], cwd=local, capture_output=True, text=True
+        ).stdout
+        assert "tier-b-branch" in branches
+        assert b"tier-b-branch" in result.stdout
+
+    def test_reachable_no_pr_with_yes_flag_deletes(self, fake_gh, tmp_path):
+        """Tier B branch + --yes: deleted without prompt."""
+        local, remote = _make_repo_with_remote(tmp_path)
+        _make_tier_b_branch(local, remote, "tier-b-branch")
+        env = fake_gh({})
+        result = subprocess.run(
+            [str(_SCRIPT), "--yes"], cwd=local,
+            env=env,
+            stdin=subprocess.DEVNULL, capture_output=True,
+        )
+        assert result.returncode == 0
+        branches = subprocess.run(
+            ["git", "branch"], cwd=local, capture_output=True, text=True
+        ).stdout
+        assert "tier-b-branch" not in branches
+
+    def test_unmerged_branch_not_touched(self, fake_gh, tmp_path):
+        """Tier C branch (not reachable from origin/main, no merged PR) is never deleted."""
+        local, remote = _make_repo_with_remote(tmp_path)
+        _make_feature_branch(local, "unmerged-branch")
+        env = fake_gh({})
+        result = subprocess.run(
+            [str(_SCRIPT), "--yes"], cwd=local,
+            env=env,
+            stdin=subprocess.DEVNULL, capture_output=True,
+        )
+        assert result.returncode == 0
+        branches = subprocess.run(
+            ["git", "branch"], cwd=local, capture_output=True, text=True
+        ).stdout
+        assert "unmerged-branch" in branches
+
+    def test_dry_run_separates_confirmed_and_probable(self, tmp_path):
+        """Dry-run shows Tier A under 'confirmed merged' and Tier B under 'probable merges'."""
+        local, remote = _make_repo_with_remote(tmp_path)
+        _make_feature_branch(local, "tier-a-branch")
+        _make_tier_b_branch(local, remote, "tier-b-branch")
+        _make_feature_branch(local, "tier-c-branch")
+
+        shim_dir = tmp_path / "gh_shim_sep"
+        shim_dir.mkdir()
+        shim_py = shim_dir / "gh"
+        shim_py.write_text(_gh_shim_source({"tier-a-branch": {"number": 1, "mergedAt": "2026-05-01"}}))
+        shim_py.chmod(0o755)
+        env = {**os.environ, "PATH": str(shim_dir) + ":" + os.environ.get("PATH", "")}
+
+        result = subprocess.run(
+            [str(_SCRIPT), "--dry-run"], cwd=local,
+            env=env, stdin=subprocess.DEVNULL, capture_output=True,
+        )
+        assert result.returncode == 0
+        output = result.stdout.decode()
+        assert "confirmed merged" in output
+        assert "tier-a-branch" in output
+        assert "probable" in output.lower() or "would prompt" in output.lower()
+        assert "tier-b-branch" in output
+        assert "tier-c-branch" not in output
+
+    def test_existing_tier_a_silent_clean_preserved(self, tmp_path):
+        """Tier A branch (gh-confirmed merged) cleans silently, no prompt needed."""
+        local, remote = _make_repo_with_remote(tmp_path)
+        _make_feature_branch(local, "tier-a-branch")
+
+        shim_dir = tmp_path / "gh_shim_a"
+        shim_dir.mkdir()
+        shim_py = shim_dir / "gh"
+        shim_py.write_text(_gh_shim_source({"tier-a-branch": {"number": 1, "mergedAt": "2026-05-01"}}))
+        shim_py.chmod(0o755)
+        env = {**os.environ, "PATH": str(shim_dir) + ":" + os.environ.get("PATH", "")}
+
+        result = subprocess.run(
+            [str(_SCRIPT)], cwd=local,
+            env=env,
+            stdin=subprocess.DEVNULL, capture_output=True,
+        )
+        assert result.returncode == 0
+        branches = subprocess.run(
+            ["git", "branch"], cwd=local, capture_output=True, text=True
+        ).stdout
+        assert "tier-a-branch" not in branches
+        assert b"prompt" not in result.stdout.lower()
+
+    def test_dry_run_with_yes_flag_no_prompt(self, fake_gh, tmp_path):
+        """--dry-run --yes: tier B listed but nothing deleted, no prompt."""
+        local, remote = _make_repo_with_remote(tmp_path)
+        _make_tier_b_branch(local, remote, "tier-b-branch")
+        env = fake_gh({})
+        result = subprocess.run(
+            [str(_SCRIPT), "--dry-run", "--yes"], cwd=local,
+            env=env,
+            stdin=subprocess.DEVNULL, capture_output=True,
+        )
+        assert result.returncode == 0
+        branches = subprocess.run(
+            ["git", "branch"], cwd=local, capture_output=True, text=True
+        ).stdout
+        assert "tier-b-branch" in branches
+        output = result.stdout.decode()
+        assert "tier-b-branch" in output
+
+
+class TestLockedWorktreeLiveness:
+    """Live vs dead pid liveness check for locked worktrees."""
+
+    def test_locked_worktree_live_pid_skipped(self, tmp_path):
+        """Locked worktree with live pid (current process) is not removed."""
+        local, remote = _make_repo_with_remote(tmp_path)
+        _make_feature_branch(local, "locked-branch")
+        wt_path = tmp_path / "locked-wt"
+        _make_worktree(local, "locked-branch", wt_path)
+        subprocess.run(
+            ["git", "worktree", "lock", "--reason", f"test (pid {os.getpid()})", str(wt_path)],
+            cwd=local, check=True,
+        )
+
+        shim_dir = tmp_path / "gh_shim_live"
+        shim_dir.mkdir()
+        shim_py = shim_dir / "gh"
+        shim_py.write_text(_gh_shim_source({"locked-branch": {"number": 300, "mergedAt": "2026-05-01"}}))
+        shim_py.chmod(0o755)
+        env = {**os.environ, "PATH": str(shim_dir) + ":" + os.environ.get("PATH", "")}
+
+        result = subprocess.run(
+            [str(_SCRIPT), "--yes"], cwd=local,
+            env=env,
+            stdin=subprocess.DEVNULL, capture_output=True,
+        )
+        assert wt_path.exists()
+        output = result.stdout.decode()
+        assert "live" in output.lower() or "locked" in output.lower()
+
+    def test_locked_worktree_dead_pid_removed(self, tmp_path):
+        """Locked worktree with dead pid is unlocked and removed."""
+        local, remote = _make_repo_with_remote(tmp_path)
+        _make_feature_branch(local, "stale-locked-branch")
+        wt_path = tmp_path / "stale-wt"
+        _make_worktree(local, "stale-locked-branch", wt_path)
+        dead = _dead_pid()
+        subprocess.run(
+            ["git", "worktree", "lock", "--reason", f"test (pid {dead})", str(wt_path)],
+            cwd=local, check=True,
+        )
+
+        shim_dir = tmp_path / "gh_shim_dead"
+        shim_dir.mkdir()
+        shim_py = shim_dir / "gh"
+        shim_py.write_text(_gh_shim_source({"stale-locked-branch": {"number": 301, "mergedAt": "2026-05-01"}}))
+        shim_py.chmod(0o755)
+        env = {**os.environ, "PATH": str(shim_dir) + ":" + os.environ.get("PATH", "")}
+
+        result = subprocess.run(
+            [str(_SCRIPT), "--yes"], cwd=local,
+            env=env,
+            stdin=subprocess.DEVNULL, capture_output=True,
+        )
+        output = result.stdout.decode()
+        assert "stale" in output.lower() or "dead" in output.lower()


### PR DESCRIPTION
## Summary

- `gh pr list --head <branch>` misses merged branches whose commits reached `main` via a differently-named PR head (renamed branch, agent worktree prefix, closed-and-reshipped PR). This caused the local branch scan list to grow over time.
- Adds `git merge-base --is-ancestor` as a second detection signal. Tier A (gh-confirmed) deletes silently as before; Tier B (reachable-only) prompts for confirmation or auto-confirms with `--yes`.
- Non-TTY stdin without `--yes` skips Tier B with a warning — prevents hangs when invoked via piped/cron/Claude Code Bash tool.
- Locked worktrees now check the pid embedded in the lock reason before unlocking: live agent worktrees are skipped rather than torn down.

## Test plan

- [x] 37/37 tests pass (`pytest claude/.claude/scripts/tests/test_cleanup_merged_branches.py`)
- [x] `ruff check claude/.claude/scripts/` clean
- [ ] `cleanup-merged-branches --dry-run` on this repo shows current stale local branches (e.g. `decompose-hook-tests`, `worktree-skill-footprint-restructure`) under "Probable merges" section
- [ ] `cleanup-merged-branches --yes` cleans them without prompting
- [ ] `cleanup-merged-branches` (no flags, from a terminal) prompts per Tier B branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)