### PR TITLE
fix(plugins): remove duplicate hooks entry from skill-review plugin manifest

### DIFF
--- a/plugins/skill-review/.claude-plugin/plugin.json
+++ b/plugins/skill-review/.claude-plugin/plugin.json
@@ -1,10 +1,9 @@
 {
   "name": "skill-review",
   "description": "Behavioral-equivalence audit for SKILL.md changes. Gates git commit when staged changes include a SKILL.md. Primarily useful in claude-config itself where SKILL.md files are authored.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "Cordova Strategy"
   },
-  "skills": "./skills/",
-  "hooks": "./hooks/hooks.json"
+  "skills": "./skills/"
 }


### PR DESCRIPTION
## Summary

- The `skill-review` plugin manifest explicitly declared `"hooks": "./hooks/hooks.json"`, but Claude Code auto-loads `hooks/hooks.json` from the standard path for any plugin that contains one — causing a duplicate-load failure that prevented the plugin from initializing entirely.
- Removed the redundant `manifest.hooks` entry from `plugins/skill-review/.claude-plugin/plugin.json`; the file continues to be loaded via standard auto-loading.
- Bumped `version` to `1.0.1`.

`claude-hook-review`'s manifest was already correct (no `hooks` key) and is unchanged.

## Test plan

- [ ] Run `/doctor` and confirm the `skill-review@claude-config` plugin error is gone.
- [ ] Confirm `/skill-review` appears in the loaded skills list (not in the deficit listing).
- [ ] Smoke-test the gate: stage a no-op edit to any `SKILL.md` and attempt a commit — the `require-skill-review.sh` PreToolUse hook should block with the `/skill-review` instruction.
- [ ] `pytest claude/.claude/` — 682 tests pass (verified before PR).
- [ ] `ruff check claude/.claude/` — clean (verified before PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)