### PR TITLE
fix(install): wire claude-config marketplace registration for contributor onboarding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ CI runs both on every PR and main push. Both must pass before the PR can be revi
 
 ## Skill edits
 
-When editing a `SKILL.md`, invoke the skill on its own diff before committing. A skill edit can violate the rules it enforces — the skill is the reviewer of its own changes. Run `/skill-review` via the Skill tool and check the diff against its output before staging the file.
+When editing a `SKILL.md`, invoke the skill on its own diff before committing. A skill edit can violate the rules it enforces — the skill is the reviewer of its own changes. Run `/skill-review` via the Skill tool and check the diff against its output before staging the file. (`/skill-review` is provided by the `skill-review@claude-config` plugin, auto-enabled after `./install.sh` — see [docs/skills.md — Project-scoped plugins](./docs/skills.md#project-scoped-plugins).)
 
 ## Contact
 

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -209,6 +209,12 @@
         "source": "github",
         "repo": "anthropics/claude-plugins-official"
       }
+    },
+    "claude-config": {
+      "source": {
+        "source": "directory",
+        "path": ""
+      }
     }
   },
   "model": "opusplan",

--- a/install.sh
+++ b/install.sh
@@ -23,14 +23,21 @@ if [ -f "$SETTINGS_FILE" ]; then
   echo ""
   echo "=== Registering marketplaces from extraKnownMarketplaces ==="
   existing_marketplaces="$(claude plugin marketplace list --json 2>/dev/null | jq -r '.[].name')"
-  while IFS=$'\t' read -r name repo; do
+  while IFS=$'\t' read -r name source_type identifier; do
+    case "$source_type" in
+      directory) identifier="$REPO_DIR" ;;  # directory sources in stowed config are always self-referential
+      github)    : ;;
+      *)         echo "  ! $name: unknown source type '$source_type' — skipping"; continue ;;
+    esac
     if echo "$existing_marketplaces" | grep -qFx "$name"; then
       echo "  ✓ $name (already registered)"
     else
-      echo "  → adding $name ($repo)"
-      claude plugin marketplace add "$repo" --scope user
+      echo "  → adding $name ($identifier)"
+      claude plugin marketplace add "$identifier" --scope user
     fi
-  done < <(jq -r '.extraKnownMarketplaces // {} | to_entries[] | "\(.key)\t\(.value.source.repo)"' "$SETTINGS_FILE")
+  done < <(jq -r '.extraKnownMarketplaces // {} | to_entries[] |
+    "\(.key)\t\(.value.source.source)\t\(.value.source.repo // .value.source.path // "")"
+  ' "$SETTINGS_FILE")
 
   echo ""
   echo "=== Installing plugins from enabledPlugins ==="


### PR DESCRIPTION
## Summary

- **`install.sh`**: fixes the marketplace-registration loop — was reading `.value.source.repo` from `extraKnownMarketplaces`, which is absent for directory-source entries (jq emitted `null` → `claude plugin marketplace add null` failed silently). Replaces the single-field jq query with a three-column query (name, source type, identifier) and branches on source type: `directory` sources use `$REPO_DIR` (the checkout path of `install.sh`); `github` sources preserve existing behavior.
- **`claude/.claude/settings.json`**: adds a `claude-config` entry to `extraKnownMarketplaces` with `source.source: "directory"`. Was missing entirely — no auto-registration path existed for new contributors. `path: ""` satisfies the schema's required field; install.sh overrides it with `$REPO_DIR` at registration time.
- **`CONTRIBUTING.md`**: adds one-line pointer in "Skill edits" noting that `/skill-review` is provided by the `skill-review@claude-config` plugin (auto-enabled by `./install.sh`), with a link to docs/skills.md for the marketplace setup details.

## Root cause

PR #207 moved `skill-review` and `claude-hook-review` to project-scoped plugins auto-enabled via the project-local `.claude/settings.json`. That resolution requires the `claude-config` marketplace to be registered at user scope first. Without this fix, `./install.sh` silently failed to register it, contributors had no `/skill-review` available, and the first SKILL.md commit was blocked by `require-skill-review.sh` with no obvious recovery path.

## Upgrade notes

If you previously ran `./install.sh` and the `claude-config` marketplace is absent or pointing at a stale path, re-run: `claude plugin marketplace remove claude-config && ./install.sh`.

## Verification note

Before merging: confirm `path: ""` in the stowed `extraKnownMarketplaces.claude-config` entry does not produce a session-start warning in non-claude-config repos. Exposure is scoped (the matching `enabledPlugins` is project-local to the claude-config checkout, so other projects won't trigger a plugin-load attempt), but a smoke test on a fresh stow is recommended.

## Test plan

- [ ] Clone repo to a path other than the primary checkout (e.g., `/tmp/claude-config-test`). Run `./install.sh`. Confirm stdout includes `→ adding claude-config (/tmp/claude-config-test)` and no `null` failures.
- [ ] `claude plugin marketplace list` shows `claude-config` registered at the correct path.
- [ ] Idempotency: re-run `./install.sh` → `✓ claude-config (already registered)`.
- [ ] Open a Claude Code session in the test checkout. `/skill-review` appears in `/skills` and the commit gate fires correctly on a SKILL.md change.
- [ ] Open a session in an unrelated repo (after stow). No session-start warning about `claude-config` marketplace.
- [ ] `pytest claude/.claude/` passes.
- [ ] `ruff check claude/.claude/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)