### PR TITLE
feat(hooks): add chain-detection hint to deny-private-project-refs deny messages

### DIFF
--- a/claude/.claude/hooks/deny-private-project-refs.sh
+++ b/claude/.claude/hooks/deny-private-project-refs.sh
@@ -108,6 +108,19 @@
 # Allowlist extension: append to OSS_ALLOWLIST below if a legitimate
 # open-source prefix is blocked. Do NOT add private-project-specific
 # prefixes.
+#
+# Shape-aware deny hint.
+# ----------------------
+# When the command chains operations with && or ||, the deny messages
+# (both tracker-ID and private-projects branches) append a hint suggesting
+# the agent split the chain into separate Bash calls. Detection is
+# best-effort grep (not a real shell parser) — && and || in prose are
+# rare enough to justify detection; ; is excluded to avoid false positives
+# on prose semicolons. The hint is informational only — the deny condition
+# is unchanged. The "matched entry is intentionally NOT named" invariant
+# above is preserved: the hint uses placeholder examples (<name>), not
+# the matched token. Parallel to cwd_anchor_note_if_chained in
+# require-worktree-for-git-writes.sh.
 
 set -uo pipefail
 
@@ -313,6 +326,21 @@ is_pseudo_file_path() {
   esac
 }
 
+# Detect && / || chain operators in the command and append a corrective
+# hint to deny messages when the chain shape is present. ; is excluded —
+# it appears too often in English prose (commit messages, PR descriptions)
+# to be useful as a chain signal. Detection is best-effort grep: && or ||
+# inside a string-quoted region (e.g. --body "use && to chain") would
+# still trigger the hint (known false positive).
+chain_split_hint_if_chained() {
+  if printf '%s' "$1" | grep -qE '&&|\|\|'; then
+    # $1 is used as a grep predicate only — intentionally not echoed.
+    # Echoing any part of $COMMAND would risk re-exposing the matched
+    # blocklist entry (see header "Invariant" note).
+    printf '%s' " Tip: this command chains operations with && / ||. If the matched token is in a path or setup portion of the chain (e.g. a \`cd /home/<name>/...\` prefix) and is NOT actually a private-project reference in the gated content, split the chain into two separate Bash calls — the cwd persists between calls in the same session, so running \`cd /path\` as one call and the gated command as a follow-up call keeps the path out of the gated command's text. If the match IS a real private-project reference in the gated content (PR body, commit message, gh api body), the chain-split won't help — rewrite the content instead. The match-anywhere foundation is intentional; see the hook header for design rationale."
+  fi
+}
+
 # Each content surface that could carry a tracker ID is appended here
 # separately so a future change won't silently drop coverage of one.
 SCAN_TARGET=""
@@ -462,7 +490,7 @@ HITS=$(printf '%s' "$SCAN_TARGET" \
 if [ -n "$HITS" ]; then
   # Report the first few offenders to keep the message short.
   HIT_LIST=$(printf '%s' "$HITS" | head -5 | tr '\n' ' ' | sed 's/ $//')
-  emit_deny "Commit blocked by redaction gate: the staged diff, commit message, referenced commit-message file, PR title, PR body, referenced body-source file, gh api request body, or referenced --input file contains tracker-ID tokens that may reveal a private project: ${HIT_LIST}. See repo CLAUDE.md section 'Redact private-project-identifying content'. If the match is an open-source reference or technical constant not on the allowlist, add the prefix to the OSS_ALLOWLIST variable in ~/.claude/hooks/deny-private-project-refs.sh. Otherwise rewrite the commit message / staged content / PR body / gh api body without the tracker ID before retrying."
+  emit_deny "Commit blocked by redaction gate: the staged diff, commit message, referenced commit-message file, PR title, PR body, referenced body-source file, gh api request body, or referenced --input file contains tracker-ID tokens that may reveal a private project: ${HIT_LIST}. See repo CLAUDE.md section 'Redact private-project-identifying content'. If the match is an open-source reference or technical constant not on the allowlist, add the prefix to the OSS_ALLOWLIST variable in ~/.claude/hooks/deny-private-project-refs.sh. Otherwise rewrite the commit message / staged content / PR body / gh api body without the tracker ID before retrying.$(chain_split_hint_if_chained "$COMMAND")"
   exit 0
 fi
 
@@ -487,7 +515,7 @@ if [ -r "$PRIVATE_PROJECTS_FILE" ]; then
     if printf '%s' "$SCAN_TARGET" | grep -qiw -F -- "$line"; then
       # Generic message — see header "Invariant" note. The matched
       # entry is intentionally NOT named.
-      emit_deny "Blocked by redaction gate: the staged diff, commit message, referenced commit-message file, PR title, PR body, referenced body-source file, gh api request body, or referenced --input file contains an entry from your ~/.claude/private-projects.md blocklist. Review the content and remove the project name before retrying. (The hook deliberately does not name which entry matched — printing it would re-expose the value in terminal output, CI logs, and Claude's conversation context, which is exactly what this gate exists to prevent.) See repo CLAUDE.md section 'Redact private-project-identifying content'."
+      emit_deny "Blocked by redaction gate: the staged diff, commit message, referenced commit-message file, PR title, PR body, referenced body-source file, gh api request body, or referenced --input file contains an entry from your ~/.claude/private-projects.md blocklist. Review the content and remove the project name before retrying. (The hook deliberately does not name which entry matched — printing it would re-expose the value in terminal output, CI logs, and Claude's conversation context, which is exactly what this gate exists to prevent.) See repo CLAUDE.md section 'Redact private-project-identifying content'.$(chain_split_hint_if_chained "$COMMAND")"
       exit 0
     fi
   done < "$PRIVATE_PROJECTS_FILE"

--- a/claude/.claude/hooks/tests/test_deny_private_project_refs.py
+++ b/claude/.claude/hooks/tests/test_deny_private_project_refs.py
@@ -1806,3 +1806,84 @@ class TestDenyPrivateProjectRefs:
             )
             == "deny"
         )
+
+    # -- Shape-aware chain-detection hint ------------------------------------
+    # When the command chains operations with && or ||, deny messages
+    # append a hint suggesting the agent split the chain into separate
+    # Bash calls. Detection is best-effort grep — ; is excluded to avoid
+    # false positives on prose semicolons.
+
+    def test_tracker_id_chained_command_deny_includes_chain_hint(self, claude_config_repo):
+        """Chained cd && git commit: chain detected, hint appended to deny."""
+        result = subprocess.run(
+            [str(DENY_PRIVATE_PROJECT_REFS_HOOK)],
+            input=json.dumps(bash_input(
+                "cd /home/username/mycode && git commit -m 'WIDGET-123 fix'"
+            )),
+            capture_output=True,
+            text=True,
+            cwd=claude_config_repo,
+            check=False,
+        )
+        payload = json.loads(result.stdout)
+        assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
+        reason = payload["hookSpecificOutput"]["permissionDecisionReason"]
+        assert "Tip: this command chains" in reason
+
+    def test_blocklist_chained_command_deny_includes_chain_hint(self, claude_config_repo, private_projects_file):
+        """Chained cd && gh pr create: blocklist match + chain detected, hint appended."""
+        private_projects_file("Acme Corp\n")
+        result = subprocess.run(
+            [str(DENY_PRIVATE_PROJECT_REFS_HOOK)],
+            input=json.dumps(bash_input(
+                "cd /home/username/mycode && gh pr create --body 'Acme Corp integration work'"
+            )),
+            capture_output=True,
+            text=True,
+            cwd=claude_config_repo,
+            check=False,
+        )
+        payload = json.loads(result.stdout)
+        assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
+        reason = payload["hookSpecificOutput"]["permissionDecisionReason"]
+        assert "Tip: this command chains" in reason
+        # The "matched entry NOT named" invariant must hold even with the chain hint appended.
+        assert "Acme Corp" not in reason
+        assert "acme corp" not in reason.lower()
+
+    def test_tracker_id_unchained_command_deny_omits_chain_hint(self, claude_config_repo):
+        """Unchained command: deny fires for tracker-ID, but no chain hint."""
+        result = subprocess.run(
+            [str(DENY_PRIVATE_PROJECT_REFS_HOOK)],
+            input=json.dumps(bash_input(
+                "git commit -m 'Fix WIDGET-123 regression'"
+            )),
+            capture_output=True,
+            text=True,
+            cwd=claude_config_repo,
+            check=False,
+        )
+        payload = json.loads(result.stdout)
+        assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
+        reason = payload["hookSpecificOutput"]["permissionDecisionReason"]
+        assert "Tip: this command chains" not in reason
+
+    def test_chain_hint_not_emitted_for_semicolon_in_message(self, claude_config_repo):
+        """Semicolons in prose (commit message body) do not trigger the chain hint.
+        Best-effort: the helper detects && and || only, excluding ; to avoid
+        false positives on prose semicolons. This is a known design tradeoff;
+        see the chain_split_hint_if_chained helper comment."""
+        result = subprocess.run(
+            [str(DENY_PRIVATE_PROJECT_REFS_HOOK)],
+            input=json.dumps(bash_input(
+                "git commit -m 'Fix WIDGET-123; also update docs'"
+            )),
+            capture_output=True,
+            text=True,
+            cwd=claude_config_repo,
+            check=False,
+        )
+        payload = json.loads(result.stdout)
+        assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
+        reason = payload["hookSpecificOutput"]["permissionDecisionReason"]
+        assert "Tip: this command chains" not in reason


### PR DESCRIPTION
## Summary

- Adds `chain_split_hint_if_chained()` helper to `deny-private-project-refs.sh` that detects `&&`/`||` chains in the Bash command and appends a corrective hint to both deny messages (tracker-ID branch and private-projects branch)
- The hint suggests splitting the chain into two separate Bash calls so a blocklisted token in a `cd /home/<name>/...` setup prefix doesn't appear in the gated command text
- Hint uses `<name>` placeholder — the \"matched entry NOT named\" invariant is preserved and explicitly tested in the new chained-blocklist test
- Mirrors the existing `cwd_anchor_note_if_chained` pattern in `require-worktree-for-git-writes.sh`
- 4 new tests: chained+tracker hint, chained+blocklist hint (with invariant assertion), unchained no-hint, semicolon-in-message no-hint

## Background

During PR #209, the redaction gate fired when `cd /home/<name>/... && gh pr create ...` was used and the user's name in the path matched their `~/.claude/private-projects.md` blocklist. The correct fix is not to weaken the match-anywhere foundation but to detect the chain shape and guide the agent toward the split-call workaround.

## Design decisions

- `&&`/`||` only — `;` excluded because it appears too often in English prose (commit messages, PR descriptions) to be a reliable chain signal
- Detection is best-effort grep (not a shell parser) — `&&` inside a quoted string body is a known false positive, documented in the helper comment
- Deny conditions unchanged — this is purely a UX improvement to the deny message

## Test plan

- [x] 698 tests pass (`pytest claude/.claude/`)
- [x] Ruff clean (`ruff check claude/.claude/`)
- [ ] Smoke test: from a worktree, run `cd /home/<your-name>/... && gh pr create --base main --head <branch> --title "..." --body "..."` with a blocklisted token in the path — deny message should include the chain-split hint
- [ ] Negative: `gh pr create` with a blocklisted token in the body and no chain operator — deny message should NOT include the hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)