### PR TITLE
feat(skills): mark command-style skills as disable-model-invocation

### DIFF
--- a/claude/.claude/commands/handoff.md
+++ b/claude/.claude/commands/handoff.md
@@ -1,3 +1,8 @@
+---
+description: Write a cross-session handoff file at /tmp/<descriptive-slug>-handoff.md.
+disable-model-invocation: true
+---
+
 Write a cross-session handoff file at `/tmp/<descriptive-slug>-handoff.md` using the structure below.
 
 ## §1 Goal

--- a/claude/.claude/commands/read-docx-comments.md
+++ b/claude/.claude/commands/read-docx-comments.md
@@ -1,5 +1,6 @@
 ---
 argument-hint: "<path/to/file.docx>"
+disable-model-invocation: true
 ---
 
 Extract all comments from the provided .docx file. The user uses this to give feedback on plans and documents by adding comments in Google Docs / Word.

--- a/claude/.claude/skills/plan-it/SKILL.md
+++ b/claude/.claude/skills/plan-it/SKILL.md
@@ -1,12 +1,7 @@
 ---
 name: plan-it
-description: >
-  Produces an implementation plan and hands off to /plan-review.
-  TRIGGER when asked for a plan or implementation strategy
-  for work spanning multiple files or domains. DO NOT TRIGGER for
-  single-file tweaks, "just implement it" requests, or when a plan
-  already exists (use /plan-review instead).
-user-invocable: true
+description: Produce an implementation plan for a feature or bug fix.
+disable-model-invocation: true
 argument-hint: "[optional topic or ticket id]"
 ---
 


### PR DESCRIPTION
## Summary

- `plan-it`: replaces `user-invocable: true` (default, was always model-invocable) with `disable-model-invocation: true`; updates description to user-facing summary since TRIGGER routing text is dead weight when the description is no longer loaded into Claude's context
- `commands/handoff.md`: adds frontmatter with `disable-model-invocation: true` (was missing any frontmatter, making it model-invocable)
- `commands/read-docx-comments.md`: adds `disable-model-invocation: true` to existing frontmatter

## Why

Per the Claude Code skills docs, skills without `disable-model-invocation: true` have their descriptions loaded into every session so Claude can auto-invoke them. These three are user-controlled workflows — Claude should not decide to run them; the user must type `/skill-name` explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)