### PR TITLE
feat: disable update-config built-in, promote two memories to durable surfaces

### DIFF
--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -57,6 +57,7 @@ If the subagent reports a check was blocked by permissions, do NOT fall back to 
 - Never write `~/.claude/*-markers/*` by hand. Each review skill writes its own marker directory (`/code-review` → `review-markers/`, `/plan-review` → `plan-review-markers/`, etc.) when a review passes, and pre-commit hooks gate on their presence. If a commit is blocked, run the review skill the hook names; if the skill is harness-blocked, spawn a subagent that can run it. A general "ship it" instruction is not authorization to forge a marker.
 - If a skill's active-bypass gate refuses to release after the skill has finished, run `~/.claude/scripts/marker.sh clear-stale` to evict orphaned active markers from dead sessions.
 - Don't add globs (`Bash(pytest *)`, `Bash(npm run *)`) to `permissions.allow`. Globs widen the surface to flag injection, command chaining, and shell-expansion attacks — see `claude/.claude/skills/review-permissions/SKILL.md` checklist items 1–9. Use exact-match rules (`Bash(pytest)`, `Bash(npm run verify)`) instead.
+- `.claude/settings.json` vs `.claude/settings.local.json` scoping: project-shared rules (permissions, hooks, skillOverrides that every engineer on the project needs) go in committed `.claude/settings.json`. Personal-machine-only rules (per-machine tooling, individual preferences) go in gitignored `.claude/settings.local.json`. Before adding a rule, ask: would another engineer on this project need this? If yes → `settings.json`. If no → `settings.local.json`.
 
 ## Code Comments and Durable Documentation
 

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -201,7 +201,8 @@
     "keybindings-help": "off",
     "review": "off",
     "security-review": "off",
-    "simplify": "off"
+    "simplify": "off",
+    "update-config": "off"
   },
   "extraKnownMarketplaces": {
     "claude-plugins-official": {

--- a/claude/.claude/skills/review-permissions/REFERENCES.md
+++ b/claude/.claude/skills/review-permissions/REFERENCES.md
@@ -37,3 +37,36 @@ They are deliberately absent from the global allow list because:
 
 Do not reintroduce these to the stowed global allow list without re-evaluating
 the trust boundary.
+
+## Allowing privileged scripts — three-layer strict-shape pattern
+
+Claude Code permission rules are glob-only (no regex, no alternation, no
+`{a,b}`). Chain segments evaluate independently (`safe-cmd && evil-cmd`
+lets the first segment through silently while prompting on the second).
+Deny rules cannot carve out exceptions: a deny like `Bash(<script> *)`
+matches everything including the valid shapes (deny runs before allow;
+allow is never reached). Without further enforcement, any shape outside
+the explicit allow list **prompts** the user — prompt fatigue leads to
+absent-minded approvals.
+
+When you legitimately need to allow a privileged script, use all three
+layers:
+
+1. **`settings.json` `permissions.allow`** — exact-string `Bash(...)`
+   entries for each valid invocation shape (no trailing `*`). Ships to
+   all stow users. Achieves silent auto-approval for known-good forms.
+2. **Dedicated `PreToolUse:Bash` hook** — fast-exit 0 if the script name
+   doesn't appear; otherwise match the full command string against
+   anchored regex patterns for the N valid shapes. Exit 2 + usage on
+   stderr for anything else. Do not include attacker-controlled bytes
+   verbatim in the error message (truncate to 80 chars).
+3. **Script's own arg validation** — `case` whitelist with explicit
+   mismatched-combination rejection. Third independent layer; holds if
+   the hook is bypassed.
+
+For trivial scripts that call only absolute paths and do not exec
+untrusted input, layer 3 alone may be sufficient — see the
+`cleanup-merged-branches` decision above for that case.
+
+Verified against the official permissions docs at
+`code.claude.com/docs/en/permissions.md`.

--- a/claude/.claude/skills/review-permissions/SKILL.md
+++ b/claude/.claude/skills/review-permissions/SKILL.md
@@ -190,11 +190,11 @@ assume `Bash(cmd:*)` matches the entire command string, not just arguments.
 
 ## Output format
 
-For each finding, state:
+State each finding as: rule → checklist item (by number and name) → attack vector (a concrete exploiting command) → suggested fix (tighter rule or alternative). If no issues are found, say: "No issues found."
+## Allowing privileged scripts
 
-1. **Which rule** — the exact `permissions.allow` entry
-2. **Which checklist item** (by number and name)
-3. **Attack vector** — a concrete command that exploits the rule
-4. **Suggested fix** — a tighter rule or alternative approach
-
-If no issues are found, say: "No issues found."
+When an allow rule covers a custom script (not a standard tool), confirm
+the **three-layer strict-shape pattern** is in place: exact-string allow
+entries + dedicated `PreToolUse:Bash` hook + script-internal arg
+validation. See `REFERENCES.md` — "Allowing privileged scripts" for the
+full pattern and rationale.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -25,7 +25,7 @@ Each skill lives in `claude/.claude/skills/<skill-name>/SKILL.md`. A skill direc
 
 ## Bundled skills disabled by default
 
-Claude Code ships a set of bundled skills alongside its custom-skill support. Seven bundled skills are disabled in this repo's `settings.json` via `skillOverrides: "off"`. The reason in each case is either redundancy with a more capable repo-specific skill or low utility relative to the description-budget cost. All skill descriptions contribute to the `skillListingBudgetFraction` context allocation; `/doctor` reports a warning when the budget overflows and descriptions are dropped. The disabled skills freed budget for the always-relevant `user-invocable: false` skills that auto-trigger during the engineering workflow.
+Claude Code ships a set of bundled skills alongside its custom-skill support. Eight bundled skills are disabled in this repo's `settings.json` via `skillOverrides: "off"`. The reason in each case is either redundancy with a more capable repo-specific skill or low utility relative to the description-budget cost. All skill descriptions contribute to the `skillListingBudgetFraction` context allocation; `/doctor` reports a warning when the budget overflows and descriptions are dropped. The disabled skills freed budget for the always-relevant `user-invocable: false` skills that auto-trigger during the engineering workflow.
 
 | Bundled skill | Why disabled |
 |---|---|
@@ -36,6 +36,7 @@ Claude Code ships a set of bundled skills alongside its custom-skill support. Se
 | `/review` | "Review a PR" — superseded by `/code-review` (specialist reviewer routing) and `/ultrareview`. |
 | `/security-review` | Superseded by `/code-review` specialist routing (ciso-reviewer agent fires automatically). |
 | `/simplify` | Overlaps with `/code-review`, which spins up domain specialists and produces a structured checklist. |
+| `/update-config` | Bundled generic settings.json editor. Redundant with `/review-permissions` (permissions.allow), `/claude-hook-review` (hooks), and `/skill-review` (skill bodies); remaining env/model/theme edits are trivial direct file changes. |
 
 ### Re-enable for your session
 


### PR DESCRIPTION
## Summary

- Disable the `update-config` built-in skill via `skillOverrides: "off"` — its ~1,100-char description was the largest single contributor to the skill-listing budget overflow that caused `git-state-safety` to appear with no description in the available-skills system reminder
- `update-config`'s high-value territory is already covered by focused skills: `review-permissions` (permissions.allow), `claude-hook-review` (hooks), `skill-review` (skill bodies); remaining env/model/theme edits are trivial direct file changes
- Update `docs/skills.md`: bump disabled-skill count to eight, add rationale row for `update-config`
- Promote permission-grammar + three-layer strict-shape pattern from memory into `review-permissions/REFERENCES.md` (full pattern) + a one-line gloss in `review-permissions/SKILL.md` (cross-reference)
- Promote `settings.json` vs `settings.local.json` scoping rule from memory into `claude/.claude/CLAUDE.md` Safety section (applies to all projects, not just claude-config)
- Deleted the two promoted memory files + removed their MEMORY.md index lines (memory is for personal preferences, not load-bearing engineering rules per existing `feedback_memory_vs_claude_md_classification` guidance)

## Test plan

- [ ] JSON sanity: `python3 -c "import json; json.load(open('claude/.claude/settings.json'))"`
- [ ] Docs row count: `grep -c '^| /' docs/skills.md` → 8
- [ ] Promoted content: `grep -n "three-layer strict-shape" claude/.claude/skills/review-permissions/SKILL.md claude/.claude/skills/review-permissions/REFERENCES.md` → hits in both
- [ ] Settings split rule: `grep -n "settings.local.json" claude/.claude/CLAUDE.md` → at least one hit
- [ ] Fresh session: `update-config` absent from available-skills list; `loop` and `schedule` still present
- [ ] Fresh session: `git-state-safety` shows its full TRIGGER / DO NOT TRIGGER description (the truncation symptom this PR fixes)
- [ ] `/doctor` quiet on skill-listing budget in fresh session

🤖 Generated with [Claude Code](https://claude.com/claude-code)