### PR TITLE
fix(review-permissions): remove stale update-config reference

### DIFF
--- a/claude/.claude/skills/review-permissions/SKILL.md
+++ b/claude/.claude/skills/review-permissions/SKILL.md
@@ -7,7 +7,7 @@ description: >
   or allowed commands.
   DO NOT TRIGGER when: reviewing hook entries in settings.json (use
   `claude-hook-review`); reviewing other settings.json fields — env,
-  model, theme (use `update-config`); reviewing Bash command behavior
+  model, theme; reviewing Bash command behavior
   that is unrelated to permissions scoping.
 allowed-tools: Read, Grep, Glob, Bash
 user-invocable: false


### PR DESCRIPTION
`update-config` was disabled in #223; the `(use `update-config`)` parenthetical in the DO NOT TRIGGER description pointed to a skill that no longer fires.

One-word removal — no behavioral change to the skill's logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)