### PR TITLE
feat(config): enforce skillOverrides coverage, add hook/plugin routing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,8 +39,24 @@ committed file directly via PR.
 **Hook defense-in-depth:** Hooks must filter their own input by tool
 name and matcher; do not rely solely on settings.json `if` conditions.
 
+**Should this be a hook?** When the user asks for an automated or
+recurring behavior — "from now on when X…", "each time X…", "whenever
+X…", "before/after X…" — the answer is a hook configured in
+`.claude/settings.json`, not a memory or a skill instruction. The
+harness executes hooks; nothing in memory or a CLAUDE.md prose rule can
+fulfill an automatic-trigger request. Route to the `claude-hook-review`
+skill for hook design and review.
+
 **Plugin config:** `enabledPlugins` only takes effect in
 `settings.json`, not `settings.local.json`.
+
+**Disabling a plugin: `false` vs. removing the entry.** In this repo's
+committed `claude/.claude/settings.json`, `enabledPlugins[name]: false`
+is reserved for plugins kept as quick-flip handles for occasional
+re-enable. Plugins with no foreseeable re-enable use case are removed
+from the map entirely. Don't propose `false` reflexively as the
+disable-pattern — it smuggles in a re-enable affordance the user may
+not want to extend. Mirror existing entries when in doubt.
 
 **No shared partials across skills — but co-located auxiliary files are distinct.** `SKILL.md` frontmatter has no `includes:`, `import:`, or `extends:` fields; the `@path` import syntax works in `CLAUDE.md` only, not in `SKILL.md`. When two skills need the same rule text, duplicate it into both skill files intentionally — do not extract it into a `_shared/` directory or similar abstraction. Duplication keeps each skill independently readable and prevents brittle cross-skill coupling. A skill directory may contain co-located auxiliary files (`REFERENCES.md` for edit-time reference; a runtime auxiliary like `plan-review/ROUTING.md` — an exception for load-bearing content that cannot be shortened, not a routine response to hitting the length cap) — these belong to one skill and are not cross-skill sharing. See [`docs/skills.md` — Skill architecture notes](docs/skills.md#skill-architecture-notes) for the full breakdown.
 

--- a/claude/.claude/skills/tests/test_skills.py
+++ b/claude/.claude/skills/tests/test_skills.py
@@ -28,6 +28,7 @@ Run with: pytest claude/.claude/
 """
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -250,4 +251,18 @@ class TestModelInvokableSkillTriggerContracts:
         assert "DO NOT TRIGGER when:" in desc, (
             f"{skill_name}/SKILL.md description is missing 'DO NOT TRIGGER when:' block; "
             f"add it or set disable-model-invocation: true if this skill should not auto-load"
+        )
+
+
+def test_skill_overrides_documented_in_docs_skills_md() -> None:
+    """Every disabled bundled skill in skillOverrides must have a row in docs/skills.md."""
+    repo_root = Path(__file__).resolve().parents[4]
+    settings = json.loads((repo_root / "claude/.claude/settings.json").read_text())
+    docs_text = (repo_root / "docs/skills.md").read_text()
+    for skill_name in settings.get("skillOverrides", {}):
+        marker = f"| `/{skill_name}` |"
+        assert marker in docs_text, (
+            f"skillOverrides has {skill_name!r} but docs/skills.md has no "
+            f"`{marker}` row. Every disabled bundled skill needs a rationale "
+            'row in the "Bundled skills disabled by default" table.'
         )


### PR DESCRIPTION
## Summary

- Adds a static pytest contract that every `skillOverrides` key in `claude/.claude/settings.json` has a matching row in the "Bundled skills disabled by default" table in `docs/skills.md` — turning the convention from prose discipline into a mechanical gate
- Adds a **Should this be a hook?** bullet to repo `CLAUDE.md` that routes automated/recurring-behavior requests to `claude-hook-review`, replacing routing guidance previously carried by the now-disabled `update-config` built-in
- Adds a **Disabling a plugin: `false` vs. removing the entry.** bullet to repo `CLAUDE.md` that codifies the `enabledPlugins` disable-style convention, promoted from machine-local memory to durable contributor instructions; deletes the now-superseded memory file

## Test plan

- [ ] `pytest claude/.claude/skills/tests/test_skills.py::test_skill_overrides_documented_in_docs_skills_md -v` passes
- [ ] Temporarily remove a row from the "Bundled skills disabled by default" table in `docs/skills.md` and re-run — test fails naming the missing skill; restore row
- [ ] `pytest claude/.claude/` green end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)