### PR TITLE
feat(lovable-cloud): disable model auto-routing on migration-sync skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "lovable-cloud",
       "description": "Skills for Lovable Cloud projects — Project/Workspace Knowledge fields, edge-function auth model, and migration-sync workflow.",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "author": {
         "name": "Cordova Strategy"
       },

--- a/plugins/lovable-cloud/.claude-plugin/plugin.json
+++ b/plugins/lovable-cloud/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lovable-cloud",
   "description": "Skills for Lovable Cloud projects — Project/Workspace Knowledge fields, edge-function auth model, and migration-sync workflow.",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": {
     "name": "Cordova Strategy"
   },

--- a/plugins/lovable-cloud/skills/lovable-cloud-migration-sync/SKILL.md
+++ b/plugins/lovable-cloud/skills/lovable-cloud-migration-sync/SKILL.md
@@ -5,6 +5,7 @@ description: >
   TRIGGER when: the user signals Lovable's migration apply step completed, regardless of exact wording.
   DO NOT TRIGGER when: all originals already deleted, or user asks about mechanics without signaling completion.
 user-invocable: true
+disable-model-invocation: true
 ---
 
 # Lovable Migration Sync


### PR DESCRIPTION
## Summary

- Add `disable-model-invocation: true` to `lovable-cloud-migration-sync` frontmatter
- Skill remains `user-invocable: true` — engineers can still invoke `/lovable-cloud-migration-sync` explicitly
- Frees ~200 tokens of skill-listing budget so the `lovable-cloud-edge-functions` description is no longer dropped
- Bump plugin version 2.0.0 → 2.1.0 (plugin cache is version-keyed — consuming projects need the version change to pick up the update)

## Context

`lovable-cloud-migration-sync` fires after a human pastes a message into Lovable's chat and Lovable commits duplicate migrations. Auto-routing has low value here because the human is already in the loop. The PR-comment checkbox in the consuming project now carries the nudge instead.

## Test plan
- [ ] In a fresh Claude Code session, run `/doctor` and confirm `lovable-cloud:lovable-cloud-migration-sync` no longer appears in the dropped-descriptions list
- [ ] Confirm `/lovable-cloud-migration-sync` autocomplete still appears in the slash-command picker (user-invocable path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)