### PR TITLE
fix(cleanup-merged-branches): surface git stderr on worktree remove failure

### DIFF
--- a/claude/.claude/scripts/cleanup-merged-branches.sh
+++ b/claude/.claude/scripts/cleanup-merged-branches.sh
@@ -363,13 +363,17 @@ for BRANCH in "${TO_DELETE[@]}"; do
         echo "    worktree:       unlocked stale lock (pid ${WORKTREE_LOCK_PID} dead)"
       fi
     fi
-    if git worktree remove "$WORKTREE_PATH" 2>/dev/null; then
+    WORKTREE_REMOVE_OUTPUT=
+    if WORKTREE_REMOVE_OUTPUT=$(git worktree remove "$WORKTREE_PATH" 2>&1); then
       echo "    worktree:       removed: ${WORKTREE_PATH}"
     else
       if [ "$WORKTREE_LOCKED" -eq 1 ]; then
         git worktree lock "$WORKTREE_PATH" 2>/dev/null || true
       fi
       echo "    worktree:       remove failed (manual step needed)"
+      if [ -n "$WORKTREE_REMOVE_OUTPUT" ]; then
+        printf '%s\n' "$WORKTREE_REMOVE_OUTPUT" | sed 's/^/                    /'
+      fi
       continue
     fi
   else

--- a/claude/.claude/scripts/tests/test_cleanup_merged_branches.py
+++ b/claude/.claude/scripts/tests/test_cleanup_merged_branches.py
@@ -719,6 +719,7 @@ class TestLockedWorktreeRemoveFailsCleanly:
         assert result.returncode == 0
         assert "unlocked stale lock" in result.stdout
         assert "remove failed (manual step needed)" in result.stdout
+        assert "contains modified or untracked files" in result.stdout
         # Worktree dir and its content must survive
         assert wt_path.exists()
         assert (wt_path / "leftover.txt").exists()


### PR DESCRIPTION
## Summary

- Replaces `git worktree remove "$WORKTREE_PATH" 2>/dev/null` with a stderr-capturing form so the git diagnostic (e.g. `fatal: '...' contains modified or untracked files, use --force to delete it`) is printed indented beneath the existing "remove failed (manual step needed)" line instead of being swallowed
- Adds `WORKTREE_REMOVE_OUTPUT=` before the `if` block to prevent a stale value from a failed removal printing on a subsequent successful iteration
- Updates `test_locked_dirty_worktree_is_refused_and_relocked` to assert the git error text appears in script output (enforces the new convention per CLAUDE.md)

The sibling `worktree unlock` and re-`worktree lock` calls keep `2>/dev/null` — they're best-effort fixups whose stderr would add noise to the success path.

## Test plan

- [x] `pytest claude/.claude/scripts/tests/test_cleanup_merged_branches.py -k locked_dirty_worktree -v` — passes with new assertion
- [x] Full suite: `pytest claude/.claude/ -x -q` — 748 tests pass
- [x] `ruff check claude/.claude/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)