### PR TITLE
fix(settings): restore pytest/ruff allow rules lost in duplicate-permissions collapse

### DIFF
--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -1,9 +1,52 @@
 {
   "permissions": {
     "allow": [
+      "Bash(~/.claude/scripts/marker.sh write code-review)",
+      "Bash(~/.claude/scripts/marker.sh write skill-review)",
+      "Bash(~/.claude/scripts/marker.sh write plan-review)",
+      "Bash(~/.claude/scripts/marker.sh write ready-for-review)",
+      "Bash(~/.claude/scripts/marker.sh activate plan-review)",
+      "Bash(~/.claude/scripts/marker.sh activate ready-for-review)",
+      "Bash(~/.claude/scripts/marker.sh activate respond-pr)",
+      "Bash(~/.claude/scripts/marker.sh deactivate plan-review)",
+      "Bash(~/.claude/scripts/marker.sh deactivate ready-for-review)",
+      "Bash(~/.claude/scripts/marker.sh deactivate respond-pr)",
+      "Bash(~/.claude/scripts/marker.sh activate memory-skill)",
+      "Bash(~/.claude/scripts/marker.sh deactivate memory-skill)",
+      "Bash(~/.claude/scripts/cleanup-merged-branches.sh)",
+      "Bash(~/.claude/scripts/cleanup-merged-branches.sh --dry-run)",
+      "Bash(cleanup-merged-branches)",
+      "Bash(cleanup-merged-branches --dry-run)",
       "Bash(pytest claude/.claude/)",
       "Bash(ruff check claude/.claude/)"
+    ],
+    "deny": [
+      "Bash(sudo *)",
+      "Bash(sudo)",
+      "Read(**/.env)",
+      "Read(**/.env.local)",
+      "Read(**/.env.local.*)",
+      "Read(**/.env.production)",
+      "Read(**/.env.production.*)",
+      "Read(**/.env.development)",
+      "Read(**/.env.development.*)",
+      "Read(**/.env.staging)",
+      "Read(**/.env.staging.*)",
+      "Read(**/.env.test)",
+      "Read(**/.env.test.*)",
+      "Read(**/credentials.json)"
     ]
+  },
+  "model": "opusplan",
+  "skillOverrides": {
+    "claude-api": "off",
+    "fewer-permission-prompts": "off",
+    "init": "off",
+    "keybindings-help": "off",
+    "review": "off",
+    "security-review": "off",
+    "simplify": "off",
+    "update-config": "off"
   },
   "hooks": {
     "SessionStart": [
@@ -200,65 +243,12 @@
     "claude-md-management@claude-plugins-official": false,
     "claude-code-setup@claude-plugins-official": false
   },
-  "skillOverrides": {
-    "claude-api": "off",
-    "fewer-permission-prompts": "off",
-    "init": "off",
-    "keybindings-help": "off",
-    "review": "off",
-    "security-review": "off",
-    "simplify": "off",
-    "update-config": "off"
-  },
   "extraKnownMarketplaces": {
     "claude-plugins-official": {
       "source": {
         "source": "github",
         "repo": "anthropics/claude-plugins-official"
       }
-    },
-    "claude-config": {
-      "source": {
-        "source": "directory",
-        "path": ""
-      }
     }
-  },
-  "model": "opusplan",
-  "permissions": {
-    "allow": [
-      "Bash(~/.claude/scripts/marker.sh write code-review)",
-      "Bash(~/.claude/scripts/marker.sh write skill-review)",
-      "Bash(~/.claude/scripts/marker.sh write plan-review)",
-      "Bash(~/.claude/scripts/marker.sh write ready-for-review)",
-      "Bash(~/.claude/scripts/marker.sh activate plan-review)",
-      "Bash(~/.claude/scripts/marker.sh activate ready-for-review)",
-      "Bash(~/.claude/scripts/marker.sh activate respond-pr)",
-      "Bash(~/.claude/scripts/marker.sh deactivate plan-review)",
-      "Bash(~/.claude/scripts/marker.sh deactivate ready-for-review)",
-      "Bash(~/.claude/scripts/marker.sh deactivate respond-pr)",
-      "Bash(~/.claude/scripts/marker.sh activate memory-skill)",
-      "Bash(~/.claude/scripts/marker.sh deactivate memory-skill)",
-      "Bash(~/.claude/scripts/cleanup-merged-branches.sh)",
-      "Bash(~/.claude/scripts/cleanup-merged-branches.sh --dry-run)",
-      "Bash(cleanup-merged-branches)",
-      "Bash(cleanup-merged-branches --dry-run)"
-    ],
-    "deny": [
-      "Bash(sudo *)",
-      "Bash(sudo)",
-      "Read(**/.env)",
-      "Read(**/.env.local)",
-      "Read(**/.env.local.*)",
-      "Read(**/.env.production)",
-      "Read(**/.env.production.*)",
-      "Read(**/.env.development)",
-      "Read(**/.env.development.*)",
-      "Read(**/.env.staging)",
-      "Read(**/.env.staging.*)",
-      "Read(**/.env.test)",
-      "Read(**/.env.test.*)",
-      "Read(**/credentials.json)"
-    ]
   }
 }


### PR DESCRIPTION
## Summary

- The committed `settings.json` had two top-level `permissions` keys (lines 2 and 228). JSON parsers resolve duplicate keys as last-one-wins, so the **first** block's entries — `Bash(pytest claude/.claude/)` and `Bash(ruff check claude/.claude/)` — were silently dead since the second block overwrote them.
- An in-session settings write (Claude Code's normalizing serializer, triggered by some `/model`, plugin, or permissions UI interaction) merged the duplicates into a single canonical block, also pruning the dangling `extraKnownMarketplaces.claude-config` entry that had `"path": ""`.
- This PR accepts the normalized structure and restores the two contributor test/lint allow rules documented in CLAUDE.md's "Commands" section.

## What changed

- `permissions.allow`: de-duped to a single block; `Bash(pytest claude/.claude/)` and `Bash(ruff check claude/.claude/)` restored.
- `skillOverrides` and `model`: de-duped (moved to canonical position, no value changes).
- `extraKnownMarketplaces`: dangling `claude-config` entry with empty `"path": ""` removed.

## Why the two rules were "lost"

The duplicate-key structure meant the pytest/ruff rules only existed in HEAD's **first** `permissions` block. When Claude Code's serializer merged the blocks (last-one-wins semantics), only the second block survived. The file is now serializer-idempotent — the next settings write will produce no diff.

## Test plan

- [ ] Verify `python3 -c "import json; json.load(open('claude/.claude/settings.json'))"` exits 0.
- [ ] Verify `grep -c '"permissions"' claude/.claude/settings.json` returns `1`.
- [ ] Run `pytest claude/.claude/` — should execute without a permission prompt.
- [ ] Run `ruff check claude/.claude/` — should execute without a permission prompt.
- [ ] Trigger a settings-mutating in-session action (e.g. toggle a skill override) and confirm `git diff` shows no change to `settings.json` afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)