### PR TITLE
feat(plan-it): name /plan-it as no-plan entry in plan-review gate deny message

### DIFF
--- a/claude/.claude/hooks/require-plan-review.sh
+++ b/claude/.claude/hooks/require-plan-review.sh
@@ -94,7 +94,7 @@ REASON="Write/Edit blocked by plan-review gate: a plan file exists in .claude/pl
 
   - If a plan covers this change → run /plan-review against it. The skill records the review in ~/.claude/plan-review-markers/ and this write will be allowed through on retry.
 
-  - If no plan covers this change yet → run /plan-it first. It authors the plan (depth-tiers per its own Step 5 — small changes get a short plan, large changes get a full one) and hands off to /plan-review at the end.
+  - If no plan covers this change yet → run /plan-it first. It authors the plan and hands off to /plan-review at the end.
 
 The model judges which case applies from conversation context. Plans live wherever you put them — typically .claude/plans/, but also /tmp/<slug>.md, handoff docs, or external design doc URLs. The hook does not try to detect plan-change correlation."
 REASON_JSON=$(printf '%s' "$REASON" | jq -Rs .)

--- a/claude/.claude/hooks/require-plan-review.sh
+++ b/claude/.claude/hooks/require-plan-review.sh
@@ -90,6 +90,12 @@ if [ -n "$TARGET_PATH" ]; then
   fi
 fi
 
-REASON="Write/Edit blocked by plan-review gate: a plan file exists in .claude/plans/ but no plan-review marker was found for this session. Run the /plan-review skill now. When the review is clean, the skill will record the review in ~/.claude/plan-review-markers/ and this write will be allowed through on retry."
+REASON="Write/Edit blocked by plan-review gate: a plan file exists in .claude/plans/ but no plan-review marker was found for this session. Next step depends on whether a plan covers this change:
+
+  - If a plan covers this change → run /plan-review against it. The skill records the review in ~/.claude/plan-review-markers/ and this write will be allowed through on retry.
+
+  - If no plan covers this change yet → run /plan-it first. It authors the plan (depth-tiers per its own Step 5 — small changes get a short plan, large changes get a full one) and hands off to /plan-review at the end.
+
+The model judges which case applies from conversation context. Plans live wherever you put them — typically .claude/plans/, but also /tmp/<slug>.md, handoff docs, or external design doc URLs. The hook does not try to detect plan-change correlation."
 REASON_JSON=$(printf '%s' "$REASON" | jq -Rs .)
 printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' "$REASON_JSON"

--- a/claude/.claude/skills/plan-it/SKILL.md
+++ b/claude/.claude/skills/plan-it/SKILL.md
@@ -5,7 +5,10 @@ description: >
   TRIGGER when: asked for a plan or implementation strategy
   for work spanning multiple files or domains. DO NOT TRIGGER when:
   single-file tweaks, "just implement it" requests, or when a plan
-  already exists (use /plan-review instead).
+  already exists (use /plan-review instead). Exception: deliberate
+  invocation (slash command, or gate-driven from
+  require-plan-review.sh) is always fine — Step 5's depth-tiering
+  handles small changes.
 user-invocable: true
 argument-hint: "[optional topic or ticket id]"
 ---

--- a/claude/.claude/skills/plan-it/SKILL.md
+++ b/claude/.claude/skills/plan-it/SKILL.md
@@ -5,10 +5,7 @@ description: >
   TRIGGER when: asked for a plan or implementation strategy
   for work spanning multiple files or domains. DO NOT TRIGGER when:
   single-file tweaks, "just implement it" requests, or when a plan
-  already exists (use /plan-review instead). Exception: deliberate
-  invocation (slash command, or gate-driven from
-  require-plan-review.sh) is always fine — Step 5's depth-tiering
-  handles small changes.
+  already exists (use /plan-review instead).
 user-invocable: true
 argument-hint: "[optional topic or ticket id]"
 ---


### PR DESCRIPTION
## Summary

- The plan-review gate's deny message previously pointed only at `/plan-review`, which falls off a cliff when no plan covers the change — producing forged reviews against unrelated plans, mid-task user prompts, or ad hoc plan authoring.
- Reword the deny message to branch on two cases: plan-exists → `/plan-review`; no-plan-yet → `/plan-it` first (it authors the plan and hands off to `/plan-review`).

## Lighter alternatives considered

| Alternative | Why rejected |
|---|---|
| `/plan-review` absorbs authoring | Overloads it with a second responsibility; duplicates depth-tiering rules already in `/plan-it` Step 5; violates one-skill-one-job. |
| Hook detects plan-change correlation | Heuristic, fragile; plans routinely live outside `.claude/plans/` (`/tmp/<slug>-handoff.md`, external design docs); false negatives erode gate trust. |
| Embed plan count in deny message | Plans routinely live outside `.claude/plans/`; a count of one location misleads the model. |

## Diff

| File | Change |
|---|---|
| `claude/.claude/hooks/require-plan-review.sh` | REASON string reworded to branch on plan-exists vs no-plan-yet cases |

## Audience

Every Claude Code session on every machine that stows `claude-config`. Files under `claude/` are distributed to all stow users on `git pull` — wording precision matters.

## Test plan

- [x] `pytest claude/.claude/` — 748/748 pass (tests check `permissionDecision == "deny"`, not message text verbatim)
- [x] `ruff check claude/.claude/` — clean
- [ ] Manual smoke: in any session with `.claude/plans/` populated, trigger a Write/Edit — confirm deny message names both `/plan-it` (no-plan case) and `/plan-review` (plan-exists case) with the branching description

🤖 Generated with [Claude Code](https://claude.com/claude-code)