### PR TITLE
fix(ready-for-review): check CI after the final push, not before

### DIFF
--- a/claude/.claude/plans/i-ve-seen-claude-report-imperative-treehouse.md
+++ b/claude/.claude/plans/i-ve-seen-claude-report-imperative-treehouse.md
@@ -1,0 +1,89 @@
+# Fix stale CI-status reports in `ready-for-review`
+
+## Context
+
+Claude has reported CI as green during the `ready-for-review` gate when CI
+was actually pending. Root cause is step ordering in
+`claude/.claude/skills/ready-for-review/SKILL.md`:
+
+- **Step 5 ("CI status")** runs `gh pr checks <n>`, which queries GitHub and
+  therefore only sees the **last-pushed** commit.
+- **Step 6 ("Final hygiene recheck")** runs afterward and is where fix
+  commits from steps 2/3 actually get pushed.
+
+So when steps 2/3 produce a fix commit, step 5 reports CI for the pre-fix
+HEAD, step 6 pushes the fix commit, and the Completion summary echoes step
+5's now-stale result. Observed: step 5 saw `11ef241` green, step 6 pushed
+`e1acc31`, gate reported "CI green" while `e1acc31` was still pending.
+
+The check runs at the wrong time. The fix is to run it once, at the right
+time — after the branch is in its final pushed state — not to check early
+and then warn that the early result might be stale.
+
+## Change
+
+Prose-only edit to `claude/.claude/skills/ready-for-review/SKILL.md`:
+**relocate the CI-status check to run after the final push.** No script or
+hook changes; the `HOOK_TEST_FIXTURE` blocks (steps 0 and 7) move with their
+content but are not modified.
+
+New step order (sequential renumber — only the CI step relocates):
+
+| New | Was  | Step                          |
+|-----|------|-------------------------------|
+| 1   | 1    | Preconditions                 |
+| 2   | 2    | Verification                  |
+| 3   | 3    | Code review                   |
+| 4   | 4    | Sync PR description           |
+| 5   | 5.5  | Create PR if missing          |
+| 6   | 6    | Final hygiene recheck (pushes)|
+| 7   | 5    | **CI status**                 |
+| 8   | 7    | Record completion + deactivate|
+
+Because step 7 now runs after every push, `gh pr checks` always reflects the
+pushed HEAD — no "stale result" concept needed.
+
+Relocated step 7 body (the only content change is the framing line and one
+added outcome bullet for the post-push registration race):
+
+> ## 7. CI status (warn only)
+>
+> The branch is now in its final pushed state. Run `gh pr checks <n>`.
+>
+> - All green → continue.
+> - Still running → note the in-flight checks; user decides whether to wait.
+> - No checks reported (`gh pr checks` exits non-zero) → CI has not
+>   registered a run for the pushed commit yet. Report as pending.
+> - Red → surface failing check names with a one-line summary of each.
+>   Do not auto-halt — sometimes the human reviewer wants to see the
+>   failure themselves — but make the failure explicit before handoff.
+
+The fourth bullet is required: immediately after step 6's push, CI for the
+new commit may not be registered yet and `gh pr checks` exits non-zero — that
+must read as pending, never as green. It uses the same `→` style as the
+three existing bullets in this step.
+
+Reference fix-ups from the renumber:
+
+- Step 1: "step 5.5 will open one" → "step 5 will open one".
+- Step 6: "PR #N (created in step 5.5 if newly opened)" → "step 5".
+- Step 8: "halt-on-fail step (1, 2, 3, 6)" — step 6's number is unchanged,
+  so this reference stays correct.
+- Old step 5's "skip if no PR" caveat is dropped: step 5 (create PR) now
+  guarantees a PR exists before step 7 runs.
+
+## Files
+
+- `claude/.claude/skills/ready-for-review/SKILL.md` — relocate + renumber
+  steps 5–7; reference fix-ups in steps 1 and 6.
+
+## Verification
+
+- Per repo CLAUDE.md ("When editing a skill, run the skill on its own
+  diff"): invoke `/skill-review` on the staged diff; confirm no findings.
+- Read steps 1–8 in sequence and confirm: every push completes before the
+  CI check; no step-number reference is dangling.
+- Confirm the two `HOOK_TEST_FIXTURE` fenced blocks are byte-identical to
+  before (the hook-alignment test re-reads them from this file).
+- Run the test suite: `pytest claude/.claude/` and
+  `ruff check claude/.claude/`.

--- a/claude/.claude/skills/ready-for-review/SKILL.md
+++ b/claude/.claude/skills/ready-for-review/SKILL.md
@@ -35,7 +35,7 @@ If the chain fails (empty `SESSION_ID`), the `capture-session-id.sh` SessionStar
 - Working tree is clean: no unstaged or uncommitted changes.
 - If a PR exists for the branch, capture its number and base:
   `gh pr view --json number,baseRefName`
-- If no PR exists, note this — step 5.5 will open one after verification
+- If no PR exists, note this — step 5 will open one after verification
   and review complete.
 
 ## 2. Verification (halt on fail)
@@ -101,7 +101,7 @@ Flag and fix:
 - **Reviewer-action items Claude can answer itself.** Strip claims
   you can verify ("all migrations match precedent" — confirm and
   remove), test counts (those belong in the commit message), and
-  CI placeholders (step 5 covers those). Keep items requiring
+  CI placeholders (step 7 covers those). Keep items requiring
   reviewer judgment: deploy coordination, security-invariant catalog
   approval, architectural sign-off.
 - Stale prose left behind by code changes — a removed guard, an
@@ -124,17 +124,7 @@ breaks GitHub markdown code-span rendering. Backslash-escape backticks
 only inside double-quoted strings or unquoted (`<<EOF`) heredocs where
 they would otherwise trigger command substitution.
 
-## 5. CI status (warn only; skip if no PR)
-
-Run `gh pr checks <n>`.
-
-- All green → continue.
-- Still running → note the in-flight checks; user decides whether to wait.
-- Red → surface failing check names with a one-line summary of each.
-  Do not auto-halt — sometimes the human reviewer wants to see the
-  failure themselves — but make the failure explicit before handoff.
-
-## 5.5. Create PR if missing (skip if PR already exists)
+## 5. Create PR if missing (skip if PR already exists)
 
 Skip if PR found in step 1. Halt if no remote tracking — "Branch is not pushed. Push with `git push -u origin <branch>` then re-run." TICKET-ID: split branch on `/`; if first segment matches `^[A-Za-z]+-[0-9]+$`, use as title prefix; else omit. Title: `<TICKET-ID>: <slug-hyphens-as-spaces>` ≤70 chars.
 Body (omit `$ARGUMENTS` if empty; use single-quoted `<<'EOF'` heredoc; capture PR number for step 6):
@@ -159,9 +149,19 @@ Steps 3 and 4 may have produced new commits or body edits. Reconfirm:
   re-verify the branch is no longer ahead.
 - PR body edit (if any) landed — re-fetch with `gh pr view` and confirm.
 
-Confirm PR #N (created in step 5.5 if newly opened) is up to date with the branch HEAD.
+Confirm PR #N (created in step 5 if newly opened) is up to date with the branch HEAD.
 
-## 7. Record gate completion + deactivate session
+## 7. CI status (warn only)
+
+Run `gh pr checks <n>`:
+- All green → continue.
+- Still running → note the in-flight checks; user decides whether to wait.
+- No checks reported (`gh pr checks` exits non-zero) → not yet registered; treat as pending.
+- Red → surface failing check names with a one-line summary of each.
+  Do not auto-halt — sometimes the human reviewer wants to see the
+  failure themselves — but make the failure explicit before handoff.
+
+## 8. Record gate completion + deactivate session
 
 If every halt-on-fail step above passed, record the completed gate
 and remove the active-session marker:
@@ -196,5 +196,5 @@ is ready for human review:
 - Verification: commands run and their results.
 - Code review: findings fixed, or "none."
 - PR description: sections updated, or "already in sync" / "no PR."
-- CI: status per check, or "no PR."
+- CI: status per check.
 - Branch: clean, pushed, PR #N ready for review.


### PR DESCRIPTION
## Summary

- Step 5 (CI status) ran `gh pr checks` before step 6 could push fix commits, so the gate reported a stale-green result for the pre-push HEAD
- Relocate CI status to step 7, after all pushes are complete, so it always reflects the pushed branch HEAD
- Add a fourth bullet for the post-push registration race: `gh pr checks` exits non-zero with "no checks reported" before CI registers a run for the new commit — treat as pending, not green

## Steps renumbered

| New | Was | Step |
|-----|-----|------|
| 5 | 5.5 | Create PR if missing |
| 6 | 6 | Final hygiene recheck (unchanged) |
| 7 | 5 | CI status |
| 8 | 7 | Record completion + deactivate |

## Test plan

- [ ] Run `/ready-for-review` on a branch where steps 2/3 produce a fix commit — confirm CI is checked after the push, not before
- [ ] Confirm hook-alignment test suite passes (`pytest claude/.claude/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)