### PR TITLE
fix(CLAUDE.md): correct plan-mode/subagent mechanism in Agent Briefing

### DIFF
--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -41,7 +41,7 @@ If the subagent reports a check was blocked by permissions, do NOT fall back to 
 ## Agent Briefing
 
 - When spawning sub-agents with `isolation: "worktree"`, do NOT include an explicit `Working directory: /path/to/repo` line. The harness sets the agent's CWD to the isolated worktree automatically; naming the main repo path causes the agent to use `git -C <main-path>` operations that bypass isolation and mutate the main working tree directly.
-- Before delegating execution to a sub-agent from a session that has been in plan mode, call `ExitPlanMode` in the parent first. Sub-agents inherit harness-enforced plan-mode state and will refuse to execute — returning a plan file even when the prompt says "execute, do not plan" — until the parent exits plan mode. Symptom: the sub-agent cites a "plan-mode system-reminder" as harness-enforced and asks the user to exit plan mode.
+- Before delegating execution to a sub-agent from a session in plan mode, call `ExitPlanMode` in the parent first. A spawned sub-agent receives the plan-mode system-reminder and a typical agent honors it — declining to execute and returning a plan file even when the prompt says "execute, do not plan." This is the agent obeying an instruction, not a hard harness block, so the symptom is a polite refusal, not a tool error. Exit plan mode in the parent before delegating execution work.
 - In a repo with worktree enforcement opt-in (`.claude/worktree-required` committed), Edit and Write must also target the worktree path — the hook blocks main-tree file writes, but resolving paths to `.claude/worktrees/<branch>/...` up front avoids the round-trip denial.
 
 ## Model Routing

--- a/claude/.claude/skills/handoff/SKILL.md
+++ b/claude/.claude/skills/handoff/SKILL.md
@@ -22,10 +22,10 @@ Header line: working directory + current git branch. Then list paths edited this
 List active markers under `~/.claude/*-markers/` and `~/.claude/.*-active.d/` — filenames, which skill wrote each, and (for completion markers) the staged-diff hash the marker covers.
 
 ## §6 Open questions / decisions deferred
-Open AskUserQuestion exchanges, pending decisions the user still owes a call on, and recent failed commands + root causes the resuming session needs to know.
+Open AskUserQuestion exchanges, pending decisions the user still owes a call on, and recent failed commands + root causes the resuming session needs to know. If the session is in plan mode and §3's next step will be delegated to sub-agents, note it here — sub-agents inherit plan-mode state and will refuse to execute until the resuming agent calls `ExitPlanMode`.
 
 ## §7 Resume command
-`Read /tmp/<slug>-handoff.md and continue.` When §3's next step is execution to be delegated to sub-agents, add a line telling the resuming agent to call `ExitPlanMode` first if it opens in plan mode — sub-agents spawned from a plan-mode session honor the plan-mode system-reminder and decline to execute.
+`Read /tmp/<slug>-handoff.md and continue.`
 
 ## You may drop
 

--- a/claude/.claude/skills/handoff/SKILL.md
+++ b/claude/.claude/skills/handoff/SKILL.md
@@ -22,7 +22,7 @@ Header line: working directory + current git branch. Then list paths edited this
 List active markers under `~/.claude/*-markers/` and `~/.claude/.*-active.d/` — filenames, which skill wrote each, and (for completion markers) the staged-diff hash the marker covers.
 
 ## §6 Open questions / decisions deferred
-Open AskUserQuestion exchanges, pending decisions the user still owes a call on, and recent failed commands + root causes the resuming session needs to know. If the session is in plan mode and §3's next step will be delegated to sub-agents, note it here — sub-agents inherit plan-mode state and will refuse to execute until the resuming agent calls `ExitPlanMode`.
+Open AskUserQuestion exchanges, pending decisions the user still owes a call on, and recent failed commands + root causes the resuming session needs to know. If the session is in plan mode and §3's next step will be delegated to sub-agents, add an explicit note here that the resuming agent must call `ExitPlanMode` before spawning sub-agents — sub-agents inherit plan-mode state and will refuse to execute otherwise.
 
 ## §7 Resume command
 `Read /tmp/<slug>-handoff.md and continue.`

--- a/claude/.claude/skills/handoff/SKILL.md
+++ b/claude/.claude/skills/handoff/SKILL.md
@@ -25,7 +25,7 @@ List active markers under `~/.claude/*-markers/` and `~/.claude/.*-active.d/` �
 Open AskUserQuestion exchanges, pending decisions the user still owes a call on, and recent failed commands + root causes the resuming session needs to know.
 
 ## §7 Resume command
-`Read /tmp/<slug>-handoff.md and continue.`
+`Read /tmp/<slug>-handoff.md and continue.` When §3's next step is execution to be delegated to sub-agents, add a line telling the resuming agent to call `ExitPlanMode` first if it opens in plan mode — sub-agents spawned from a plan-mode session honor the plan-mode system-reminder and decline to execute.
 
 ## You may drop
 


### PR DESCRIPTION
## Summary

- Replaces the inaccurate "harness-enforced" mechanism claim in the Agent Briefing bullet with an accurate description: plan-mode reaches spawned sub-agents as a **system-reminder** that a typical agent honors voluntarily, not a hard harness block
- Actionable advice (call `ExitPlanMode` in the parent before delegating execution) is unchanged
- Surfaces the same rule in `handoff/SKILL.md §6` so a resuming execution session is reminded at the moment it reads the handoff doc

## Why

A controlled probe (4 cells, 2026-05-15) established the mechanism:
- General-purpose sub-agent spawned from a plan-mode parent: received the system-reminder and self-declined (zero tool calls, polite refusal — not a tool error)
- Sub-agent with `permissionMode: acceptEdits` in frontmatter: executed Write + Bash from the same plan-mode parent — proving no universal harness block exists

The false "harness-enforced" claim invited wrong fixes (the `/insights` report proposed a "skill that disables plan-mode inheritance" — impossible to build). The discoverability gap: the rule existed in CLAUDE.md since PR #75 but the friction recurred because a handoff-resume session in plan mode didn't connect the rule at the moment it mattered.

## Test plan

- [x] `pytest claude/.claude/` — 801 tests pass
- [x] `ruff check claude/.claude/` — clean
- [x] `/skill-review` and `/ai-instruction-and-memory-files` passed clean
- [x] Agent Briefing bullet contains no "harness-enforced" wording
- [x] ExitPlanMode note placed in `handoff/SKILL.md §6` (session-state section), not §7

🤖 Generated with [Claude Code](https://claude.com/claude-code)