### PR TITLE
fix(install): remove empty-path directory marketplace from extraKnownMarketplaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ This repo exposes a marketplace via `.claude-plugin/marketplace.json`. Each plug
 
 **Current plugins:**
 
-One-time setup per machine: register the marketplace with `claude plugin marketplace add <path-or-URL-to-claude-config>`. Then install any of the plugins below at project scope:
+`./install.sh` registers the `claude-config` marketplace automatically. To register it manually (without running `install.sh`), run `claude plugin marketplace add <path-to-claude-config>`. Then install any of the plugins below at project scope:
 
 - **`lovable-cloud`** — Skills for Lovable Cloud projects: Project/Workspace Knowledge fields, edge-function auth model (ES256 gateway constraint, two-tier auth), and migration-sync workflow. `claude plugin install lovable-cloud@claude-config --scope project`
 - **`skill-review`** — Behavioral-equivalence audit for `SKILL.md` changes; gates `git commit` when staged changes include a `SKILL.md`. `claude plugin install skill-review@claude-config --scope project`

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -249,12 +249,6 @@
         "source": "github",
         "repo": "anthropics/claude-plugins-official"
       }
-    },
-    "claude-config": {
-      "source": {
-        "source": "directory",
-        "path": ""
-      }
     }
   }
 }

--- a/install.sh
+++ b/install.sh
@@ -21,22 +21,29 @@ stow -v --adopt -t "$HOME" claude
 SETTINGS_FILE="$HOME/.claude/settings.json"
 if [ -f "$SETTINGS_FILE" ]; then
   echo ""
-  echo "=== Registering marketplaces from extraKnownMarketplaces ==="
+  echo "=== Registering marketplaces ==="
   existing_marketplaces="$(claude plugin marketplace list --json 2>/dev/null | jq -r '.[].name')"
-  while IFS=$'\t' read -r name source_type identifier; do
-    case "$source_type" in
-      directory) identifier="$REPO_DIR" ;;  # directory sources in stowed config are always self-referential
-      github)    : ;;
-      *)         echo "  ! $name: unknown source type '$source_type' — skipping"; continue ;;
-    esac
+
+  # This repo is itself a marketplace. A directory source needs an absolute
+  # path, which is machine-specific and cannot live in the stowed settings.json
+  # — so register it here from this checkout's location.
+  if echo "$existing_marketplaces" | grep -qFx "claude-config"; then
+    echo "  ✓ claude-config (already registered)"
+  else
+    echo "  → adding claude-config ($REPO_DIR)"
+    claude plugin marketplace add "$REPO_DIR" --scope user
+  fi
+
+  while IFS=$'\t' read -r name repo; do
     if echo "$existing_marketplaces" | grep -qFx "$name"; then
       echo "  ✓ $name (already registered)"
     else
-      echo "  → adding $name ($identifier)"
-      claude plugin marketplace add "$identifier" --scope user
+      echo "  → adding $name ($repo)"
+      claude plugin marketplace add "$repo" --scope user
     fi
   done < <(jq -r '.extraKnownMarketplaces // {} | to_entries[] |
-    "\(.key)\t\(.value.source.source)\t\(.value.source.repo // .value.source.path // "")"
+    select(.value.source.source == "github") |
+    "\(.key)\t\(.value.source.repo)"
   ' "$SETTINGS_FILE")
 
   echo ""

--- a/install.sh
+++ b/install.sh
@@ -34,7 +34,11 @@ if [ -f "$SETTINGS_FILE" ]; then
     claude plugin marketplace add "$REPO_DIR" --scope user
   fi
 
-  while IFS=$'\t' read -r name repo; do
+  while IFS=$'\t' read -r name source_type repo; do
+    if [ "$source_type" != "github" ]; then
+      echo "  ! $name: non-github source '$source_type' — skipping (only github sources are portable)"
+      continue
+    fi
     if echo "$existing_marketplaces" | grep -qFx "$name"; then
       echo "  ✓ $name (already registered)"
     else
@@ -42,8 +46,7 @@ if [ -f "$SETTINGS_FILE" ]; then
       claude plugin marketplace add "$repo" --scope user
     fi
   done < <(jq -r '.extraKnownMarketplaces // {} | to_entries[] |
-    select(.value.source.source == "github") |
-    "\(.key)\t\(.value.source.repo)"
+    "\(.key)\t\(.value.source.source)\t\(.value.source.repo // "")"
   ' "$SETTINGS_FILE")
 
   echo ""


### PR DESCRIPTION
## Summary

- Removes `claude-config` from `extraKnownMarketplaces` in `claude/.claude/settings.json` — the entry had `path: ""` as a placeholder for `install.sh`, but Claude Code reads this key natively. An empty `directory`-source path resolves relative to the current project directory and produces "Marketplace file not found at `<cwd>/.claude-plugin/marketplace.json`" in every non-claude-config project.
- Updates `install.sh` to self-register the `claude-config` marketplace from `$REPO_DIR` before the loop. The jq query now emits all `extraKnownMarketplaces` entries with source type; the bash loop skips non-github entries with a visible warning (`! <name>: non-github source '<type>' — skipping`) and registers github entries as before. The old `directory`/`case` arm is removed.
- Updates `README.md` to note that `./install.sh` auto-registers the `claude-config` marketplace, with the manual `claude plugin marketplace add` command as a fallback for setups that skip `install.sh`.

## Root cause

PR #210 added the `claude-config` entry so `install.sh` could auto-register the marketplace. The `path: ""` was deliberate — `install.sh` substitutes `$REPO_DIR` at runtime — but PR #210's own verification note flagged the exact risk and the smoke test missed it. The invariant that fails: `extraKnownMarketplaces` is consumed by both `install.sh` (overrides directory paths) and Claude Code's native parser (does not). Only portable values (github sources) belong in committed config.

## Test plan

- [x] `jq -e . claude/.claude/settings.json` passes
- [x] `bash -n install.sh` passes
- [ ] `/plugin` in a non-claude-config project opens cleanly (no "Marketplace file not found")
- [ ] `lovable-cloud@claude-config` skills still load (resolves via `known_marketplaces.json`, untouched)
- [ ] `./install.sh` re-registers `claude-config` from `$REPO_DIR` on a fresh machine; idempotent on second run

🤖 Generated with [Claude Code](https://claude.com/claude-code)