### PR TITLE
fix(lovable-cloud-edge-functions): extend TRIGGER to cover pg_cron and invocation files

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "lovable-cloud",
       "description": "Skills for Lovable Cloud projects — Project/Workspace Knowledge fields, edge-function auth model, and migration-sync workflow.",
-      "version": "2.1.0",
+      "version": "2.1.2",
       "author": {
         "name": "Cordova Strategy"
       },

--- a/plugins/lovable-cloud/.claude-plugin/plugin.json
+++ b/plugins/lovable-cloud/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lovable-cloud",
   "description": "Skills for Lovable Cloud projects — Project/Workspace Knowledge fields, edge-function auth model, and migration-sync workflow.",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "author": {
     "name": "Cordova Strategy"
   },

--- a/plugins/lovable-cloud/skills/lovable-cloud-edge-functions/SKILL.md
+++ b/plugins/lovable-cloud/skills/lovable-cloud-edge-functions/SKILL.md
@@ -4,8 +4,10 @@ description: >
   Guide for adding, modifying, and deploying Supabase edge functions —
   authentication, config.toml settings, and Lovable Cloud deployment.
   TRIGGER when: adding, modifying, or reviewing edge functions in a Lovable
-  Cloud project, or modifying supabase/config.toml.
-  DO NOT TRIGGER when: not working on edge functions or config.toml.
+  Cloud project, or modifying a file that configures an edge function (e.g.
+  supabase/config.toml) or invokes one (e.g. a pg_cron job).
+  DO NOT TRIGGER when: the change neither configures, invokes, nor modifies
+  an edge function.
 user-invocable: false
 ---
 


### PR DESCRIPTION
## Summary

- The prior TRIGGER clause named only edge function code and `supabase/config.toml`, missing the case where a pg_cron migration adds a job that *invokes* an edge function without touching the function code or config.toml.
- New clause generalizes from enumerated files to a category — "modifying a file that configures or invokes an edge function" — with concrete examples (`supabase/config.toml`, `pg_cron job`) so the router can match on literal diff tokens without re-deriving the inference.
- DO NOT TRIGGER tightened from the weak "not working on edge functions or config.toml" to a positive-negative: "the change neither configures, invokes, nor modifies an edge function."
- No body edit needed — Tier 2 already documents pg_cron/pg_net callers as first-class; this aligns the routing signal to the body's existing scope.
- Bumps plugin to `2.1.2` and syncs `marketplace.json` from `2.1.0` to `2.1.2`, reconciling the drift left over from #228.

## Test plan

- [ ] Verify YAML frontmatter parses correctly (validated via `python3 -c "import yaml; ..."` — passes)
- [ ] `/skill-review` run on staged diff — clean (behavioral-equivalence audit: all removed lines preserved in new text)
- [ ] `/code-review` run on staged diff — clean
- [ ] Smoke test: apply to a session that sees a pg_cron migration touching an edge-function invocation and confirm the skill fires
- [ ] After merge: run `claude plugin install lovable-cloud@claude-config --scope project` in consuming repos to pull 2.1.2 into the plugin cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)