### PR TITLE
feat(plugin-semver): add semver guidance plugin and clean up marketplace version fields

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,6 @@
     {
       "name": "lovable-cloud",
       "description": "Skills for Lovable Cloud projects — Project/Workspace Knowledge fields, edge-function auth model, and migration-sync workflow.",
-      "version": "2.1.2",
       "author": {
         "name": "Cordova Strategy"
       },
@@ -19,7 +18,6 @@
     {
       "name": "skill-review",
       "description": "Behavioral-equivalence audit for SKILL.md changes. Gates git commit when staged changes include a SKILL.md. Install at project scope in repos that author SKILL.md files.",
-      "version": "1.0.0",
       "author": {
         "name": "Cordova Strategy"
       },
@@ -29,11 +27,19 @@
     {
       "name": "claude-hook-review",
       "description": "Review playbook for Claude Code hooks: event/matcher selection, path resolution, script skeleton, fail-open/fail-closed posture, dispatch drift, and the 9-item review checklist. Install at project scope in repos that author .claude/hooks/*.sh scripts.",
-      "version": "1.0.0",
       "author": {
         "name": "Cordova Strategy"
       },
       "source": "./plugins/claude-hook-review",
+      "category": "productivity"
+    },
+    {
+      "name": "plugin-semver",
+      "description": "Semver and version-field discipline for Claude Code plugin changes. Install at project scope in any repo that authors plugins for a Claude Code marketplace.",
+      "author": {
+        "name": "Cordova Strategy"
+      },
+      "source": "./plugins/plugin-semver",
       "category": "productivity"
     }
   ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,8 @@
 {
   "enabledPlugins": {
     "skill-review@claude-config": true,
-    "claude-hook-review@claude-config": true
+    "claude-hook-review@claude-config": true,
+    "plugin-semver@claude-config": true
   },
   "permissions": {
     "allow": [

--- a/claude/.claude/plans/plugin-semver.md
+++ b/claude/.claude/plans/plugin-semver.md
@@ -1,0 +1,236 @@
+# `plugin-semver` plugin + version-field cleanup for claude-config
+
+## Context
+
+A prior session shipped a `SKILL.md` edit to a claude-config plugin without
+updating its version, and noticed the post-merge install command keeps being
+re-derived. The original draft plan (`plugin-semver-management-skill.md`)
+proposed a guidance skill plus a hook that keeps the `version` field in
+`plugin.json` **and** the matching `marketplace.json` entry in sync.
+
+Research into the official Claude Code docs
+(`code.claude.com/docs/en/plugins-reference`, `/plugin-marketplaces`)
+overturned that premise:
+
+- Version resolution is a **fallback chain**, not a sync requirement:
+  `plugin.json` → marketplace entry → git commit SHA → `unknown`.
+- The docs say verbatim: *"Avoid setting `version` in both `plugin.json` and
+  the marketplace entry. The `plugin.json` value always wins silently, so a
+  stale manifest version can mask a version you set in `marketplace.json`."*
+- The repo already exhibited this anti-pattern: `lovable-cloud` is `2.1.0`
+  (marketplace) vs `2.1.1` (plugin.json); `skill-review` is `1.0.0` vs `1.0.1`.
+  The drift is functionally harmless (`plugin.json` wins) but the
+  `marketplace.json` numbers are dead, masked weight.
+
+So the foundational fix is not tooling to sync two fields — it is **removing
+the second field**. The plugins are client-facing (installed into client
+project repos), so explicit semver is correct (docs: "published plugins with
+stable release cycles"); commit-SHA versioning is not appropriate. The single
+source of truth is `plugin.json` — resolution position #1, authoritative,
+travels in the plugin cache.
+
+This plan does the cleanup, then adds a guidance skill so the convention
+holds going forward. No hook: bump *magnitude* is a judgment call a hook
+cannot make, and once there is one version field there is nothing to "sync".
+
+## Decisions locked (with the user)
+
+- Explicit semver, **single source of truth = `plugin.json`**.
+- Remove `version` from every `marketplace.json` plugin entry.
+- Reconcile the existing version drift **and** description drift in this PR.
+- Scope: cleanup + a guidance skill (new plugin). No enforcement hook.
+- The skill is a **project plugin** (opt-in install, no global skill-listing
+  budget cost) but its `SKILL.md` body is written in **universal Claude Code
+  terms** — it never hardcodes `claude-config` or a marketplace name, so any
+  repo that authors plugins can install and use it.
+
+## Where to run
+
+Fresh session in `~/MyCode/claude-config`. Worktree enforcement is active —
+use a linked worktree (`git worktree add .claude/worktrees/<branch> -b <branch>`)
+or an agent with `isolation: worktree`. This is a `claude-config` change: it
+ships to every stow user on `git pull`, so weight findings accordingly.
+
+---
+
+## Part A — De-duplicate the version field (cleanup)
+
+Edit `/.claude-plugin/marketplace.json`: delete the `"version"` key from all
+three plugin entries (`lovable-cloud`, `skill-review`, `claude-hook-review`).
+Leave `plugin.json` versions untouched — `2.1.1 / 1.0.1 / 1.0.0` become the
+canonical versions with **no renumbering** (they already are what Claude Code
+resolves).
+
+Reconcile description drift: for `skill-review` and `claude-hook-review`, the
+`marketplace.json` and `plugin.json` `description` strings differ. Set them
+identical in both files per plugin — adopt the marketplace-entry wording
+(discovery-facing, states when to install) into `plugin.json`.
+`lovable-cloud` descriptions already match; leave them.
+
+Files: `.claude-plugin/marketplace.json`,
+`plugins/skill-review/.claude-plugin/plugin.json`,
+`plugins/claude-hook-review/.claude-plugin/plugin.json`.
+
+## Part B — New `plugin-semver` plugin
+
+Layout (mirrors `skill-review` / `claude-hook-review`):
+
+```
+plugins/plugin-semver/
+  .claude-plugin/plugin.json
+  skills/plugin-semver/SKILL.md
+```
+
+`plugins/plugin-semver/.claude-plugin/plugin.json`:
+
+```json
+{
+  "name": "plugin-semver",
+  "description": "Semver and version-field discipline for Claude Code plugin changes. Install at project scope in any repo that authors plugins for a Claude Code marketplace.",
+  "version": "1.0.0",
+  "author": { "name": "Cordova Strategy" },
+  "skills": "./skills/"
+}
+```
+
+New entry in `.claude-plugin/marketplace.json` (after `claude-hook-review`) —
+**no `version` field**, consistent with the Part A cleanup:
+
+```json
+{
+  "name": "plugin-semver",
+  "description": "Semver and version-field discipline for Claude Code plugin changes. Install at project scope in any repo that authors plugins for a Claude Code marketplace.",
+  "author": { "name": "Cordova Strategy" },
+  "source": "./plugins/plugin-semver",
+  "category": "productivity"
+}
+```
+
+### SKILL.md (`plugins/plugin-semver/skills/plugin-semver/SKILL.md`)
+
+Frontmatter mirrors existing plugin skills — `name: plugin-semver`,
+folded `description:` with embedded triggers, `user-invocable: false`:
+
+```
+TRIGGER when: modifying any file inside a plugin directory (a directory
+  whose tree contains .claude-plugin/plugin.json), or editing a
+  .claude-plugin/marketplace.json.
+DO NOT TRIGGER when: editing skills or agents that are not part of any
+  plugin (no .claude-plugin/plugin.json in their tree) — e.g. user-scope
+  stowed skills.
+```
+
+The `.claude-plugin/` path segment is the reliable diff anchor — both
+`plugin.json` and `marketplace.json` live under it, and it is not tied to
+any particular plugin-root directory name.
+
+Body must cover (keep under the 200-line cap — `check-skill-length.sh`):
+
+1. **One version field, in `plugin.json`.** Every behavior-affecting change to
+   a plugin requires bumping `version` in that plugin's
+   `.claude-plugin/plugin.json` (plugins commonly live under `plugins/<name>/`,
+   but the rule is keyed to the manifest, not the directory name). Never add a
+   `version` field to that plugin's entry in `.claude-plugin/marketplace.json`
+   — Claude Code resolves `plugin.json` first and silently masks any
+   marketplace value, so two fields can only drift. State the rule plainly; do
+   not narrate the prior repo state (per CLAUDE.md durable-doc rules).
+
+2. **Bump magnitude — judged by backward compatibility, not change size**
+   (semver.org spec items 6–8). The plugin is the versioned unit; its public
+   API is the aggregate of every skill and hook it ships plus their documented
+   triggers and behavior (semver.org item 1: a public API "could be declared
+   in the code itself or exist strictly in documentation"). A
+   backward-incompatible change to *one* skill is therefore a major change to
+   the *whole plugin* — and per the semver.org FAQ, even the tiniest
+   incompatible change requires a major bump.
+
+   | Change to the plugin | Bump |
+   |---|---|
+   | Backward-compatible bug fix — typo, clarification, or correcting a skill to match its already-documented behavior | patch |
+   | Backward-compatible addition — a new skill or hook, a new capability in an existing skill, or a trigger broadened to fire in strictly more cases | minor |
+   | Backward-incompatible change — an existing skill's behavior or guidance changes the outcome for anyone who relied on the prior version; a trigger narrowed so it no longer fires where it used to; a skill or hook removed or renamed; the plugin renamed or split | major |
+
+   Change size is not the axis. A large additive rewrite that still does
+   everything the prior version did is `minor`; a one-line guidance reversal
+   that breaks prior reliance is `major`.
+
+3. **Post-merge install command.** After merge, consuming repos refresh with
+   `claude plugin install <name>@<marketplace> --scope project`. Derive
+   `<name>` from the plugin's directory and `<marketplace>` from the `name`
+   field of the repo's `.claude-plugin/marketplace.json` — never hardcode a
+   marketplace name. Surface the command verbatim for the PR description; the
+   author owns knowing which repos consume the plugin.
+
+4. **Checklist emitted on trigger:**
+
+   ```
+   Plugin semver checklist:
+   - [ ] the plugin's .claude-plugin/plugin.json `version` bumped
+   - [ ] Bump magnitude matches the change (see table)
+   - [ ] No `version` field added to the plugin's marketplace.json entry
+   - [ ] PR description includes the post-merge install command
+   ```
+
+The skill is itself a plugin and subject to its own rules.
+
+## Part C — Enable the plugin and update docs
+
+**Enable it.** Add to `enabledPlugins` in the repo-root `.claude/settings.json`
+(project scope — the file already enables `skill-review@claude-config` and
+`claude-hook-review@claude-config`; this is how repo-own plugins load in
+claude-config sessions):
+
+```json
+"plugin-semver@claude-config": true
+```
+
+**Document it.** In `docs/skills.md` "Project-scoped plugins" section:
+- add a table row — `plugin-semver@claude-config` | "Semver and version-field
+  discipline for plugin manifests" | "Repos that author Claude Code plugins";
+- update the "Two skills" / "Both plugins" wording to cover three;
+- add the third install command to the fenced block;
+- add one sentence stating the convention — a plugin's `version` is declared
+  in its `plugin.json` only, never in a `marketplace.json` entry.
+
+## Part D — Enforcement test for the new convention
+
+Per the repo norm of landing a convention's test in the same PR: add
+`claude/.claude/skills/tests/test_plugin_manifests.py` (collected by
+`pytest claude/.claude/`, which discovers `test_*.py` anywhere under that
+tree). Resolves repo root via path arithmetic from `__file__` and asserts:
+
+- every entry in `.claude-plugin/marketplace.json` `plugins[]` has **no**
+  `version` key;
+- every `plugins/*/.claude-plugin/plugin.json` **has** a `version`.
+
+No existing test asserts on these manifests, so there is no conflicting
+assertion to update.
+
+## Files touched
+
+- `.claude-plugin/marketplace.json` — drop 3 `version` keys; add `plugin-semver` entry
+- `plugins/skill-review/.claude-plugin/plugin.json` — align description
+- `plugins/claude-hook-review/.claude-plugin/plugin.json` — align description
+- `plugins/plugin-semver/.claude-plugin/plugin.json` — new
+- `plugins/plugin-semver/skills/plugin-semver/SKILL.md` — new
+- `.claude/settings.json` (repo root) — add to `enabledPlugins`
+- `docs/skills.md` — table row, wording, convention sentence
+- `claude/.claude/skills/tests/test_plugin_manifests.py` — new
+- `claude/.claude/plans/plugin-semver.md` — this plan file
+
+## Verification
+
+1. `jq '.plugins[] | select(.version != null) | .name' .claude-plugin/marketplace.json`
+   → empty (no entry carries `version`).
+2. `jq -r '.version' plugins/*/.claude-plugin/plugin.json` → a version for each.
+3. `pytest claude/.claude/` and `ruff check claude/.claude/` → green.
+4. Open a PR; do not self-merge.
+
+## Out of scope
+
+- No enforcement hook. Bump *magnitude* is judgment a hook cannot evaluate;
+  once `version` lives in one file there is nothing to "sync".
+- No change to the commit-SHA-vs-explicit-version model — explicit semver
+  stays (correct for client-facing plugins).
+- No edit to root `CLAUDE.md`: the skill enforces the rule for agents and
+  `docs/skills.md` documents it for humans; a third copy would only drift.

--- a/claude/.claude/skills/tests/test_plugin_manifests.py
+++ b/claude/.claude/skills/tests/test_plugin_manifests.py
@@ -1,0 +1,56 @@
+"""Contract tests for plugin and marketplace manifest version-field conventions.
+
+The convention enforced here: a plugin's version is declared in its
+.claude-plugin/plugin.json only. Marketplace entries carry no `version` key
+because Claude Code resolves plugin.json first and silently masks any
+marketplace value, making a marketplace version field dead weight that can
+only drift.
+
+Run with: pytest claude/.claude/
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_MARKETPLACE_JSON = _REPO_ROOT / ".claude-plugin" / "marketplace.json"
+_PLUGINS_DIR = _REPO_ROOT / "plugins"
+
+
+def _marketplace_plugin_entries() -> list[dict]:
+    data = json.loads(_MARKETPLACE_JSON.read_text())
+    return data.get("plugins", [])
+
+
+def _plugin_json_paths() -> list[Path]:
+    return sorted(_PLUGINS_DIR.glob("*/.claude-plugin/plugin.json"))
+
+
+def test_marketplace_entries_have_no_version_field():
+    """Every marketplace plugin entry must omit the `version` key."""
+    entries_with_version = [
+        entry["name"]
+        for entry in _marketplace_plugin_entries()
+        if "version" in entry
+    ]
+    assert entries_with_version == [], (
+        f"Marketplace entries must not carry a `version` field "
+        f"(plugin.json wins silently): {entries_with_version}"
+    )
+
+
+def test_plugin_json_files_have_version_field():
+    """Every plugin's .claude-plugin/plugin.json must declare a `version`."""
+    plugin_jsons = _plugin_json_paths()
+    assert plugin_jsons, "Expected at least one plugin under plugins/"
+
+    missing_version = []
+    for plugin_json_path in plugin_jsons:
+        data = json.loads(plugin_json_path.read_text())
+        if "version" not in data:
+            missing_version.append(str(plugin_json_path.relative_to(_REPO_ROOT)))
+
+    assert missing_version == [], (
+        f"plugin.json files missing `version`: {missing_version}"
+    )

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -64,25 +64,29 @@ Persistent per-user: add to `~/.claude/settings.local.json`:
 
 ## Project-scoped plugins
 
-Two skills that primarily apply to this repo's own workflow — editing `SKILL.md` files and authoring hook scripts — live as project-scoped plugins in `plugins/` rather than stowed user-scope skills. This keeps them out of the always-loaded skill catalog for downstream projects that stow claude-config but rarely touch these surfaces.
+Three skills that primarily apply to this repo's own workflow — editing `SKILL.md` files, authoring hook scripts, and managing plugin versioning — live as project-scoped plugins in `plugins/` rather than stowed user-scope skills. This keeps them out of the always-loaded skill catalog for downstream projects that stow claude-config but rarely touch these surfaces.
 
 | Plugin | What it provides | When to install |
 |---|---|---|
 | `skill-review@claude-config` | Behavioral-equivalence audit for `SKILL.md` changes; gates `git commit` when staged changes include a `SKILL.md` | Repos that author their own `SKILL.md` files |
 | `claude-hook-review@claude-config` | Review playbook for `.claude/hooks/*.sh` scripts and `settings.json` hook entries | Repos that author their own hook scripts |
+| `plugin-semver@claude-config` | Semver and version-field discipline for plugin manifests | Repos that author Claude Code plugins for a marketplace |
 
-Both plugins are enabled automatically in claude-config sessions via `enabledPlugins` in `.claude/settings.json`. For this to work, the claude-config marketplace must be registered on the machine:
+All three plugins are enabled automatically in claude-config sessions via `enabledPlugins` in `.claude/settings.json`. For this to work, the claude-config marketplace must be registered on the machine:
 
 ```bash
 claude plugin marketplace add ~/MyCode/claude-config   # adjust to your actual checkout path
 ```
 
-Then Claude Code will resolve the plugins from the project settings. To install either plugin in a downstream project:
+Then Claude Code will resolve the plugins from the project settings. To install any plugin in a downstream project:
 
 ```bash
 claude plugin install skill-review@claude-config --scope project
 claude plugin install claude-hook-review@claude-config --scope project
+claude plugin install plugin-semver@claude-config --scope project
 ```
+
+**Version field convention:** a plugin's `version` is declared in its `.claude-plugin/plugin.json` only — never in a `marketplace.json` entry. Claude Code resolves `plugin.json` first and silently masks any marketplace value, so adding `version` to a marketplace entry only creates drift.
 
 ## Tuning the skill-listing budget for your project
 

--- a/plugins/claude-hook-review/.claude-plugin/plugin.json
+++ b/plugins/claude-hook-review/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-hook-review",
-  "description": "Review playbook for Claude Code hooks: event/matcher selection, path resolution, script skeleton, fail-open/fail-closed posture, dispatch drift, and the 9-item review checklist. Primarily useful in claude-config where hook scripts are authored.",
+  "description": "Review playbook for Claude Code hooks: event/matcher selection, path resolution, script skeleton, fail-open/fail-closed posture, dispatch drift, and the 9-item review checklist. Install at project scope in repos that author .claude/hooks/*.sh scripts.",
   "version": "1.0.0",
   "author": {
     "name": "Cordova Strategy"

--- a/plugins/plugin-semver/.claude-plugin/plugin.json
+++ b/plugins/plugin-semver/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "plugin-semver",
+  "description": "Semver and version-field discipline for Claude Code plugin changes. Install at project scope in any repo that authors plugins for a Claude Code marketplace.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Cordova Strategy"
+  },
+  "skills": "./skills/"
+}

--- a/plugins/plugin-semver/skills/plugin-semver/SKILL.md
+++ b/plugins/plugin-semver/skills/plugin-semver/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: plugin-semver
+description: >
+  Semver and version-field discipline for Claude Code plugin changes.
+  TRIGGER when: modifying any file inside a plugin directory (a directory
+  whose tree contains .claude-plugin/plugin.json), or editing a
+  .claude-plugin/marketplace.json.
+  DO NOT TRIGGER when: editing skills or agents that are not part of any
+  plugin (no .claude-plugin/plugin.json in their tree) — e.g. user-scope
+  stowed skills.
+user-invocable: false
+---
+
+# Plugin semver
+
+Fires when modifying files inside a Claude Code plugin or a marketplace manifest.
+
+## Version field: one location only
+
+Every behavior-affecting change to a plugin requires bumping `version` in that
+plugin's `.claude-plugin/plugin.json`. Never add a `version` field to that
+plugin's entry in `.claude-plugin/marketplace.json`. Claude Code resolves
+`plugin.json` first and silently masks any marketplace value, so two version
+fields can only drift — the marketplace entry becomes dead weight.
+
+The canonical version is in `plugin.json`. The marketplace entry carries no
+`version` key.
+
+## Bump magnitude
+
+The plugin is the versioned unit. Its public API is the aggregate of every
+skill and hook it ships, plus their documented triggers and behavior. A
+backward-incompatible change to one skill is therefore a major change to the
+whole plugin — regardless of diff size.
+
+Determine the bump by backward compatibility, not by change size:
+
+| Change to the plugin | Bump |
+|---|---|
+| Backward-compatible bug fix — typo, clarification, or correcting a skill to match its already-documented behavior | patch |
+| Backward-compatible addition — a new skill or hook, a new capability in an existing skill, or a trigger broadened to fire in strictly more cases | minor |
+| Backward-incompatible change — an existing skill's behavior or guidance changes the outcome for anyone who relied on the prior version; a trigger narrowed so it no longer fires where it used to; a skill or hook removed or renamed; the plugin renamed or split | major |
+
+A large additive rewrite that still does everything the prior version did is
+`minor`. A one-line guidance reversal that breaks prior reliance is `major`.
+
+## Post-merge install command
+
+After merge, consuming repos refresh with:
+
+```
+claude plugin install <name>@<marketplace> --scope project
+```
+
+Derive `<name>` from the plugin's directory name. Derive `<marketplace>` from
+the `name` field in the root `.claude-plugin/marketplace.json` of this repo.
+Surface the command verbatim in the PR description. Which repos consume the
+plugin is the author's knowledge — this skill cannot discover external
+consumers.
+
+## Checklist
+
+Emit this on trigger and verify each item before committing:
+
+```
+Plugin semver checklist:
+- [ ] the plugin's .claude-plugin/plugin.json `version` bumped
+- [ ] Bump magnitude matches the change (see table above)
+- [ ] No `version` field added to the plugin's marketplace.json entry
+- [ ] PR description includes the post-merge install command
+```

--- a/plugins/skill-review/.claude-plugin/plugin.json
+++ b/plugins/skill-review/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "skill-review",
-  "description": "Behavioral-equivalence audit for SKILL.md changes. Gates git commit when staged changes include a SKILL.md. Primarily useful in claude-config itself where SKILL.md files are authored.",
+  "description": "Behavioral-equivalence audit for SKILL.md changes. Gates git commit when staged changes include a SKILL.md. Install at project scope in repos that author SKILL.md files.",
   "version": "1.0.1",
   "author": {
     "name": "Cordova Strategy"


### PR DESCRIPTION
## Summary

- **Removes duplicate `version` fields from `.claude-plugin/marketplace.json`**: Claude Code resolves `plugin.json` first and silently masks any marketplace value; having version in both files only creates drift. All three existing entries (`lovable-cloud`, `skill-review`, `claude-hook-review`) had this anti-pattern.
- **Adds `plugins/plugin-semver/`**: A new guidance skill that fires when editing files inside any plugin directory or marketplace manifest. Surfaces the single-source-of-truth convention and a semver bump-magnitude table keyed on backward compatibility (not change size).
- **Reconciles description drift**: `skill-review` and `claude-hook-review` plugin.json descriptions now match their marketplace entries.
- **Adds enforcement test**: `claude/.claude/skills/tests/test_plugin_manifests.py` asserts no `version` field in marketplace entries and every `plugin.json` has one.

## Semver bump table (from the new skill)

| Change to the plugin | Bump |
|---|---|
| Backward-compatible bug fix — typo, clarification, or correcting a skill to match its already-documented behavior | patch |
| Backward-compatible addition — new skill/hook, new capability, or trigger broadened | minor |
| Backward-incompatible change — behavior changes for existing users, trigger narrowed, skill/hook removed or renamed, plugin renamed/split | major |

Axis is backward compatibility (semver.org items 6–8), not change size.

## Post-merge install command (consuming repos)

```bash
claude plugin install plugin-semver@claude-config --scope project
```

## Test plan

- [x] `pytest claude/.claude/` — 801 tests pass (includes new `test_plugin_manifests.py`)
- [x] `ruff check claude/.claude/` — clean
- [x] `/skill-review` on new `SKILL.md` — clean
- [x] `/code-review` on staged diff — clean
- [ ] Smoke-test: after merge, run `claude plugin marketplace update claude-config` + `claude plugin install plugin-semver@claude-config --scope project` in a fresh session, edit a file under `plugins/<name>/`, confirm checklist surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)