### PR TITLE
docs: document platform-agnostic rule for stowed skill bodies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,8 @@ not want to extend. Mirror existing entries when in doubt.
 
 **Project-scoped plugins:** skills that apply to one or a few private projects — not broadly to all sessions — live under `plugins/<name>/` as marketplace plugins, not in `claude/.claude/skills/`. The repo exposes itself as a marketplace via `.claude-plugin/marketplace.json`. Add `.claude-plugin/plugin.json` and `skills/<name>/SKILL.md` inside `plugins/<name>/`. Install at project scope from the consuming repo: `claude plugin install <name>@claude-config --scope project`.
 
+**Global skill bodies stay platform-agnostic.** Skills under `claude/.claude/skills/` are stowed to every user who clones this repo — their bodies must read cleanly regardless of stack. Encode the generic concept; do not hardcode engine/platform-specific tokens (`pg_cron`, `net.http_post`, vendor API names). Stack-specific examples and checks belong in a project-layer skill (`<skill>-<project>/SKILL.md`) that the base skill loads via its project-layer glob — e.g. `/code-review`'s Step 0.5 globs `.claude/skills/code-review-*/SKILL.md`.
+
 ## Plans in this repo affect all stow users
 
 `claude/` is stowed into `$HOME` — changes ship to every user who clones and stows this repo, not only to the session owner. When reviewing a plan for `claude-config`, evaluate with that audience in mind. Files under `claude/` are not personal config; they are distributed to all stow users on `git pull`. Surface this when declaring the user surface in Step 2 of plan-review, and weight finding severity accordingly.

--- a/plugins/skill-review/skills/skill-review/SKILL.md
+++ b/plugins/skill-review/skills/skill-review/SKILL.md
@@ -13,8 +13,6 @@ user-invocable: false
 
 # Skill Review — Architecture & Checklist
 
-Fires during **review, audit, and authoring** of `.claude/skills/**/SKILL.md` changes.
-
 ## 1. What makes a skill load
 
 A skill file is `claude/.claude/skills/<name>/SKILL.md`. Required
@@ -183,6 +181,10 @@ If not all three hold, point at the canonical source.
     an imperative directive, an escape-hatch exception, or a
     verification command fails this audit even when the summary reads
     as equivalent.
+
+12. **Platform-genericness** — skills under `claude/.claude/skills/` keep
+    engine/platform tokens (`pg_cron`, `net.http_post`) out; stack-specific
+    content goes in a `<skill>-<project>` layer. (Repo-specific; see CLAUDE.md.)
 
 ## Step — Record review completion
 


### PR DESCRIPTION
## Summary

- Adds a **Global skill bodies stay platform-agnostic** rule to repo-root `CLAUDE.md`, explaining that skills under `claude/.claude/skills/` are stowed to every user and must not hardcode engine/platform-specific tokens (`pg_cron`, `net.http_post`, vendor API names)
- Adds checklist item 12 (**Platform-genericness**) to `plugins/skill-review/skills/skill-review/SKILL.md` so the rule is enforced at review time
- Trims a redundant section-intro sentence from SKILL.md (it restated the frontmatter description verbatim, which is always-loaded)

## Test plan

- [x] `pytest claude/.claude/` — 801 tests pass
- [x] `ruff check claude/.claude/` — no lint issues
- [x] `/skill-review` run on SKILL.md diff — behavioral-equivalence audit passed (removed sentence fully covered by frontmatter description); item 12 passes behavior test
- [x] `/ai-instruction-and-memory-files` run on CLAUDE.md diff — placement, voice, and behavior test all pass; no duplication
- [x] `/code-review` — no findings; skill-review marker already in place for SKILL.md domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)