### PR TITLE
feat(auto-mode): add claude-auto wrapper and fix README model requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,18 +362,22 @@ Auto mode replaces per-action permission prompts with a background classifier th
 #### Requirements
 
 - **Plan:** Max, Team, Enterprise, or Anthropic API. Not available on Pro, or on Bedrock, Vertex, or Foundry.
-- **Model:** see the [permission modes reference](https://code.claude.com/docs/en/permission-modes) for the current supported model list. Verify that any custom model alias in your `settings.json` ultimately resolves to a supported model.
+- **Model:** Auto mode requires a supported *session* model — the eligible set is plan-dependent (see the [permission modes reference](https://code.claude.com/docs/en/permission-modes) for the authoritative list). Opus is eligible on all qualifying plans; Sonnet is additionally eligible on Team, Enterprise, and API, but **not on Max**. This repo ships `opusplan` as the default, which routes auto mode to Sonnet during execution — on Max that produces "unavailable for this model." The `claude-auto` wrapper described in the next section handles this automatically.
 - **Claude Code:** a recent release — check `claude --version` against the [permission modes reference](https://code.claude.com/docs/en/permission-modes).
 
 #### Activating
 
-Press **Shift+Tab** in the CLI to cycle through modes until `auto` appears, then accept the one-time opt-in prompt. To start directly in auto mode:
+Press **Shift+Tab** in the CLI to cycle through modes until `auto` appears, then accept the one-time opt-in prompt. To start directly in auto mode, use the `claude-auto` wrapper shipped by this repo:
 
 ```bash
-claude --permission-mode auto
+claude-auto                                # defaults to Opus (eligible on all plans)
+claude-auto "summarize the open PRs"       # positional prompt passes through
+CLAUDE_AUTO_MODE_MODEL=sonnet claude-auto  # Sonnet override (Team/Enterprise/API only)
 ```
 
-To make it the default, add to `~/.claude/settings.json`:
+The wrapper resolves the model mismatch between `opusplan`'s Sonnet execution and auto mode's session-model requirement. On Team, Enterprise, and API plans, Sonnet is eligible for auto mode, so `claude --permission-mode auto` also works directly — the wrapper is most useful on Max, where only Opus qualifies.
+
+To make auto mode the default, add to `~/.claude/settings.json`:
 
 ```json
 {
@@ -382,6 +386,8 @@ To make it the default, add to `~/.claude/settings.json`:
   }
 }
 ```
+
+`defaultMode` sets the *mode*, not the *model* — the session-model requirement above still applies regardless of how auto mode is activated.
 
 #### Hard-floor deny rules
 

--- a/README.md
+++ b/README.md
@@ -370,12 +370,12 @@ Auto mode replaces per-action permission prompts with a background classifier th
 Press **Shift+Tab** in the CLI to cycle through modes until `auto` appears, then accept the one-time opt-in prompt. To start directly in auto mode, use the `claude-auto` wrapper shipped by this repo:
 
 ```bash
-claude-auto                                # defaults to Opus (eligible on all plans)
-claude-auto "summarize the open PRs"       # positional prompt passes through
-CLAUDE_AUTO_MODE_MODEL=sonnet claude-auto  # Sonnet override (Team/Enterprise/API only)
+claude-auto                          # defaults to Opus (eligible on all plans)
+claude-auto "summarize the open PRs"  # positional prompt passes through
+ANTHROPIC_MODEL=sonnet claude-auto   # Sonnet override (Team/Enterprise/API only)
 ```
 
-The wrapper resolves the model mismatch between `opusplan`'s Sonnet execution and auto mode's session-model requirement. On Team, Enterprise, and API plans, Sonnet is eligible for auto mode, so `claude --permission-mode auto` also works directly — the wrapper is most useful on Max, where only Opus qualifies.
+The wrapper resolves the model mismatch between `opusplan`'s Sonnet execution and auto mode's session-model requirement. On Team, Enterprise, and API plans, Sonnet is eligible for auto mode, so `claude --permission-mode auto` also works directly — the wrapper is most useful on Max, where only Opus qualifies. `ANTHROPIC_MODEL` is Claude Code's built-in model env var and applies to all invocation forms.
 
 To make auto mode the default, add to `~/.claude/settings.json`:
 

--- a/claude/.claude/plans/read-tmp-auto-mode-environment-config-ha-magical-mccarthy.md
+++ b/claude/.claude/plans/read-tmp-auto-mode-environment-config-ha-magical-mccarthy.md
@@ -110,7 +110,7 @@ it produced land in one PR — do not leave it as an orphaned untracked file.
    **Opus 4.7** with auto mode active.
 3. `claude-auto "list the open PRs"` — confirm the argument passes through to
    the prompt.
-4. `CLAUDE_AUTO_MODE_MODEL=sonnet claude-auto` — confirm the statusline shows
+4. `ANTHROPIC_MODEL=sonnet claude-auto` — confirm the statusline shows
    **Sonnet 4.6** (on Max, auto mode is then expectedly unavailable — this
    override is for Team/Enterprise/API users).
 5. Render `README.md`; confirm the `### Auto mode` section reads correctly and

--- a/claude/.claude/plans/read-tmp-auto-mode-environment-config-ha-magical-mccarthy.md
+++ b/claude/.claude/plans/read-tmp-auto-mode-environment-config-ha-magical-mccarthy.md
@@ -28,10 +28,10 @@ cleanly on every plan, not just Max.
 - **No `settings.json` change.** `opusplan` remains the committed default.
 - **Ship a launcher** at `claude/.local/bin/claude-auto` — a pure passthrough
   wrapper, following the repo's existing `~/.local/bin` PATH-wrapper pattern.
-- **Cross-plan compatibility** via an overridable model variable, defaulting to
-  `opus` (the only model eligible for auto mode on *both* Max and enterprise
-  plans). Enterprise users who prefer Sonnet's lighter execution override with
-  `CLAUDE_AUTO_MODE_MODEL=sonnet`.
+- **Cross-plan compatibility** via Claude Code's built-in `ANTHROPIC_MODEL` env
+  var, defaulting to `opus` (the only model eligible for auto mode on *both* Max
+  and enterprise plans). Enterprise users who prefer Sonnet's lighter execution
+  override with `ANTHROPIC_MODEL=sonnet`.
 - **Update** the existing README `### Auto mode` section — it currently gives
   activation instructions that fail under the repo's own shipped default on Max.
 
@@ -55,8 +55,8 @@ executable bit set (`chmod +x`); git tracks the mode, and the existing
 # on Max. Opus is the safe cross-plan default.
 #
 # Team/Enterprise/API users who prefer Sonnet's lighter execution can override:
-#   CLAUDE_AUTO_MODE_MODEL=sonnet claude-auto
-exec claude --model "${CLAUDE_AUTO_MODE_MODEL:-opus}" --permission-mode auto "$@"
+#   ANTHROPIC_MODEL=sonnet claude-auto
+exec claude --model "${ANTHROPIC_MODEL:-opus}" --permission-mode auto "$@"
 ```
 
 `stow` symlinks `claude/.local/bin/` → `~/.local/bin/` (already done by

--- a/claude/.claude/plans/read-tmp-auto-mode-environment-config-ha-magical-mccarthy.md
+++ b/claude/.claude/plans/read-tmp-auto-mode-environment-config-ha-magical-mccarthy.md
@@ -1,0 +1,118 @@
+# Auto mode: README docs + cross-plan launcher
+
+## Context
+
+A prior session configured `autoMode.environment` in three project roots; that
+work is verified and complete. While activating auto mode the repo owner hit
+`auto mode unavailable for this model`. Root cause, verified against the
+official [permission modes reference](https://code.claude.com/docs/en/permission-modes):
+
+- This repo ships `"model": "opusplan"` in `claude/.claude/settings.json`.
+  `opusplan` runs Opus in plan mode and **Sonnet during execution**.
+- Auto mode is an *execution* mode. Its supported session model is
+  plan-dependent: **Opus on every eligible plan; Sonnet additionally on Team /
+  Enterprise / API, but not on Max.**
+- So on a **Max** plan, the shipped `opusplan` default routes auto mode to
+  Sonnet 4.6 → unsupported → "unavailable for this model." On Team / Enterprise
+  / API, `opusplan`'s Sonnet execution *is* eligible and auto mode works
+  directly.
+
+`opusplan` stays the global default (owner's decision — it is the right default
+for non-auto-mode work). This change makes auto mode reachable without changing
+that default, and documents the interaction. The repo is stow-distributed to
+engineers on **both Max and enterprise plans**, so the launcher must work
+cleanly on every plan, not just Max.
+
+## Decisions
+
+- **No `settings.json` change.** `opusplan` remains the committed default.
+- **Ship a launcher** at `claude/.local/bin/claude-auto` — a pure passthrough
+  wrapper, following the repo's existing `~/.local/bin` PATH-wrapper pattern.
+- **Cross-plan compatibility** via an overridable model variable, defaulting to
+  `opus` (the only model eligible for auto mode on *both* Max and enterprise
+  plans). Enterprise users who prefer Sonnet's lighter execution override with
+  `CLAUDE_AUTO_MODE_MODEL=sonnet`.
+- **Update** the existing README `### Auto mode` section — it currently gives
+  activation instructions that fail under the repo's own shipped default on Max.
+
+## Implementation
+
+### 1. New file — `claude/.local/bin/claude-auto`
+
+Single-file `exec` launcher (no backing script in `claude/.claude/scripts/` —
+there is no logic to host there; a two-file split would be cargo-culting the
+pattern used by the logic-bearing wrappers). Must be created with the
+executable bit set (`chmod +x`); git tracks the mode, and the existing
+`claude/.local/bin/*` shims are executable.
+
+```bash
+#!/usr/bin/env bash
+# claude-auto — launch Claude Code in auto mode on a model auto mode accepts.
+#
+# Repo default model is opusplan (Opus in plan mode, Sonnet during execution).
+# Auto mode is an execution mode; its supported session model is plan-dependent:
+# Opus on every eligible plan; Sonnet additionally on Team/Enterprise/API, not
+# on Max. Opus is the safe cross-plan default.
+#
+# Team/Enterprise/API users who prefer Sonnet's lighter execution can override:
+#   CLAUDE_AUTO_MODE_MODEL=sonnet claude-auto
+exec claude --model "${CLAUDE_AUTO_MODE_MODEL:-opus}" --permission-mode auto "$@"
+```
+
+`stow` symlinks `claude/.local/bin/` → `~/.local/bin/` (already done by
+`install.sh`, which also `mkdir -p`s the directory). **No `install.sh` change
+needed** — a re-run of `./install.sh` picks up the new wrapper automatically.
+
+### 2. README — `### Auto mode` section (`README.md`, ~lines 358–440)
+
+- **`#### Requirements` → Model bullet** (line 365): replace the generic "verify
+  your alias resolves to a supported model" text with the concrete situation —
+  auto mode needs a supported *session* model; the supported set is
+  plan-dependent (Opus everywhere eligible; Sonnet also on Team/Enterprise/API,
+  not Max); link the permission-modes reference for the authoritative list;
+  state the repo consequence — the shipped `opusplan` default runs Sonnet during
+  execution, so on Max the bare `claude --permission-mode auto` reports
+  "unavailable for this model." Point to the `claude-auto` wrapper.
+- **`#### Activating`** (lines 368–384): keep the Shift+Tab description. Replace
+  the bare `claude --permission-mode auto` example as the primary instruction
+  with the `claude-auto` wrapper, showing argument passthrough and the
+  `CLAUDE_AUTO_MODE_MODEL=sonnet` override. Note that on Team/Enterprise/API the
+  bare `claude --permission-mode auto` works directly under `opusplan` (Sonnet
+  is eligible there). Add a one-line caveat to the `defaultMode` block: it sets
+  the *mode*, not the *model*, so the model requirement above still applies.
+
+Documentation lives in the `### Auto mode` section only. The `### Scripts`
+section is scoped to `claude/.claude/scripts/` utilities and is left unchanged;
+`claude-auto` is a `.local/bin` launcher, not a `scripts/` utility.
+
+## Files modified
+
+| File | Change |
+|---|---|
+| `claude/.local/bin/claude-auto` | **new** — executable launcher |
+| `README.md` | `### Auto mode` — Model requirement + Activating subsections |
+| `claude/.claude/plans/read-tmp-auto-mode-environment-config-ha-magical-mccarthy.md` | **new** — this plan; ships in the same PR |
+
+Not changed: `claude/.claude/settings.json` (opusplan stays), `install.sh`
+(wrapper auto-stows), no test file (pure `exec` passthrough has no logic to
+assert; the repo's `scripts/tests/` covers logic-bearing scripts only).
+
+`~/.claude/plans/` is stow-linked to `claude/.claude/plans/`, so the plan file
+is repo-tracked. `git add` it alongside the implementation so the plan and what
+it produced land in one PR — do not leave it as an orphaned untracked file.
+
+## Verification
+
+1. `./install.sh` — confirm `~/.local/bin/claude-auto` is a symlink and
+   executable (`ls -l ~/.local/bin/claude-auto`).
+2. From a repo directory, run `claude-auto`. Expect: the one-time auto-mode
+   consent dialog (first run only), then a session whose statusline shows
+   **Opus 4.7** with auto mode active.
+3. `claude-auto "list the open PRs"` — confirm the argument passes through to
+   the prompt.
+4. `CLAUDE_AUTO_MODE_MODEL=sonnet claude-auto` — confirm the statusline shows
+   **Sonnet 4.6** (on Max, auto mode is then expectedly unavailable — this
+   override is for Team/Enterprise/API users).
+5. Render `README.md`; confirm the `### Auto mode` section reads correctly and
+   the permission-modes reference link resolves.
+6. `/code-review` on the diff before handoff (repo workflow).

--- a/claude/.local/bin/claude-auto
+++ b/claude/.local/bin/claude-auto
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# claude-auto — launch Claude Code in auto mode on a model auto mode accepts.
+#
+# Repo default model is opusplan (Opus in plan mode, Sonnet during execution).
+# Auto mode is an execution mode; its supported session model is plan-dependent:
+# Opus on every eligible plan; Sonnet additionally on Team/Enterprise/API, not
+# on Max. Opus is the safe cross-plan default.
+#
+# Team/Enterprise/API users who prefer Sonnet's lighter execution can override:
+#   CLAUDE_AUTO_MODE_MODEL=sonnet claude-auto
+exec claude --model "${CLAUDE_AUTO_MODE_MODEL:-opus}" --permission-mode auto "$@"

--- a/claude/.local/bin/claude-auto
+++ b/claude/.local/bin/claude-auto
@@ -7,5 +7,5 @@
 # on Max. Opus is the safe cross-plan default.
 #
 # Team/Enterprise/API users who prefer Sonnet's lighter execution can override:
-#   CLAUDE_AUTO_MODE_MODEL=sonnet claude-auto
-exec claude --model "${CLAUDE_AUTO_MODE_MODEL:-opus}" --permission-mode auto "$@"
+#   ANTHROPIC_MODEL=sonnet claude-auto
+exec claude --model "${ANTHROPIC_MODEL:-opus}" --permission-mode auto "$@"


### PR DESCRIPTION
## Summary

- Adds `claude/.local/bin/claude-auto` — a cross-plan-compatible launcher that resolves the model mismatch between `opusplan`'s Sonnet execution and auto mode's session-model requirement; defaults to Opus (eligible on all qualifying plans), with `ANTHROPIC_MODEL=sonnet` override for Team/Enterprise/API users who prefer the lighter model
- Updates `README.md` `### Auto mode` section: Model bullet now gives the precise plan-dependent eligibility (Opus everywhere; Sonnet also on Team/Enterprise/API but not Max) and points to the wrapper; Activating subsection replaces the broken bare `claude --permission-mode auto` example with `claude-auto` usage, notes that Team/Enterprise/API can still use the bare form, and adds a `defaultMode` caveat
- Adds the implementation plan file (stow-tracked under `claude/.claude/plans/`)

## Root cause

This repo ships `opusplan` as the default model. `opusplan` routes auto mode (an *execution* mode) to Sonnet 4.6. On Max plans, Sonnet is not eligible for auto mode — producing "unavailable for this model" against the existing README instructions. On Team/Enterprise/API, Sonnet is eligible, so the bare form works there.

## Test plan

- [ ] Merge to main; run `./install.sh` from main tree; confirm `ls -la ~/.local/bin/claude-auto` shows a symlink and `x` bit
- [ ] Run `claude-auto` — expect one-time consent prompt (first run), then statusline shows **Opus 4.7** with auto mode active
- [ ] Run `claude-auto "list the open PRs"` — confirm positional arg passes through
- [ ] (Team/Enterprise/API only) `ANTHROPIC_MODEL=sonnet claude-auto` — statusline shows **Sonnet 4.6** with auto mode active

🤖 Generated with [Claude Code](https://claude.com/claude-code)