### PR TITLE
fix(redaction-hook): name matched blocklist entry and quote offending line(s) in deny

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,9 +347,9 @@ The match is **case-insensitive whole-word**, which is narrower than substring m
 
 A committed list of private-project names in this public repo would itself be the leak — it would hardcode in cleartext the exact strings the rule prevents from shipping. The file lives at `~/.claude/private-projects.md` directly, **not** inside `claude-config/claude/.claude/` (which `stow` symlinks into `$HOME/`). Creating it in the wrong place risks accidental commit; the repo-root `.gitignore` has a belt-and-suspenders entry for `claude/.claude/private-projects.md` as a safety net.
 
-#### Privacy of the deny message
+#### What the deny message reports
 
-When the blocklist scan blocks a commit or PR, the deny message **does not name which entry matched**. Echoing a name the user explicitly flagged as sensitive would re-expose it in terminal output, screenshots, CI logs, and Claude's own conversation context — exactly the surfaces the gate exists to protect. The tracker-ID scan does name matched tokens because they're mechanical patterns, not user-flagged secrets.
+When the blocklist scan blocks a commit or PR, the deny message names each matched blocklist entry and quotes the offending line(s) from the staged content. The matched token is the user's own private-project name, already in the staged content and in `~/.claude/private-projects.md`; naming it in the deny discloses it to no new party, while letting the agent locate and remove it in one pass rather than bisecting the diff. The tracker-ID scan similarly names matched tokens.
 
 #### For fork contributors
 

--- a/claude/.claude/hooks/deny-private-project-refs.sh
+++ b/claude/.claude/hooks/deny-private-project-refs.sh
@@ -98,12 +98,13 @@
 # identifiers (which the user can blocklist as separate entries if
 # they appear in commit-time content).
 #
-# Invariant: the blocklist scan's deny message does NOT name the
-# matched entry. Echoing a name the user explicitly flagged as
-# sensitive would re-expose it in terminal output, screenshots, CI
-# logs, and Claude's conversation context — exactly the surfaces this
-# gate exists to protect. Generic-message-only is load-bearing and
-# tested.
+# Blocklist deny message: names each matched blocklist entry verbatim
+# and quotes the offending line(s) from the scanned content (capped at
+# 3 lines per entry, each truncated to 200 chars). The matched token is
+# the user's own private-project name, already in the staged content
+# and in ~/.claude/private-projects.md; naming it in the deny
+# discloses it to no new party while letting the agent remove it in
+# one pass rather than bisecting the diff manually.
 #
 # Allowlist extension: append to OSS_ALLOWLIST below if a legitimate
 # open-source prefix is blocked. Do NOT add private-project-specific
@@ -117,10 +118,10 @@
 # best-effort grep (not a real shell parser) — && and || in prose are
 # rare enough to justify detection; ; is excluded to avoid false positives
 # on prose semicolons. The hint is informational only — the deny condition
-# is unchanged. The "matched entry is intentionally NOT named" invariant
-# above is preserved: the hint uses placeholder examples (<name>), not
-# the matched token. Parallel to cwd_anchor_note_if_chained in
-# require-worktree-for-git-writes.sh.
+# is unchanged. The hint uses placeholder examples (<name>) in its
+# illustrative cd-path guidance; it does not echo $COMMAND because the
+# command text is not needed for the split guidance. Parallel to
+# cwd_anchor_note_if_chained in require-worktree-for-git-writes.sh.
 
 set -uo pipefail
 
@@ -334,9 +335,9 @@ is_pseudo_file_path() {
 # still trigger the hint (known false positive).
 chain_split_hint_if_chained() {
   if printf '%s' "$1" | grep -qE '&&|\|\|'; then
-    # $1 is used as a grep predicate only — intentionally not echoed.
-    # Echoing any part of $COMMAND would risk re-exposing the matched
-    # blocklist entry (see header "Invariant" note).
+    # $1 is used as a grep predicate only — its text is not echoed in
+    # the hint because the command content is not needed for the split
+    # guidance.
     printf '%s' " Tip: this command chains operations with && / ||. If the matched token is in a path or setup portion of the chain (e.g. a \`cd /home/<name>/...\` prefix) and is NOT actually a private-project reference in the gated content, split the chain into two separate Bash calls — the cwd persists between calls in the same session, so running \`cd /path\` as one call and the gated command as a follow-up call keeps the path out of the gated command's text. If the match IS a real private-project reference in the gated content (PR body, commit message, gh api body), the chain-split won't help — rewrite the content instead. The match-anywhere foundation is intentional; see the hook header for design rationale."
   fi
 }
@@ -499,6 +500,7 @@ fi
 # readability gate ([ -r ]) covers both absent and unreadable cases.
 PRIVATE_PROJECTS_FILE="${HOME}/.claude/private-projects.md"
 if [ -r "$PRIVATE_PROJECTS_FILE" ]; then
+  blocklist_report=""
   while IFS= read -r raw_line || [ -n "$raw_line" ]; do
     # Strip CR (CRLF), then leading/trailing whitespace.
     line=${raw_line%$'\r'}
@@ -511,12 +513,25 @@ if [ -r "$PRIVATE_PROJECTS_FILE" ]; then
     # `-F` is literal-match (no regex foot-guns), `-i` case-insensitive,
     # `-w` whole-word boundaries, `--` guards entries that happen to
     # start with `-`. See header "Whole-word matching" note for the
-    # tradeoff rationale.
-    if printf '%s' "$SCAN_TARGET" | grep -qiw -F -- "$line"; then
-      # Generic message — see header "Invariant" note. The matched
-      # entry is intentionally NOT named.
-      emit_deny "Blocked by redaction gate: the staged diff, commit message, referenced commit-message file, PR title, PR body, referenced body-source file, gh api request body, or referenced --input file contains an entry from your ~/.claude/private-projects.md blocklist. Review the content and remove the project name before retrying. (The hook deliberately does not name which entry matched — printing it would re-expose the value in terminal output, CI logs, and Claude's conversation context, which is exactly what this gate exists to prevent.) See repo CLAUDE.md section 'Redact private-project-identifying content'.$(chain_split_hint_if_chained "$COMMAND")"
-      exit 0
+    # tradeoff rationale. Collect the offending lines (cap 3 per entry);
+    # grep | head may SIGPIPE under pipefail — bare assignment is safe
+    # because -e is not set.
+    matched_lines=$(printf '%s' "$SCAN_TARGET" | grep -iw -F -- "$line" | head -3)
+    if [ -n "$matched_lines" ]; then
+      blocklist_report="${blocklist_report}"$'\n'"  - ${line}"
+      while IFS= read -r hit; do
+        if [ "${#hit}" -gt 200 ]; then
+          hit="${hit:0:200}…"
+        fi
+        blocklist_report="${blocklist_report}"$'\n'"    ${hit}"
+      done <<< "$matched_lines"
     fi
   done < "$PRIVATE_PROJECTS_FILE"
+
+  if [ -n "$blocklist_report" ]; then
+    emit_deny "Blocked by redaction gate: staged/committed content matches entries from your ~/.claude/private-projects.md blocklist. Remove these references before retrying:${blocklist_report}
+
+See repo CLAUDE.md section 'Redact private-project-identifying content'.$(chain_split_hint_if_chained "$COMMAND")"
+    exit 0
+  fi
 fi

--- a/claude/.claude/hooks/tests/test_deny_private_project_refs.py
+++ b/claude/.claude/hooks/tests/test_deny_private_project_refs.py
@@ -731,7 +731,8 @@ class TestDenyPrivateProjectRefs:
     # Second mechanical defense alongside the tracker-ID scan. Reads
     # ~/.claude/private-projects.md as a literal, case-insensitive
     # substring blocklist. Fails open if the file is absent or unreadable.
-    # Critical invariant: the deny message NEVER names the matched entry.
+    # Deny message behavior: names each matched blocklist entry and quotes
+    # the offending line(s) so the agent can locate and remove it in one pass.
 
     def test_blocklist_match_in_commit_message_denied(self, claude_config_repo, private_projects_file):
         private_projects_file("Acme Corp\n")
@@ -956,14 +957,13 @@ class TestDenyPrivateProjectRefs:
                 == "deny"
             ), f"expected deny for {punct_form!r}"
 
-    def test_blocklist_deny_message_does_not_name_entry(self, claude_config_repo, private_projects_file):
-        """LOAD-BEARING: the deny message must NOT echo the matched entry.
+    def test_blocklist_deny_message_names_matched_entry(self, claude_config_repo, private_projects_file):
+        """Deny message must name the matched blocklist entry verbatim.
 
-        Echoing a name the user explicitly flagged as sensitive would
-        re-expose it in terminal output, screenshots, CI logs, and
-        Claude's own conversation context — exactly the surfaces this
-        gate exists to protect. This invariant is documented in the
-        hook header and must hold across refactors.
+        The matched token is the user's own private-project name, already
+        in the staged content. Naming it in the deny lets the agent remove
+        it in one pass rather than bisecting the diff manually. The user
+        is also pointed at their blocklist file for context.
         """
         private_projects_file("Acme Corp\n")
         result = subprocess.run(
@@ -979,15 +979,90 @@ class TestDenyPrivateProjectRefs:
         assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
         reason = payload["hookSpecificOutput"]["permissionDecisionReason"]
 
-        # Bright-line: no case variant of the matched entry appears.
-        assert "Acme Corp" not in reason
-        assert "acme corp" not in reason.lower()
+        # Entry is named so the agent knows what to remove.
+        assert "Acme Corp" in reason
 
-        # Lock in the explanation so a refactor that drops it fails fast.
-        assert "deliberately does not name which entry matched" in reason
-
-        # Sanity: the user is pointed at their own blocklist file.
+        # User is pointed at their own blocklist file.
         assert "private-projects.md" in reason
+
+    def test_blocklist_deny_quotes_offending_line(self, claude_config_repo, private_projects_file):
+        """Deny message includes the offending line, not just the entry name."""
+        private_projects_file("Acme Corp\n")
+        result = subprocess.run(
+            [str(DENY_PRIVATE_PROJECT_REFS_HOOK)],
+            input=json.dumps(bash_input("git commit -m 'Acme Corp quarterly report'")),
+            capture_output=True,
+            text=True,
+            cwd=claude_config_repo,
+            check=False,
+        )
+        payload = json.loads(result.stdout)
+        assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
+        reason = payload["hookSpecificOutput"]["permissionDecisionReason"]
+        assert "Acme Corp" in reason
+        # "quarterly report" only appears because the offending line was quoted.
+        assert "quarterly report" in reason
+
+    def test_blocklist_deny_names_all_matched_entries(self, claude_config_repo, private_projects_file):
+        """When multiple blocklist entries match, all are reported in one message."""
+        private_projects_file("Acme Corp\nFoo Bar Inc\n")
+        result = subprocess.run(
+            [str(DENY_PRIVATE_PROJECT_REFS_HOOK)],
+            input=json.dumps(bash_input("git commit -m 'fix Acme Corp and Foo Bar Inc integration'")),
+            capture_output=True,
+            text=True,
+            cwd=claude_config_repo,
+            check=False,
+        )
+        payload = json.loads(result.stdout)
+        assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
+        reason = payload["hookSpecificOutput"]["permissionDecisionReason"]
+        assert "Acme Corp" in reason
+        assert "Foo Bar Inc" in reason
+
+    def test_blocklist_deny_truncates_long_offending_line(self, claude_config_repo, private_projects_file, tmp_path):
+        """An offending line longer than 200 chars is truncated with an ellipsis."""
+        private_projects_file("Acme Corp\n")
+        long_line = "Acme Corp " + "x" * 220
+        msg_file = tmp_path / "commit-msg.txt"
+        msg_file.write_text(long_line + "\n")
+        result = subprocess.run(
+            [str(DENY_PRIVATE_PROJECT_REFS_HOOK)],
+            input=json.dumps(bash_input(f"git commit -F {msg_file}")),
+            capture_output=True,
+            text=True,
+            cwd=claude_config_repo,
+            check=False,
+        )
+        payload = json.loads(result.stdout)
+        assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
+        reason = payload["hookSpecificOutput"]["permissionDecisionReason"]
+        assert "Acme Corp" in reason
+        assert "…" in reason
+
+    def test_blocklist_deny_offending_lines_capped_at_three(self, claude_config_repo, private_projects_file, tmp_path):
+        """When an entry matches more than 3 lines, at most 3 are quoted."""
+        private_projects_file("Acme Corp\n")
+        msg_file = tmp_path / "commit-msg.txt"
+        msg_file.write_text(
+            "line1 Acme Corp\nline2 Acme Corp\nline3 Acme Corp\nline4 Acme Corp\nline5 Acme Corp\n"
+        )
+        result = subprocess.run(
+            [str(DENY_PRIVATE_PROJECT_REFS_HOOK)],
+            input=json.dumps(bash_input(f"git commit -F {msg_file}")),
+            capture_output=True,
+            text=True,
+            cwd=claude_config_repo,
+            check=False,
+        )
+        payload = json.loads(result.stdout)
+        assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
+        reason = payload["hookSpecificOutput"]["permissionDecisionReason"]
+        assert "Acme Corp" in reason
+        # Count lines in reason that are indented quoted lines (4-space prefix)
+        # containing the entry — must be at most 3.
+        quoted_lines = [ln for ln in reason.split("\n") if ln.startswith("    ") and "Acme Corp" in ln]
+        assert len(quoted_lines) <= 3
 
     # -- git commit -F / --file commit-message-source files ----------------
     # Parallel to gh pr's --body-file: the commit-message file's contents
@@ -1111,12 +1186,10 @@ class TestDenyPrivateProjectRefs:
             == "allow"
         )
 
-    def test_git_commit_F_blocklist_match_denied_with_generic_message(
+    def test_git_commit_F_blocklist_match_denied_names_entry(
         self, claude_config_repo, private_projects_file, tmp_path,
     ):
-        """User-local blocklist must apply to -F file content. Deny
-        message must NOT name the matched entry — the generic-message-
-        only invariant is load-bearing on the new scan path too."""
+        """User-local blocklist applies to -F file content; entry is named in deny."""
         private_projects_file("Acme Corp\n")
         msg_file = tmp_path / "commit-msg.txt"
         msg_file.write_text("Polish Acme Corp release flow.\n")
@@ -1132,9 +1205,8 @@ class TestDenyPrivateProjectRefs:
         payload = json.loads(result.stdout)
         assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
         reason = payload["hookSpecificOutput"]["permissionDecisionReason"]
-        assert "Acme Corp" not in reason
-        assert "acme corp" not in reason.lower()
-        assert "deliberately does not name which entry matched" in reason
+        assert "Acme Corp" in reason
+        assert "private-projects.md" in reason
 
     # -- gh api mutating-call surfaces -------------------------------------
     # `gh api repos/.../pulls/N/comments`, `.../comments/M/replies`,
@@ -1351,11 +1423,10 @@ class TestDenyPrivateProjectRefs:
             == "allow"
         )
 
-    def test_gh_api_blocklist_match_in_input_file_denied_with_generic_message(
+    def test_gh_api_blocklist_match_in_input_file_denied_names_entry(
         self, claude_config_repo, private_projects_file, tmp_path,
     ):
-        """User-local blocklist applies to --input file content too,
-        with the generic-message-only invariant preserved."""
+        """User-local blocklist applies to --input file content; entry is named in deny."""
         private_projects_file("Acme Corp\n")
         body_file = tmp_path / "comment.json"
         body_file.write_text('{"body": "Acme Corp release polish"}\n')
@@ -1373,9 +1444,8 @@ class TestDenyPrivateProjectRefs:
         payload = json.loads(result.stdout)
         assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
         reason = payload["hookSpecificOutput"]["permissionDecisionReason"]
-        assert "Acme Corp" not in reason
-        assert "acme corp" not in reason.lower()
-        assert "deliberately does not name which entry matched" in reason
+        assert "Acme Corp" in reason
+        assert "private-projects.md" in reason
 
     # -- gh api implicit POST and `@<path>` field-from-file bypass paths ---
     # Two bypasses surfaced in security review: (1) `gh api` auto-promotes
@@ -1542,10 +1612,9 @@ class TestDenyPrivateProjectRefs:
         self, claude_config_repo, private_projects_file,
     ):
         """A commit message containing BOTH a tracker token AND a
-        blocklist entry must surface the tracker-ID deny message. The
-        blocklist entry must NOT appear in the deny output — preserves
-        both the documented priority order AND the generic-message-only
-        invariant on the blocklist code path."""
+        blocklist entry must surface the tracker-ID deny message only.
+        The blocklist scan is skipped when the tracker-ID scan fires,
+        so the blocklist entry does not appear in the output."""
         private_projects_file("Acme Corp\n")
         result = subprocess.run(
             [str(DENY_PRIVATE_PROJECT_REFS_HOOK)],
@@ -1564,8 +1633,7 @@ class TestDenyPrivateProjectRefs:
         # Tracker-ID branch fired (priority): its specific marker phrase.
         assert "Commit blocked by redaction gate" in reason
         assert "WIDGET-123" in reason
-        # Blocklist entry must NOT appear — preserves generic-message
-        # invariant even when both scans would have matched.
+        # Blocklist scan is skipped when tracker fires, so entry absent.
         assert "Acme Corp" not in reason
         assert "acme corp" not in reason.lower()
 
@@ -1831,7 +1899,7 @@ class TestDenyPrivateProjectRefs:
         assert "Tip: this command chains" in reason
 
     def test_blocklist_chained_command_deny_includes_chain_hint(self, claude_config_repo, private_projects_file):
-        """Chained cd && gh pr create: blocklist match + chain detected, hint appended."""
+        """Chained cd && gh pr create: blocklist match named, chain hint appended."""
         private_projects_file("Acme Corp\n")
         result = subprocess.run(
             [str(DENY_PRIVATE_PROJECT_REFS_HOOK)],
@@ -1846,10 +1914,8 @@ class TestDenyPrivateProjectRefs:
         payload = json.loads(result.stdout)
         assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
         reason = payload["hookSpecificOutput"]["permissionDecisionReason"]
+        assert "Acme Corp" in reason
         assert "Tip: this command chains" in reason
-        # The "matched entry NOT named" invariant must hold even with the chain hint appended.
-        assert "Acme Corp" not in reason
-        assert "acme corp" not in reason.lower()
 
     def test_tracker_id_unchained_command_deny_omits_chain_hint(self, claude_config_repo):
         """Unchained command: deny fires for tracker-ID, but no chain hint."""

--- a/claude/.claude/plans/i-think-we-made-flickering-newt.md
+++ b/claude/.claude/plans/i-think-we-made-flickering-newt.md
@@ -1,0 +1,173 @@
+# Plan: Make the private-project redaction hook name what it blocked
+
+## Context
+
+`deny-private-project-refs.sh` blocks `git commit` / `gh pr create` / `gh pr edit`
+/ `gh api` when staged content contains an entry from
+`~/.claude/private-projects.md`. The blocklist branch deliberately emits a
+**generic** deny message that does **not** name which entry matched. The stated
+rationale (hook header lines 101-106, README lines 350-352): echoing a
+user-flagged name would "re-expose it in terminal output, CI logs, and Claude's
+conversation context."
+
+That rationale does not hold up:
+
+- The matched token is, by definition, the user's own private-project name,
+  already present in the content the agent staged. The hook still blocks the
+  *commit* — the name is kept out of public git history — but the name is not a
+  secret *to this user*: it sits in the staged file and in
+  `~/.claude/private-projects.md`, which the agent can read directly. Naming it in
+  the deny message discloses it to no principal who did not already hold it.
+- Every surface the deny message reaches — the agent's conversation context, the
+  local terminal, and the session transcript file under `~/.claude/projects/.../`
+  — is owned by the same single user who owns the blocklist and authored the
+  staged content. On a deny-then-retry-from-memory flow the agent may never run
+  `git diff --cached`, so the deny message can be the *only* persisted copy of the
+  name in that transcript — but that transcript is the same user's file. The
+  change relocates the user's own private name into the user's own transcript; it
+  creates no incremental exposure to a *new* party. (The original "re-expose it in
+  ... Claude's conversation context" framing treated the user's own transcript as
+  a surface to protect *from the user* — which is not a coherent threat model on
+  this single-user-local-machine surface.)
+- "CI logs" is not a meaningful surface for this hook — it is a local
+  `PreToolUse` hook on `git`/`gh`; CI does not run Claude Code hooks. A developer
+  manually pasting terminal output elsewhere is a human-mediated path that applies
+  equally to ordinary `git diff` output and is outside the hook's control.
+- The cost is high and real: sessions burn many tool calls bisecting the diff to
+  rediscover a token the hook already identified. The example that prompted this
+  showed an agent flailing through ~10 tool calls before a human had to point at
+  the offending line (a private-project name, whole-word-matched inside a filesystem path).
+
+The sibling tracker-ID branch (lines 490-495) already names matched tokens
+(`${HIT_LIST}`) — so the "never name" behavior is an inconsistency, not a
+coherent policy. This change brings the blocklist branch into line with it and
+goes one step further (per the user's choice): it also quotes the offending
+line(s), so the agent sees exactly where the token sits.
+
+**Outcome:** the deny message names every matching blocklist entry and quotes the
+offending line(s), so the agent can fix the content in one pass.
+
+## Scope decision — tracker-ID branch left unchanged
+
+Per the "audit structural siblings" heuristic, the tracker-ID branch was checked.
+It already names matched tokens (`PROJ-123`-shaped, trivially greppable), so it
+does **not** exhibit the flailing bug this change fixes. Adding line-context there
+is scope creep and is deliberately excluded.
+
+## Change
+
+Files (all in repo root):
+
+### 1. `claude/.claude/hooks/deny-private-project-refs.sh`
+
+**Blocklist scan loop — lines 501-522.** Replace the early-`exit 0`-on-first-match
+loop with accumulate-then-report:
+
+- Iterate the whole blocklist (keep the existing CR-strip / whitespace-trim /
+  blank-and-`#`-comment skipping at lines 502-509 unchanged).
+- For each entry, capture matching lines with the same predicate already used,
+  minus `-q`: `printf '%s' "$SCAN_TARGET" | grep -iw -F -- "$line" | head -3`
+  (cap at 3 offending lines per entry). Offending lines are sourced **only** from
+  `SCAN_TARGET` — the already-staged / already-authored content the hook scans —
+  never from `private-projects.md` itself, so the quote can never widen to the
+  blocklist file's own surrounding lines.
+- A quoted line may carry adjacent content beyond the matched token (e.g. a
+  hostname on the same line). This is accepted: the line is content the user
+  themselves staged and can re-read; the cap below bounds volume, and quoting the
+  line is what lets the agent locate the match in one pass.
+- Truncate each captured line to ~200 chars (`${hit:0:200}…`) so a minified blob
+  can't flood the message.
+- Shell note for the implementer: `grep ... | head -3` under the hook's
+  `set -o pipefail` can leave a non-zero pipe status when `head` closes the pipe
+  early. The hook does **not** set `-e`, so a bare command-substitution assignment
+  (`matched_lines=$(...)`) absorbs this harmlessly — do not wrap it in an `if`
+  condition that would misread the SIGPIPE status as a real failure.
+- Accumulate into a `blocklist_report` string: one block per matched entry —
+  the entry name, then its (truncated, capped) offending line(s).
+- After the loop, if `blocklist_report` is non-empty, call `emit_deny` once with a
+  message that lists all matched entries + lines, retains the CLAUDE.md pointer,
+  and keeps the `chain_split_hint_if_chained "$COMMAND"` suffix. Then `exit 0`.
+
+`emit_deny` (lines 131-137) already JSON-escapes the entire reason via
+`jq -Rs .`, so embedded newlines, quotes, and backslashes from diff content are
+handled — no extra escaping needed.
+
+**Header comment — lines 101-106.** Rewrite the "Invariant" block. New text states
+the deny message names matched entries and quotes offending lines, and gives the
+reason: the matched token is already present in the gated content the agent
+staged and will read via `git diff --cached`, so naming it adds no exposure
+beyond the diff itself while eliminating costly bisection.
+
+**Header comment — lines 119-123.** Drop the clause asserting the
+"matched entry is intentionally NOT named" invariant is "preserved." The chain
+hint still uses `<name>` placeholders for its own `cd`-path examples — that is
+fine and unrelated; only the invariant-justifying sentence is removed.
+
+**Comment — lines 337-340** (`chain_split_hint_if_chained`). Drop the
+"would risk re-exposing the matched blocklist entry (see header 'Invariant')"
+rationale. `$COMMAND` is still not echoed — simply because it is not needed for
+the hint, not because of a privacy invariant.
+
+**Comment — lines 516-517.** Remove the "Generic message ... intentionally NOT
+named" comment; replace with a one-line note describing the report shape.
+
+### 2. `claude/.claude/hooks/tests/test_deny_private_project_refs.py`
+
+Rewrite the five tests + section comment that assert non-naming
+(Explore-confirmed locations):
+
+- Section comment line 734 — `# Critical invariant: the deny message NEVER
+  names the matched entry.` → describe the new naming behavior.
+- `test_blocklist_deny_message_does_not_name_entry` (959-990) → rename to
+  `test_blocklist_deny_message_names_matched_entry`; assert the entry
+  (`Acme Corp`) **is** in `reason`, assert the offending line is quoted, drop the
+  `"deliberately does not name which entry matched"` assertion, keep
+  `"private-projects.md" in reason`.
+- `test_git_commit_F_blocklist_match_denied_with_generic_message` (1114-1137) →
+  assert the entry is named on the `-F` commit-message-file path.
+- `test_gh_api_blocklist_match_in_input_file_denied_with_generic_message`
+  (1354-1378) → assert the entry is named on the `gh api --input` path.
+- `test_tracker_id_takes_priority_over_blocklist_match` (1541-1570) → tracker
+  message still fires; blocklist branch is not reached, so its assertions stay
+  valid as-is.
+- `test_blocklist_chained_command_deny_includes_chain_hint` (1833-1852) → assert
+  the entry is named **and** the chain hint is appended.
+
+Add new tests:
+
+- Multiple matching blocklist entries → all named in one deny message.
+- Offending line is quoted verbatim in the deny message.
+- A >200-char offending line is truncated.
+- An entry appearing on >3 lines → at most 3 lines quoted.
+
+### 3. `README.md` — lines 350-352
+
+Rewrite the "Privacy of the deny message" subsection: the deny message names
+matched entries and quotes offending lines. Rationale (use the accurate framing,
+not "no exposure beyond the diff"): the matched token is the user's own private
+name, already in the staged content and in the user-local blocklist; every
+surface the message reaches — terminal, agent context, session transcript — is
+owned by that same user, so naming it discloses nothing to a new party while
+eliminating costly diff-bisection. Drop the "re-expose it in ... CI logs"
+claim — CI does not run this hook. Consider renaming the subsection
+(e.g. "What the deny message reports").
+
+### 4. `docs/hooks.md` — line 9 (optional, light touch)
+
+If the existing hook description would now be misleading, adjust one sentence.
+No change if it does not mention message contents.
+
+## Verification
+
+1. `pytest claude/.claude/` — full suite green (dispatch via `check-runner`).
+2. `ruff check claude/.claude/` — clean.
+3. Manual smoke test in a scratch repo wired to this hook:
+   - Add a synthetic entry to a test `private-projects.md`, stage a file
+     containing it, attempt `git commit` → confirm the deny message names the
+     entry and quotes the offending line.
+   - Stage content matching two entries → confirm both are reported in one
+     message.
+   - Stage content where the entry sits on a >200-char line → confirm
+     truncation.
+4. Per repo CLAUDE.md "run the skill on its own diff": this is a hook change,
+   so `/claude-hook-review` on the diff before PR handoff.


### PR DESCRIPTION
## Summary

- Replaces early-exit-on-first-match loop with accumulate-then-report in the blocklist branch of `deny-private-project-refs.sh`
- Deny message now names every matched blocklist entry and quotes up to 3 offending lines per entry (each truncated to 200 chars), so an agent can locate and remove the reference in one pass
- Brings blocklist branch into line with the tracker-ID branch, which already named matched tokens

## Why the old invariant didn't hold

The matched token is the user's own private-project name, already present in the staged content the agent authored. Naming it in the deny discloses it to no new party: every surface the message reaches (terminal, agent conversation context, session transcript) is owned by the same single user who owns `~/.claude/private-projects.md`. The prior "never name" rationale treated the user's own session transcript as a surface to protect from the user — not a coherent threat model on this single-user local-machine surface. Withholding the name caused agents to burn ~10 tool calls bisecting the diff to rediscover a token the hook already identified.

## Changes

| File | What changed |
|------|-------------|
| `claude/.claude/hooks/deny-private-project-refs.sh` | Blocklist scan loop: early-exit replaced with accumulate-then-report; header comment updated to describe new behavior; chain-hint comment trimmed to remove stale invariant reference |
| `claude/.claude/hooks/tests/test_deny_private_project_refs.py` | 5 tests renamed/updated to assert naming; 4 new tests added (quotes offending line, all entries named, truncation at 200 chars, 3-line cap) |
| `README.md` | "Privacy of the deny message" subsection rewritten as "What the deny message reports" |
| `claude/.claude/plans/i-think-we-made-flickering-newt.md` | Implementation plan |

## Test plan

- [x] `pytest claude/.claude/` — 811 tests pass
- [x] `ruff check claude/.claude/` — clean
- [ ] Manual smoke test: add a synthetic entry to `~/.claude/private-projects.md`, stage a file containing it, run `git commit` — confirm deny names the entry and quotes the offending line

🤖 Generated with [Claude Code](https://claude.com/claude-code)