### PR TITLE
fix(check-runner): prevent stale spool contamination via one-call discipline

### DIFF
--- a/claude/.claude/agents/check-runner.md
+++ b/claude/.claude/agents/check-runner.md
@@ -18,19 +18,21 @@ Run each enumerated command exactly once. On non-zero exit, capture and move to 
 
 Every Bash call must include the tool's `timeout` parameter set to 600000 (10 minutes). Do not omit it. A command that exceeds 10 minutes is treated as a TIMEOUT verdict for that command — capture whatever output the spool file holds and proceed to the next command.
 
-For each command, run it in one self-contained Bash call — not split across multiple calls. The single call computes the epoch, runs the command, captures the exit code, and emits the result inline:
+For each command, run it in one self-contained Bash call — not split across multiple calls. The single call emits the spool path before the command runs, then the exit code and a bounded tail inline:
 
 ```
-EPOCH=$(date +%s%3N); SPOOL="${TMPDIR:-/tmp}/<slug>-${EPOCH}.txt"; <command> > "$SPOOL" 2>&1; EXIT=$?; echo "SPOOL:$SPOOL EXIT:$EXIT"; tail -50 "$SPOOL"
+EPOCH=$(date +%s%3N); SPOOL="${TMPDIR:-/tmp}/<slug>-${EPOCH}.txt"; echo "SPOOL:$SPOOL"; <command> > "$SPOOL" 2>&1; EXIT=$?; echo "EXIT:$EXIT"; tail -50 "$SPOOL"
 ```
 
-`<slug>` is the command lowercased with non-alphanumeric runs collapsed to `-` (e.g., `npm test` → `npm-test`, `ruff check` → `ruff-check`).
+`<slug>` is the command lowercased with non-alphanumeric runs collapsed to `-` (e.g., `npm test` → `npm-test`, `ruff check` → `ruff-check`). `<command>` must be a single simple command with no embedded `;` or shell control operators; cwd is anchored separately (see Working directory above).
+
+Emitting the spool path before the command ensures the path is known even when the Bash tool's `timeout` kills the call before the `EXIT` and `tail` lines run — a TIMEOUT verdict can reference the partial spool without re-locating it.
 
 **Never read back the spool in a separate Bash call. Never locate a spool file with a glob or `ls` pattern.** Stale spool files from prior sessions accumulate under the same slug prefix in `${TMPDIR:-/tmp}/`; a glob matches them all and contaminates the verdict. The only spool content used in the structured verdict is what the creating call emits inline.
 
 Return a structured verdict using the inline output:
 - Per-command: name, exit code, pass/fail.
-- Smallest failure excerpt for each failed command (last ~50 lines from the inline tail, or the runner's summary block, whichever is smaller).
+- Smallest failure excerpt for each failed command — the `tail` output from the creating call (up to ~50 lines). The subagent does not read the spool directly; if the parent needs more context, it reads the spool file.
 - Overall PASS or FAIL.
 - The spool file paths (emitted inline by the creating call).
 

--- a/claude/.claude/agents/check-runner.md
+++ b/claude/.claude/agents/check-runner.md
@@ -18,15 +18,21 @@ Run each enumerated command exactly once. On non-zero exit, capture and move to 
 
 Every Bash call must include the tool's `timeout` parameter set to 600000 (10 minutes). Do not omit it. A command that exceeds 10 minutes is treated as a TIMEOUT verdict for that command — capture whatever output the spool file holds and proceed to the next command.
 
-For each command:
-1. Run via Bash with `timeout: 600000`. Capture both stdout and stderr.
-2. Write the full output to `${TMPDIR:-/tmp}/<slug>-<epoch-ms>.txt` via Bash redirect (`command > file 2>&1`), where `<slug>` is the command lowercased with non-alphanumeric runs collapsed to `-` (e.g., `npm test` → `npm-test`, `ruff check` → `ruff-check`) and `<epoch-ms>` is the result of `date +%s%3N`.
+For each command, run it in one self-contained Bash call — not split across multiple calls. The single call computes the epoch, runs the command, captures the exit code, and emits the result inline:
 
-Return a structured verdict:
+```
+EPOCH=$(date +%s%3N); SPOOL="${TMPDIR:-/tmp}/<slug>-${EPOCH}.txt"; <command> > "$SPOOL" 2>&1; EXIT=$?; echo "SPOOL:$SPOOL EXIT:$EXIT"; tail -50 "$SPOOL"
+```
+
+`<slug>` is the command lowercased with non-alphanumeric runs collapsed to `-` (e.g., `npm test` → `npm-test`, `ruff check` → `ruff-check`).
+
+**Never read back the spool in a separate Bash call. Never locate a spool file with a glob or `ls` pattern.** Stale spool files from prior sessions accumulate under the same slug prefix in `${TMPDIR:-/tmp}/`; a glob matches them all and contaminates the verdict. The only spool content used in the structured verdict is what the creating call emits inline.
+
+Return a structured verdict using the inline output:
 - Per-command: name, exit code, pass/fail.
-- Smallest failure excerpt for each failed command (last ~50 lines or the runner's summary block, whichever is smaller).
+- Smallest failure excerpt for each failed command (last ~50 lines from the inline tail, or the runner's summary block, whichever is smaller).
 - Overall PASS or FAIL.
-- The output file paths.
+- The spool file paths (emitted inline by the creating call).
 
 Do not interpret failures or recommend fixes — that is the parent's job.
 

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -86,6 +86,6 @@ check-runner writes command output to `${TMPDIR:-/tmp}/<slug>-<epoch-ms>.txt`. I
 
 Two contributing factors: (a) the procedure described two steps (run the command, then write/read the spool), opening a window for glob-based recovery to substitute stale content; (b) no prohibition on glob-based spool recovery existed.
 
-Resolved: (1) the per-command procedure now uses one self-contained Bash call that computes the epoch, redirects to a fresh spool, captures the exit code, and emits the spool path plus a bounded `tail` inline — all in the same call; (2) an explicit prohibition added: never locate a spool file by glob or `ls`; the only spool content included in the verdict is what the creating call emits inline.
+Resolved: (1) the per-command procedure now uses one self-contained Bash call that emits the spool path *before* the command runs, then redirects the command's output to the spool, captures the exit code, and emits a bounded `tail` — all in the same call. Emitting the path first ensures it survives a Bash-tool timeout kill: if the harness terminates the call mid-command, the pre-run echo has already landed in the call's output and the TIMEOUT verdict can reference the partial spool. (2) An explicit prohibition added: never locate a spool file by glob or `ls`; the only spool content included in the verdict is what the creating call emits inline.
 
 Consistent with §10–§12: foundational scoping (one-call discipline + inline-output prohibition) over layered detection heuristics.

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -79,3 +79,13 @@ A check-runner invocation of `npm run verify` in a consuming project returned in
 The return contract never asks for test counts — it defines per-command exit code, pass/fail, failure excerpt, and spool path. Volunteering a per-sub-suite breakdown was outside the contract; haiku had no grounding procedure for doing it correctly.
 
 Resolved with prose — an umbrella-command-discipline paragraph: for any single enumerated command that internally runs multiple sub-suites, check-runner returns exactly one verdict entry (name, exit code, overall pass/fail) — no per-sub-suite breakdown, no test counts, no characterization of individual sub-results. The parent reads the spool file if counts are needed. A grounded count-extraction procedure was considered and rejected: runner formats differ across tools (test frameworks, hook scripts, build tools all emit different summary shapes); an umbrella command emits N summary blocks with no single canonical "count"; the result is still a haiku model extracting structured data from free-form text — compounding complexity. Consistent with the §10 and §11 stance of foundational scoping over layered heuristic hardening.
+
+## 13. check-runner verdict contamination from stale spool files (2026-05-16)
+
+check-runner writes command output to `${TMPDIR:-/tmp}/<slug>-<epoch-ms>.txt`. In environments with multiple sessions or worktrees — e.g., a shared developer machine running parallel Claude Code sessions — spool files accumulate across sessions. The slug component is stable across runs for a given command (`npm-run-verify`, `ruff-check`, etc.), so prior runs' spool files share the slug prefix. When the agent read the spool in a separate Bash call using a glob (`${TMPDIR:-/tmp}/<slug>-*.txt`), it matched all stale files from prior sessions. In one incident, ~85 stale files matched and produced a 67 MB read; the agent confabulated a verdict from the mixture rather than from the current run's output.
+
+Two contributing factors: (a) the procedure described two steps (run the command, then write/read the spool), opening a window for glob-based recovery to substitute stale content; (b) no prohibition on glob-based spool recovery existed.
+
+Resolved: (1) the per-command procedure now uses one self-contained Bash call that computes the epoch, redirects to a fresh spool, captures the exit code, and emits the spool path plus a bounded `tail` inline — all in the same call; (2) an explicit prohibition added: never locate a spool file by glob or `ls`; the only spool content included in the verdict is what the creating call emits inline.
+
+Consistent with §10–§12: foundational scoping (one-call discipline + inline-output prohibition) over layered detection heuristics.


### PR DESCRIPTION
## Summary

- **Root cause:** The previous per-command procedure described two steps — run the command, then write/read the spool. This opened a window where a separate Bash call could locate the spool via a glob (`${TMPDIR:-/tmp}/<slug>-*.txt`), matching all stale spool files from prior sessions sharing the same slug prefix. In one incident, ~85 stale files matched and produced a 67 MB read; the agent confabulated a verdict from the mixture.
- **Fix (check-runner.md):** Each command now runs in one self-contained Bash call. The spool path is echoed *before* the command runs so the path survives a Bash-tool timeout kill — if the harness terminates the call mid-command, the pre-run echo has already landed and the TIMEOUT verdict can reference the partial spool. The call then redirects command output to the spool, captures the exit code, and emits a bounded `tail` inline. An explicit prohibition added: never locate a spool file with a glob or `ls`. Also: the failure-excerpt verdict bullet now reflects that the subagent sees only the inline tail (not the full spool), and a note clarifies that `<command>` must be a single simple command with no embedded `;` or shell control operators.
- **Fix (docs/design-decisions.md):** New §13 documents the incident, the two contributing factors, and the resolution — including the echo-before-command ordering and the timeout-recovery rationale. Consistent with the §10–§12 pattern of foundational scoping over layered detection heuristics.

## Test plan

- [x] `pytest claude/.claude/` and `ruff check claude/.claude/` — skipped; diff touches only agent config (`.claude/agents/check-runner.md`) and docs, no executable code

🤖 Generated with [Claude Code](https://claude.com/claude-code)