### PR TITLE
docs(claude-hook-review): surface agent escalation in plugin description

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "claude-hook-review",
-      "description": "Review playbook for Claude Code hooks: event/matcher selection, path resolution, script skeleton, fail-open/fail-closed posture, dispatch drift, and the 9-item review checklist. Install at project scope in repos that author .claude/hooks/*.sh scripts.",
+      "description": "Review playbook for Claude Code hooks: event/matcher selection, path resolution, script skeleton, fail-open/fail-closed posture, dispatch drift, the review checklist, and operational-footprint escalation to staff-platform-engineer. Install at project scope in repos that author .claude/hooks/*.sh scripts.",
       "author": {
         "name": "Cordova Strategy"
       },

--- a/plugins/claude-hook-review/.claude-plugin/plugin.json
+++ b/plugins/claude-hook-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-hook-review",
-  "description": "Review playbook for Claude Code hooks: event/matcher selection, path resolution, script skeleton, fail-open/fail-closed posture, dispatch drift, and the 9-item review checklist. Install at project scope in repos that author .claude/hooks/*.sh scripts.",
-  "version": "1.1.0",
+  "description": "Review playbook for Claude Code hooks: event/matcher selection, path resolution, script skeleton, fail-open/fail-closed posture, dispatch drift, the review checklist, and operational-footprint escalation to staff-platform-engineer. Install at project scope in repos that author .claude/hooks/*.sh scripts.",
+  "version": "1.1.1",
   "author": {
     "name": "Cordova Strategy"
   },


### PR DESCRIPTION
## What

Follow-up to #252. v1.1.0 added Section 10 (operational-footprint escalation to `staff-platform-engineer`), but the `claude-hook-review` plugin description still advertised only "the 9-item review checklist" — understating the headline capability of that release, and reading ambiguously now that the skill has a literal Section 10.

## Change

- Update the description in **both** `plugins/claude-hook-review/.claude-plugin/plugin.json` and the root `.claude-plugin/marketplace.json` to name the escalation capability and drop the now-ambiguous "9-item" count. The two strings are kept verbatim-identical to avoid drift.
- Bump `plugin.json` version `1.1.0 → 1.1.1` — a documentation clarification correcting metadata to match already-shipped behavior (semver patch). No `version` field added to the marketplace entry.

No skill behavior changes.

## Plugin semver checklist

- [x] `plugin.json` `version` bumped (1.1.0 → 1.1.1)
- [x] Bump magnitude matches the change (patch — clarification)
- [x] No `version` field added to the marketplace.json entry
- [x] Post-merge install command below

## Post-merge install

Consuming repos refresh with:

```
claude plugin install claude-hook-review@claude-config --scope project
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)