### PR TITLE
docs(claude-md): fix heading misplacement and plugin/skill mislabels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ X…", "before/after X…" — the answer is a hook configured in
 `.claude/settings.json`, not a memory or a skill instruction. The
 harness executes hooks; nothing in memory or a CLAUDE.md prose rule can
 fulfill an automatic-trigger request. Route to the `claude-hook-review`
-plugin for hook design and review.
+skill for hook design and review.
 
 **Plugin config:** `enabledPlugins` only takes effect in
 `settings.json`, not `settings.local.json`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,8 @@ not want to extend. Mirror existing entries when in doubt.
 `/plan-it` is the prescribed entry for plan creation. `/plan-review` and
 `/code-review` are mandatory pipeline steps before PR handoff — both are
 hook-enforced (see README "Workflow" for the full skill invocation order and
-which hook gates each transition).
+which hook gates each transition). When staged changes include a SKILL.md,
+`/skill-review` is also required; `/code-review` invokes it automatically.
 
 ## Plans in this repo affect all stow users
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,11 +68,10 @@ not want to extend. Mirror existing entries when in doubt.
 
 ## Review pipeline
 
-`/plan-it` is the prescribed entry for plan creation. `/plan-review`,
-`/code-review`, and `/skill-review` are mandatory pipeline steps before PR
-handoff — all three are hook-enforced (see README "Workflow" for the full
-skill invocation order and which hook gates each transition).
-`/skill-review`'s gate fires only when staged changes include a SKILL.md; it ships in the bundled `skill-review` plugin (not under `claude/.claude/skills/`).
+`/plan-it` is the prescribed entry for plan creation. `/plan-review` and
+`/code-review` are mandatory pipeline steps before PR handoff — both are
+hook-enforced (see README "Workflow" for the full skill invocation order and
+which hook gates each transition).
 
 ## Plans in this repo affect all stow users
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ X…", "before/after X…" — the answer is a hook configured in
 `.claude/settings.json`, not a memory or a skill instruction. The
 harness executes hooks; nothing in memory or a CLAUDE.md prose rule can
 fulfill an automatic-trigger request. Route to the `claude-hook-review`
-skill for hook design and review.
+plugin for hook design and review.
 
 **Plugin config:** `enabledPlugins` only takes effect in
 `settings.json`, not `settings.local.json`.
@@ -87,11 +87,13 @@ check the diff against its output — e.g. an edit adding prose to a
 skill that argues for brevity is the kind of thing the skill would
 flag against itself.
 
+## Review pipeline
+
 `/plan-it` is the prescribed entry for plan creation. `/plan-review`,
 `/code-review`, and `/skill-review` are mandatory pipeline steps before PR
 handoff — all three are hook-enforced (see README "Workflow" for the full
 skill invocation order and which hook gates each transition).
-`/skill-review`'s gate fires only when staged changes include a SKILL.md.
+`/skill-review`'s gate fires only when staged changes include a SKILL.md; it ships in the bundled `skill-review` plugin (not under `claude/.claude/skills/`).
 
 ## Redact private-project-identifying content
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,14 @@ not want to extend. Mirror existing entries when in doubt.
 
 **Global skill bodies stay platform-agnostic.** Skills under `claude/.claude/skills/` are stowed to every user who clones this repo — their bodies must read cleanly regardless of stack. Encode the generic concept; do not hardcode engine/platform-specific tokens (`pg_cron`, `net.http_post`, vendor API names). Stack-specific examples and checks belong in a project-layer skill (`<skill>-<project>/SKILL.md`) that the base skill loads via its project-layer glob — e.g. `/code-review`'s Step 0.5 globs `.claude/skills/code-review-*/SKILL.md`.
 
+## Review pipeline
+
+`/plan-it` is the prescribed entry for plan creation. `/plan-review`,
+`/code-review`, and `/skill-review` are mandatory pipeline steps before PR
+handoff — all three are hook-enforced (see README "Workflow" for the full
+skill invocation order and which hook gates each transition).
+`/skill-review`'s gate fires only when staged changes include a SKILL.md; it ships in the bundled `skill-review` plugin (not under `claude/.claude/skills/`).
+
 ## Plans in this repo affect all stow users
 
 `claude/` is stowed into `$HOME` — changes ship to every user who clones and stows this repo, not only to the session owner. When reviewing a plan for `claude-config`, evaluate with that audience in mind. Files under `claude/` are not personal config; they are distributed to all stow users on `git pull`. Surface this when declaring the user surface in Step 2 of plan-review, and weight finding severity accordingly.
@@ -86,14 +94,6 @@ committing a skill change, invoke the skill via the `Skill` tool and
 check the diff against its output — e.g. an edit adding prose to a
 skill that argues for brevity is the kind of thing the skill would
 flag against itself.
-
-## Review pipeline
-
-`/plan-it` is the prescribed entry for plan creation. `/plan-review`,
-`/code-review`, and `/skill-review` are mandatory pipeline steps before PR
-handoff — all three are hook-enforced (see README "Workflow" for the full
-skill invocation order and which hook gates each transition).
-`/skill-review`'s gate fires only when staged changes include a SKILL.md; it ships in the bundled `skill-review` plugin (not under `claude/.claude/skills/`).
 
 ## Redact private-project-identifying content
 


### PR DESCRIPTION
## Summary

- Re-home the review-pipeline paragraph under its own `## Review pipeline` heading — it was orphaned under `## When editing a skill, run the skill on its own diff`, a different topic.
- Move `## Review pipeline` to immediately after `## Working in this repo` — the section is gate-defining (hook-enforced) and belongs before the process sub-rules that follow from it, not after them.
- Tighten the pipeline enumeration: `/plan-review` and `/code-review` are called out as unconditionally mandatory; `/skill-review` is noted as conditional (fires when SKILL.md is staged) and invoked automatically by `/code-review`.

Note: an earlier commit changed `claude-hook-review` from "skill" to "plugin"; this was reverted per reviewer feedback — `claude-hook-review` is a skill that happens to ship inside a plugin, and the skill identity is the right call-site label.

Found via independent audit of the root `CLAUDE.md` prompted by a `/claude-md-management:claude-md-improver` run.

## Test plan
- [ ] Re-read `CLAUDE.md` — `## Review pipeline` appears immediately after the `## Working in this repo` section ends, before `## Plans in this repo affect all stow users`.
- [ ] `grep -n "skill-review" CLAUDE.md` — conditional note reads "When staged changes include a SKILL.md, `/skill-review` is also required; `/code-review` invokes it automatically."
- [ ] `grep -n "claude-hook-review" CLAUDE.md` — still reads "skill" (not "plugin").
- [ ] File stays under 200 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)