### PR TITLE
feat(scripts): stowed script to update @claude-config plugins in consumer repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,14 @@ Utility scripts in `claude/.claude/scripts/` (stowed to `~/.claude/scripts/`).
   cleanup-merged-branches --dry-run  # preview without acting
   ```
 
+- **`update-claude-config-plugins.sh`** — checks which `@claude-config` marketplace plugins installed in the current project are behind the marketplace's latest version, and interactively offers to update each one. Refreshes the marketplace first (`claude plugin marketplace update`) so the diff is against the live catalog. Scoped to `@claude-config` plugins only: they carry real semver in `plugin.json` (enforced by the `plugin-semver` plugin), making version comparison clean. Run from the consumer repo's root; project-scope entries from other repos are excluded.
+
+  ```bash
+  update-claude-config-plugins             # interactive update
+  update-claude-config-plugins --yes       # update all outdated plugins without prompting
+  update-claude-config-plugins --dry-run   # preview outdated plugins without updating
+  ```
+
 ## Configuration
 
 Configuration options spanning machine-local, project-local, and user-local settings. See [SECURITY.md](./SECURITY.md) for the threat model — what the hook system protects against and what it doesn't.

--- a/claude/.claude/scripts/tests/test_update_claude_config_plugins.py
+++ b/claude/.claude/scripts/tests/test_update_claude_config_plugins.py
@@ -1,0 +1,439 @@
+"""Tests for update-claude-config-plugins.sh.
+
+The claude CLI is replaced in every test by a PATH shim that returns canned
+JSON for marketplace list / plugin list and records plugin update calls.
+A fixture marketplace directory provides the plugin.json files the script
+reads to determine latest versions.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+_SCRIPT = Path(__file__).parent.parent / "update-claude-config-plugins.sh"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: fake marketplace directory
+# ---------------------------------------------------------------------------
+
+def _make_marketplace_dir(
+    root: Path,
+    plugins: list[dict],
+) -> Path:
+    """Create a fake claude-config marketplace directory at root.
+
+    plugins is a list of dicts with keys:
+      name        str   plugin name
+      version     str   latest version
+      description str   plugin description
+      source      str   source subdir relative to root (default: "plugins/<name>")
+    """
+    marketplace_plugins = []
+    for p in plugins:
+        source = p.get("source", f"plugins/{p['name']}")
+        marketplace_plugins.append({"name": p["name"], "source": f"./{source}"})
+
+        plugin_dir = root / source / ".claude-plugin"
+        plugin_dir.mkdir(parents=True, exist_ok=True)
+        (plugin_dir / "plugin.json").write_text(json.dumps({
+            "name": p["name"],
+            "version": p["version"],
+            "description": p.get("description", f"Description of {p['name']}"),
+        }))
+
+    manifest_dir = root / ".claude-plugin"
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    (manifest_dir / "marketplace.json").write_text(json.dumps({
+        "plugins": marketplace_plugins,
+    }))
+    return root
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: fake claude CLI shim
+# ---------------------------------------------------------------------------
+
+def _make_claude_shim(
+    bin_dir: Path,
+    marketplace_location: Path,
+    installed_plugins: list[dict],
+    update_log: Path,
+) -> None:
+    """Write a fake claude executable to bin_dir.
+
+    Handles:
+      claude plugin marketplace list --json
+      claude plugin marketplace update claude-config
+      claude plugin list --json
+      claude plugin update <plugin> --scope <scope>
+
+    update_log records each "plugin update" invocation as a JSON line.
+    """
+    installed_json = json.dumps(installed_plugins)
+    marketplace_list_json = json.dumps([{
+        "name": "claude-config",
+        "source": "directory",
+        "installLocation": str(marketplace_location),
+    }])
+
+    shim = textwrap.dedent(f"""\
+        #!/usr/bin/env python3
+        import json, sys
+
+        args = sys.argv[1:]
+
+        def is_subcommand(*parts):
+            return args[:len(parts)] == list(parts)
+
+        if is_subcommand("plugin", "marketplace", "list") and "--json" in args:
+            print({repr(marketplace_list_json)})
+            sys.exit(0)
+
+        if is_subcommand("plugin", "marketplace", "update", "claude-config"):
+            sys.exit(0)
+
+        if is_subcommand("plugin", "list") and "--json" in args:
+            print({repr(installed_json)})
+            sys.exit(0)
+
+        if is_subcommand("plugin", "update") and len(args) >= 5:
+            plugin_id = args[2]
+            # args: plugin update <id> --scope <scope>
+            scope_idx = args.index("--scope") if "--scope" in args else -1
+            scope = args[scope_idx + 1] if scope_idx >= 0 and scope_idx + 1 < len(args) else ""
+            with open({repr(str(update_log))}, "a") as f:
+                f.write(json.dumps({{"plugin": plugin_id, "scope": scope}}) + "\\n")
+            sys.exit(0)
+
+        print(f"Unhandled: {{args}}", file=sys.stderr)
+        sys.exit(1)
+    """)
+
+    shim_path = bin_dir / "claude"
+    shim_path.write_text(shim)
+    shim_path.chmod(0o755)
+
+
+def _run_script(
+    *args: str,
+    bin_dir: Path,
+    cwd: Path,
+    stdin_data: bytes | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ, "PATH": f"{bin_dir}:{os.environ['PATH']}"}
+    return subprocess.run(
+        [str(_SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        cwd=str(cwd),
+        env=env,
+        input=stdin_data.decode() if stdin_data else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _read_update_log(update_log: Path) -> list[dict]:
+    if not update_log.exists():
+        return []
+    return [json.loads(line) for line in update_log.read_text().splitlines() if line.strip()]
+
+
+def _make_installed_plugin(
+    name: str,
+    version: str,
+    scope: str = "project",
+    project_path: str = "/fake/repo",
+) -> dict:
+    entry: dict = {
+        "id": f"{name}@claude-config",
+        "version": version,
+        "scope": scope,
+        "enabled": True,
+        "installPath": f"/fake/cache/{name}/{version}",
+    }
+    if scope == "project":
+        entry["projectPath"] = project_path
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestDryRun:
+    def test_reports_outdated_plugin(self, tmp_path: Path) -> None:
+        marketplace = _make_marketplace_dir(
+            tmp_path / "marketplace",
+            [{"name": "my-plugin", "version": "2.0.0", "description": "A test plugin"}],
+        )
+        update_log = tmp_path / "updates.log"
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _make_claude_shim(
+            bin_dir,
+            marketplace,
+            [_make_installed_plugin("my-plugin", "1.0.0", project_path=str(repo))],
+            update_log,
+        )
+
+        result = _run_script("--dry-run", bin_dir=bin_dir, cwd=repo)
+
+        assert result.returncode == 0
+        assert "my-plugin" in result.stdout
+        assert "1.0.0" in result.stdout
+        assert "2.0.0" in result.stdout
+        assert _read_update_log(update_log) == []
+
+    def test_shows_description(self, tmp_path: Path) -> None:
+        marketplace = _make_marketplace_dir(
+            tmp_path / "marketplace",
+            [{"name": "p", "version": "1.1.0", "description": "Does useful things"}],
+        )
+        update_log = tmp_path / "updates.log"
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _make_claude_shim(
+            bin_dir, marketplace,
+            [_make_installed_plugin("p", "1.0.0", project_path=str(repo))],
+            update_log,
+        )
+
+        result = _run_script("--dry-run", bin_dir=bin_dir, cwd=repo)
+
+        assert "Does useful things" in result.stdout
+
+    def test_locally_ahead_dev_copy_not_flagged(self, tmp_path: Path) -> None:
+        """An installed version newer than the marketplace must not appear as outdated."""
+        marketplace = _make_marketplace_dir(
+            tmp_path / "marketplace",
+            [{"name": "dev-plugin", "version": "1.0.0"}],
+        )
+        update_log = tmp_path / "updates.log"
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _make_claude_shim(
+            bin_dir, marketplace,
+            [_make_installed_plugin("dev-plugin", "2.0.0-dev", project_path=str(repo))],
+            update_log,
+        )
+
+        result = _run_script("--dry-run", bin_dir=bin_dir, cwd=repo)
+
+        assert result.returncode == 0
+        assert "dev-plugin" not in result.stdout
+
+    def test_all_current_exits_zero(self, tmp_path: Path) -> None:
+        marketplace = _make_marketplace_dir(
+            tmp_path / "marketplace",
+            [{"name": "stable", "version": "1.5.0"}],
+        )
+        update_log = tmp_path / "updates.log"
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _make_claude_shim(
+            bin_dir, marketplace,
+            [_make_installed_plugin("stable", "1.5.0", project_path=str(repo))],
+            update_log,
+        )
+
+        result = _run_script("--dry-run", bin_dir=bin_dir, cwd=repo)
+
+        assert result.returncode == 0
+        assert "up to date" in result.stdout
+
+
+class TestAssumeYes:
+    def test_updates_all_outdated_plugins(self, tmp_path: Path) -> None:
+        marketplace = _make_marketplace_dir(
+            tmp_path / "marketplace",
+            [
+                {"name": "alpha", "version": "2.0.0"},
+                {"name": "beta", "version": "3.1.0"},
+            ],
+        )
+        update_log = tmp_path / "updates.log"
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _make_claude_shim(
+            bin_dir, marketplace,
+            [
+                _make_installed_plugin("alpha", "1.0.0", project_path=str(repo)),
+                _make_installed_plugin("beta", "3.0.0", project_path=str(repo)),
+            ],
+            update_log,
+        )
+
+        result = _run_script("--yes", bin_dir=bin_dir, cwd=repo)
+
+        assert result.returncode == 0
+        calls = _read_update_log(update_log)
+        assert len(calls) == 2
+        assert any(c["plugin"] == "alpha@claude-config" for c in calls)
+        assert any(c["plugin"] == "beta@claude-config" for c in calls)
+
+    def test_passes_correct_scope_to_update(self, tmp_path: Path) -> None:
+        marketplace = _make_marketplace_dir(
+            tmp_path / "marketplace",
+            [{"name": "shared", "version": "2.0.0"}],
+        )
+        update_log = tmp_path / "updates.log"
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        home = tmp_path / "home"
+        home.mkdir()
+        _make_claude_shim(
+            bin_dir, marketplace,
+            [_make_installed_plugin("shared", "1.0.0", scope="user")],
+            update_log,
+        )
+
+        result = _run_script("--yes", bin_dir=bin_dir, cwd=home)
+
+        assert result.returncode == 0
+        calls = _read_update_log(update_log)
+        assert len(calls) == 1
+        assert calls[0]["scope"] == "user"
+
+    def test_prints_restart_reminder(self, tmp_path: Path) -> None:
+        marketplace = _make_marketplace_dir(
+            tmp_path / "marketplace",
+            [{"name": "p", "version": "2.0.0"}],
+        )
+        update_log = tmp_path / "updates.log"
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _make_claude_shim(
+            bin_dir, marketplace,
+            [_make_installed_plugin("p", "1.0.0", project_path=str(repo))],
+            update_log,
+        )
+
+        result = _run_script("--yes", bin_dir=bin_dir, cwd=repo)
+
+        assert "Restart Claude Code" in result.stdout
+
+
+class TestNonTTY:
+    def test_skips_updates_without_yes(self, tmp_path: Path) -> None:
+        """Non-TTY stdin without --yes must not run any updates."""
+        marketplace = _make_marketplace_dir(
+            tmp_path / "marketplace",
+            [{"name": "p", "version": "2.0.0"}],
+        )
+        update_log = tmp_path / "updates.log"
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _make_claude_shim(
+            bin_dir, marketplace,
+            [_make_installed_plugin("p", "1.0.0", project_path=str(repo))],
+            update_log,
+        )
+
+        # Passing stdin_data forces a non-TTY stdin in subprocess
+        result = _run_script(bin_dir=bin_dir, cwd=repo, stdin_data=b"")
+
+        assert result.returncode == 0
+        assert _read_update_log(update_log) == []
+        assert "Skipped" in result.stdout
+
+
+class TestProjectScopeFiltering:
+    def test_other_repos_project_plugins_excluded(self, tmp_path: Path) -> None:
+        marketplace = _make_marketplace_dir(
+            tmp_path / "marketplace",
+            [{"name": "tool", "version": "2.0.0"}],
+        )
+        update_log = tmp_path / "updates.log"
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        this_repo = tmp_path / "this-repo"
+        this_repo.mkdir()
+        other_repo = tmp_path / "other-repo"
+        other_repo.mkdir()
+        _make_claude_shim(
+            bin_dir, marketplace,
+            [_make_installed_plugin("tool", "1.0.0", project_path=str(other_repo))],
+            update_log,
+        )
+
+        result = _run_script("--dry-run", bin_dir=bin_dir, cwd=this_repo)
+
+        assert result.returncode == 0
+        assert "tool" not in result.stdout
+
+    def test_user_scope_plugins_always_included(self, tmp_path: Path) -> None:
+        marketplace = _make_marketplace_dir(
+            tmp_path / "marketplace",
+            [{"name": "global-tool", "version": "2.0.0"}],
+        )
+        update_log = tmp_path / "updates.log"
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        cwd = tmp_path / "any-dir"
+        cwd.mkdir()
+        _make_claude_shim(
+            bin_dir, marketplace,
+            [_make_installed_plugin("global-tool", "1.0.0", scope="user")],
+            update_log,
+        )
+
+        result = _run_script("--dry-run", bin_dir=bin_dir, cwd=cwd)
+
+        assert result.returncode == 0
+        assert "global-tool" in result.stdout
+
+
+class TestMarketplaceNotConfigured:
+    def test_exits_nonzero_with_message(self, tmp_path: Path) -> None:
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+
+        # Shim returns empty marketplace list (no claude-config entry)
+        shim = textwrap.dedent("""\
+            #!/usr/bin/env python3
+            import json, sys
+            args = sys.argv[1:]
+            if args[:3] == ["plugin", "marketplace", "list"] and "--json" in args:
+                print("[]")
+                sys.exit(0)
+            sys.exit(1)
+        """)
+        shim_path = bin_dir / "claude"
+        shim_path.write_text(shim)
+        shim_path.chmod(0o755)
+
+        result = _run_script("--dry-run", bin_dir=bin_dir, cwd=tmp_path)
+
+        assert result.returncode == 1
+        assert "claude-config" in result.stderr.lower() or "not configured" in result.stderr.lower()
+
+
+class TestBadArguments:
+    def test_unknown_flag_exits_2(self, tmp_path: Path) -> None:
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+
+        result = _run_script("--unknown-flag", bin_dir=bin_dir, cwd=tmp_path)
+
+        assert result.returncode == 2

--- a/claude/.claude/scripts/update-claude-config-plugins.sh
+++ b/claude/.claude/scripts/update-claude-config-plugins.sh
@@ -1,0 +1,290 @@
+#!/usr/bin/env bash
+# update-claude-config-plugins.sh — diff and interactively update @claude-config plugins.
+#
+# Refreshes the claude-config marketplace, identifies installed plugins whose
+# version lags the marketplace's latest, and offers to update them one by one.
+# Scope is limited to @claude-config plugins: they carry real semver in plugin.json
+# (enforced by the plugin-semver plugin), making the version comparison clean.
+# Other marketplaces use sha-pinned refs with no comparable semver — out of scope.
+#
+# Run this script from the root of the consumer repo whose plugins you want to
+# update. Project-scope plugin entries are filtered to those installed in the
+# current project root; user-scope entries are shown regardless of cwd.
+#
+# Usage:
+#   update-claude-config-plugins.sh
+#   update-claude-config-plugins.sh --dry-run
+#   update-claude-config-plugins.sh --yes
+#   update-claude-config-plugins.sh --dry-run --yes
+#
+# Exit codes:
+#   0  success (including no-op)
+#   1  prerequisite error (marketplace not configured, CLI unavailable)
+#   2  bad arguments
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Argument validation
+# ---------------------------------------------------------------------------
+
+usage() {
+  echo "Usage: $(basename "$0") [--dry-run] [--yes]" >&2
+}
+
+DRY_RUN=0
+ASSUME_YES=0
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1 ;;
+    --yes)     ASSUME_YES=1 ;;
+    *)         usage; exit 2 ;;
+  esac
+  shift
+done
+
+# ---------------------------------------------------------------------------
+# Project root — used to filter project-scope entries to the current repo
+# ---------------------------------------------------------------------------
+
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+
+# ---------------------------------------------------------------------------
+# Step 1: Verify claude-config marketplace is configured; capture installLocation
+# ---------------------------------------------------------------------------
+# Done before the refresh so a missing marketplace reports cleanly rather than
+# as a failed marketplace-update call.
+
+MARKETPLACE_LIST_JSON=$(claude plugin marketplace list --json 2>/dev/null) || {
+  echo "ERROR: 'claude plugin marketplace list --json' failed. Is the claude CLI available?" >&2
+  exit 1
+}
+
+INSTALL_LOCATION=$(echo "$MARKETPLACE_LIST_JSON" | python3 -c "
+import json, sys
+entries = json.load(sys.stdin)
+for e in entries:
+    if e.get('name') == 'claude-config':
+        loc = e.get('installLocation', '')
+        if loc:
+            print(loc)
+        sys.exit(0)
+" 2>/dev/null || true)
+
+if [ -z "$INSTALL_LOCATION" ]; then
+  echo "ERROR: The claude-config marketplace is not configured." >&2
+  echo "Add it first: claude plugin marketplace add <source> --name claude-config" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Step 2: Refresh the marketplace so installLocation reflects the latest
+# ---------------------------------------------------------------------------
+
+echo "Refreshing claude-config marketplace..." >&2
+claude plugin marketplace update claude-config >/dev/null 2>&1 || {
+  echo "WARNING: marketplace refresh failed; version data may be stale." >&2
+}
+
+# ---------------------------------------------------------------------------
+# Step 3: Build latest-version map from the marketplace's plugin.json files
+# ---------------------------------------------------------------------------
+
+MARKETPLACE_MANIFEST="${INSTALL_LOCATION}/.claude-plugin/marketplace.json"
+
+if [ ! -f "$MARKETPLACE_MANIFEST" ]; then
+  echo "ERROR: marketplace manifest not found at ${MARKETPLACE_MANIFEST}" >&2
+  exit 1
+fi
+
+declare -A LATEST_VERSION=()
+declare -A PLUGIN_DESCRIPTION=()
+
+while read -r plugin_name plugin_source_rel; do
+  [ -z "$plugin_name" ] && continue
+  plugin_json="${INSTALL_LOCATION}/${plugin_source_rel}/.claude-plugin/plugin.json"
+  if [ ! -f "$plugin_json" ]; then
+    continue
+  fi
+  parsed=$(python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    d = json.load(f)
+version = d.get('version', '')
+desc = d.get('description', '').replace('\n', ' ')
+print(version)
+print(desc)
+" "$plugin_json" 2>/dev/null || true)
+  plugin_version=$(printf '%s' "$parsed" | sed -n '1p')
+  plugin_desc=$(printf '%s' "$parsed" | sed -n '2p')
+  if [ -n "$plugin_version" ]; then
+    LATEST_VERSION["$plugin_name"]="$plugin_version"
+    PLUGIN_DESCRIPTION["$plugin_name"]="$plugin_desc"
+  fi
+done < <(python3 -c "
+import json, re, sys
+with open(sys.argv[1]) as f:
+    d = json.load(f)
+for p in d.get('plugins', []):
+    name = p.get('name', '')
+    source = p.get('source', '')
+    # Normalize ./plugins/foo or /plugins/foo to plugins/foo
+    source = re.sub(r'^\.\/', '', source).lstrip('/')
+    if name and source:
+        print(name, source)
+" "$MARKETPLACE_MANIFEST" 2>/dev/null || true)
+
+if [ "${#LATEST_VERSION[@]}" -eq 0 ]; then
+  echo "No plugins found in the claude-config marketplace manifest." >&2
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Step 4: Read installed @claude-config plugins, filtering by project root
+# ---------------------------------------------------------------------------
+
+INSTALLED_LIST_JSON=$(claude plugin list --json 2>/dev/null) || {
+  echo "ERROR: 'claude plugin list --json' failed." >&2
+  exit 1
+}
+
+declare -a OUTDATED_NAMES=()
+declare -a OUTDATED_INSTALLED_VERSIONS=()
+declare -a OUTDATED_LATEST_VERSIONS=()
+declare -a OUTDATED_SCOPES=()
+declare -a OUTDATED_PROJECT_PATHS=()
+
+while IFS=$'\t' read -r entry_name installed_version entry_scope entry_project_path; do
+  [ -z "$entry_name" ] && continue
+
+  if [ "$entry_scope" = "project" ] && [ "$entry_project_path" != "$PROJECT_ROOT" ]; then
+    continue
+  fi
+
+  latest_version="${LATEST_VERSION[$entry_name]:-}"
+  if [ -z "$latest_version" ]; then
+    continue
+  fi
+
+  if [ "$installed_version" = "$latest_version" ]; then
+    continue
+  fi
+
+  # Flag as outdated only when marketplace version sorts strictly higher.
+  # A locally-ahead dev copy (installed > latest) is silently skipped.
+  lower=$(printf '%s\n%s' "$installed_version" "$latest_version" | sort -V | head -1)
+  if [ "$lower" = "$installed_version" ]; then
+    OUTDATED_NAMES+=("$entry_name")
+    OUTDATED_INSTALLED_VERSIONS+=("$installed_version")
+    OUTDATED_LATEST_VERSIONS+=("$latest_version")
+    OUTDATED_SCOPES+=("$entry_scope")
+    OUTDATED_PROJECT_PATHS+=("$entry_project_path")
+  fi
+
+done < <(echo "$INSTALLED_LIST_JSON" | python3 -c "
+import json, sys
+entries = json.load(sys.stdin)
+for e in entries:
+    plugin_id = e.get('id', '')
+    if not plugin_id.endswith('@claude-config'):
+        continue
+    name = plugin_id.rsplit('@', 1)[0]
+    version = e.get('version', '')
+    scope = e.get('scope', '')
+    project_path = e.get('projectPath', '')
+    print(f'{name}\t{version}\t{scope}\t{project_path}')
+" 2>/dev/null || true)
+
+# ---------------------------------------------------------------------------
+# Early exit when nothing is outdated
+# ---------------------------------------------------------------------------
+
+if [ "${#OUTDATED_NAMES[@]}" -eq 0 ]; then
+  any_installed=$(echo "$INSTALLED_LIST_JSON" | python3 -c "
+import json, sys
+entries = json.load(sys.stdin)
+print(sum(1 for e in entries if e.get('id','').endswith('@claude-config')))
+" 2>/dev/null || echo 0)
+  if [ "$any_installed" -eq 0 ]; then
+    echo "No @claude-config plugins are installed in this project."
+  else
+    echo "All @claude-config plugins are up to date."
+  fi
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Report outdated plugins
+# ---------------------------------------------------------------------------
+
+echo "Outdated @claude-config plugins:"
+for i in "${!OUTDATED_NAMES[@]}"; do
+  plugin_name="${OUTDATED_NAMES[$i]}"
+  entry_scope="${OUTDATED_SCOPES[$i]}"
+  entry_project_path="${OUTDATED_PROJECT_PATHS[$i]}"
+  installed_ver="${OUTDATED_INSTALLED_VERSIONS[$i]}"
+  latest_ver="${OUTDATED_LATEST_VERSIONS[$i]}"
+  description="${PLUGIN_DESCRIPTION[$plugin_name]:-}"
+
+  if [ "$entry_scope" = "project" ]; then
+    echo "  ${plugin_name}  ${installed_ver} → ${latest_ver}  (scope: project, path: ${entry_project_path})"
+  else
+    echo "  ${plugin_name}  ${installed_ver} → ${latest_ver}  (scope: ${entry_scope})"
+  fi
+  if [ -n "$description" ]; then
+    echo "    ${description}"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Dry-run stops here
+# ---------------------------------------------------------------------------
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Interactive update loop
+# ---------------------------------------------------------------------------
+
+if [ ! -t 0 ] && [ "$ASSUME_YES" -eq 0 ]; then
+  printf 'Skipped %d update(s) (no TTY for prompt; rerun with --yes or from a terminal)\n' \
+    "${#OUTDATED_NAMES[@]}"
+  exit 0
+fi
+
+UPDATED_COUNT=0
+
+for i in "${!OUTDATED_NAMES[@]}"; do
+  plugin_name="${OUTDATED_NAMES[$i]}"
+  entry_scope="${OUTDATED_SCOPES[$i]}"
+  installed_ver="${OUTDATED_INSTALLED_VERSIONS[$i]}"
+  latest_ver="${OUTDATED_LATEST_VERSIONS[$i]}"
+
+  if [ "$ASSUME_YES" -eq 1 ]; then
+    DO_UPDATE=1
+  else
+    printf "Update %s (%s → %s, scope: %s)? [y/N]: " \
+      "$plugin_name" "$installed_ver" "$latest_ver" "$entry_scope"
+    read -r REPLY
+    if [[ "$REPLY" == "y" || "$REPLY" == "Y" ]]; then
+      DO_UPDATE=1
+    else
+      DO_UPDATE=0
+    fi
+  fi
+
+  if [ "$DO_UPDATE" -eq 1 ]; then
+    claude plugin update "${plugin_name}@claude-config" --scope "$entry_scope"
+    UPDATED_COUNT=$(( UPDATED_COUNT + 1 ))
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Closing note
+# ---------------------------------------------------------------------------
+
+if [ "$UPDATED_COUNT" -gt 0 ]; then
+  echo "Restart Claude Code for the updated plugins to take effect."
+fi

--- a/claude/.local/bin/update-claude-config-plugins
+++ b/claude/.local/bin/update-claude-config-plugins
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec "$HOME/.claude/scripts/update-claude-config-plugins.sh" "$@"


### PR DESCRIPTION
## Summary

- Adds `claude/.claude/scripts/update-claude-config-plugins.sh` (stowed to `~/.claude/scripts/`), a terminal-run maintenance script for consumer repos that install `@claude-config` plugins at project scope
- Adds a `claude/.local/bin/update-claude-config-plugins` wrapper so it's on `PATH` like the other scripts
- Documents it in the README alongside `cleanup-merged-branches.sh`

## What it does

Refreshes the `claude-config` marketplace, diffs each installed `@claude-config` plugin's semver version against the marketplace's latest `plugin.json`, reports outdated plugins with their description, then interactively offers to update each one. Flags: `--dry-run` (report only), `--yes` (auto-confirm all). Project-scope entries are filtered to the current repo root; user-scope entries always show.

Scoped to `@claude-config` only: those plugins carry real semver (enforced by `plugin-semver`), making the comparison clean. Other marketplaces use sha-pinned refs.

## Why a script, not a skill or slash command

A skill's description loads into every session context permanently. A slash command spends a Claude turn on fully deterministic logic. A terminal-run script costs zero context and zero tokens and gives true TTY interactivity.

## Test plan

- [ ] `pytest claude/.claude/` — 830 tests pass (12 new for this script)
- [ ] `ruff check claude/.claude/` — clean
- [ ] Manual smoke: `./claude/.claude/scripts/update-claude-config-plugins.sh --dry-run` from a consumer repo with `@claude-config` plugins installed — reports any outdated, exits 0
- [ ] Verify `claude plugin update name@claude-config --scope project` form is accepted by the real CLI (advisory from code review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)