### PR TITLE
fix(evals): split skill eval harness into runtime + description-fidelity modes

### DIFF
--- a/claude/.claude/skills/code-review/evals/trigger-cases.json
+++ b/claude/.claude/skills/code-review/evals/trigger-cases.json
@@ -1,5 +1,6 @@
 {
   "skill_name": "code-review",
+  "method": "runtime",
   "cases": [
     {
       "id": "code-written-commit-pending",
@@ -8,7 +9,7 @@
     },
     {
       "id": "explicit-user-code-review-request",
-      "query": "Please do a code review of this function: def fetch_user(user_id): return db.query(User).filter_by(id=user_id).first()",
+      "query": "I've just finished implementing a new feature and I'm ready to commit. Can you do a formal code review of my changes?",
       "should_trigger": true
     },
     {

--- a/claude/.claude/skills/test-conventions/evals/trigger-cases.json
+++ b/claude/.claude/skills/test-conventions/evals/trigger-cases.json
@@ -1,5 +1,6 @@
 {
   "skill_name": "test-conventions",
+  "method": "description-fidelity",
   "cases": [
     {
       "id": "planning-tests-new-feature",

--- a/claude/.claude/skills/test-evaluation/evals/trigger-cases.json
+++ b/claude/.claude/skills/test-evaluation/evals/trigger-cases.json
@@ -1,5 +1,6 @@
 {
   "skill_name": "test-evaluation",
+  "method": "description-fidelity",
   "cases": [
     {
       "id": "evaluating-existing-suite-quality",

--- a/claude/.claude/skills/tests/test_trigger_detector.py
+++ b/claude/.claude/skills/tests/test_trigger_detector.py
@@ -10,11 +10,23 @@ pytest pythonpath so `import run_trigger_evals` resolves correctly.
 
 from __future__ import annotations
 
+import json
+import subprocess
+import sys
+import tempfile
 from pathlib import Path
 
-from run_trigger_evals import detect_trigger_in_lines
+import pytest
+from run_trigger_evals import (
+    detect_trigger_in_lines,
+    format_skip_notice,
+    load_case_file,
+    partition_case_files,
+    seed_temp_project_git,
+)
 
 FIXTURES_DIR = Path(__file__).resolve().parents[4] / "evals" / "fixtures"
+HARNESS = Path(__file__).resolve().parents[4] / "evals" / "run_trigger_evals.py"
 
 
 def _lines(fixture_name: str) -> list[str]:
@@ -65,3 +77,114 @@ class TestDetectTriggerInLines:
         fired, also = detect_trigger_in_lines(lines, "code-review", [])
         assert fired is None
         assert also == []
+
+
+class TestSeedTempProjectGit:
+    def test_calculator_staged_not_committed(self) -> None:
+        """calculator.py must be staged (M ) — not unstaged ( M) — after seeding.
+
+        A silently mis-applied patch yields an empty diff, which would make every
+        code-review and test-evaluation sample fail for a reason unrelated to skill
+        triggering — the exact false signal the fixture fix exists to kill.
+        """
+        with tempfile.TemporaryDirectory() as tmp_str:
+            tmp = Path(tmp_str)
+            seed_temp_project_git(tmp)
+            result = subprocess.run(
+                ["git", "status", "--porcelain"],
+                cwd=tmp,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            lines = result.stdout.splitlines()
+            assert any(
+                line.startswith("M ") and "calculator.py" in line for line in lines
+            ), f"calculator.py should be staged (M ), got: {result.stdout!r}"
+            assert not any(
+                line.startswith(" M") and "calculator.py" in line for line in lines
+            ), f"calculator.py should not appear unstaged ( M), got: {result.stdout!r}"
+
+
+class TestCaseFileMethod:
+    """The `method` field gates which harness measures a skill."""
+
+    @staticmethod
+    def _write_case_file(directory: Path, name: str, payload: dict) -> Path:
+        path = directory / name
+        path.write_text(json.dumps(payload))
+        return path
+
+    def test_load_case_file_rejects_missing_method(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_str:
+            path = self._write_case_file(
+                Path(tmp_str), "missing.json", {"skill_name": "x", "cases": []}
+            )
+            with pytest.raises(ValueError, match="method"):
+                load_case_file(path)
+
+    def test_load_case_file_rejects_unknown_method(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_str:
+            path = self._write_case_file(
+                Path(tmp_str),
+                "unknown.json",
+                {"skill_name": "x", "method": "guesswork", "cases": []},
+            )
+            with pytest.raises(ValueError, match="method"):
+                load_case_file(path)
+
+    def test_load_case_file_accepts_valid_methods(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_str:
+            for method in ("runtime", "description-fidelity"):
+                path = self._write_case_file(
+                    Path(tmp_str),
+                    f"{method}.json",
+                    {"skill_name": "x", "method": method, "cases": []},
+                )
+                assert load_case_file(path)["method"] == method
+
+    def test_partition_splits_by_method(self) -> None:
+        """Runtime files run; description-fidelity files are reported as skipped."""
+        with tempfile.TemporaryDirectory() as tmp_str:
+            tmp = Path(tmp_str)
+            runtime = self._write_case_file(
+                tmp, "runtime.json",
+                {"skill_name": "rt", "method": "runtime", "cases": []},
+            )
+            descfid = self._write_case_file(
+                tmp, "descfid.json",
+                {"skill_name": "df", "method": "description-fidelity", "cases": []},
+            )
+            runtime_files, skipped = partition_case_files([runtime, descfid])
+            assert runtime_files == [runtime]
+            assert skipped == [("df", "description-fidelity")]
+
+    def test_format_skip_notice_names_skills(self) -> None:
+        notice = format_skip_notice(
+            [
+                ("test-evaluation", "description-fidelity"),
+                ("test-conventions", "description-fidelity"),
+            ]
+        )
+        assert "test-conventions" in notice
+        assert "test-evaluation" in notice
+        assert "README" in notice
+
+
+class TestSkipNoticeWiring:
+    def test_description_fidelity_skill_skipped_with_notice(self) -> None:
+        """`--skill` on a description-fidelity skill prints the skip notice, exits 0.
+
+        test-conventions declares method=description-fidelity, so the runtime
+        harness runs no samples — this exercises the skip path end-to-end
+        without spawning claude -p.
+        """
+        result = subprocess.run(
+            [sys.executable, str(HARNESS), "--skill", "test-conventions"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "Skipped" in result.stdout
+        assert "test-conventions" in result.stdout

--- a/evals/README.md
+++ b/evals/README.md
@@ -14,7 +14,7 @@ subscription auth. This means:
 - **No CI wiring.** Trigger-fidelity is a probabilistic model classification, not
   a deterministic computation. A single-sample binary pass/fail produces a
   flaky CI signal; the harness treats output as a human-read pass-rate report
-  (`triggered 2/3`), not a gate. Running it in CI would also require
+  (`triggered 7/10`), not a gate. Running it in CI would also require
   `--dangerously-skip-permissions` on a public repo — a security footgun.
 
 ## Usage
@@ -50,14 +50,14 @@ model used.
 ## Reading the output
 
 ```
-Skill trigger-fidelity   model=claude-sonnet-4-6  K=3   2026-05-15
+Skill trigger-fidelity   model=claude-sonnet-4-6  K=10   2026-05-15
 
 code-review                                              4/5
-  code-written-commit-pending         triggers      3/3   PASS
-  explicit-user-code-review-request   triggers      2/3   PASS
-  cosmetic-typo-fix                   does-not-trig 0/3   PASS
-  plan-only-no-code                   does-not-trig 1/3   FAIL  (plan-review fired 2/3)
-  vs-skill-review-skill-md-only       does-not-trig 0/3   PASS
+  code-written-commit-pending         triggers      10/10  PASS
+  explicit-user-code-review-request   triggers       8/10  PASS
+  cosmetic-typo-fix                   does-not-trig  0/10  PASS
+  plan-only-no-code                   does-not-trig  2/10  FAIL  (plan-review fired 7/10)
+  vs-skill-review-skill-md-only       does-not-trig  0/10  PASS
 
 summary: 1 skills, 5 cases | pass 4/5 | review the 1 FAIL cases above
 ```
@@ -67,6 +67,11 @@ summary: 1 skills, 5 cases | pass 4/5 | review the 1 FAIL cases above
 - **FAIL + parenthetical**: adjacent skill stole the trigger — the actionable signal
   for tightening the DO NOT TRIGGER prose.
 - Exit code is always `0` — measurement, not a gate.
+
+**Noise floor.** Triggering is probabilistic, so the pass rate carries sampling
+noise. At `K=10` a case that genuinely triggers ~60% of the time still reads
+FAIL roughly 1 run in 6. Treat a borderline FAIL near the 50% line as a prompt
+to re-run at higher `K` (e.g. `--samples 30`), not as a confirmed regression.
 
 ## Adding trigger cases
 
@@ -81,6 +86,7 @@ Schema:
 ```json
 {
   "skill_name": "code-review",
+  "method": "runtime",
   "cases": [
     {
       "id": "post-implementation-handoff",
@@ -102,10 +108,31 @@ Schema:
 }
 ```
 
+- `method`: required. Which harness measures this skill — see
+  [Measurement methods](#measurement-methods).
 - `id`: stable label shown in the report.
 - `should_trigger`: `true` = the skill must fire; `false` = it must stay silent.
 - `also_not_triggered`: optional. Adjacent skills that must **not** fire on this
   query. A FAIL names which adjacent skill stole the trigger.
+
+## Measurement methods
+
+Each `trigger-cases.json` declares a `method`:
+
+- **`runtime`** — this harness spawns `claude -p` and watches for the skill's
+  `Skill` tool call to fire. It measures real auto-dispatch in a live session.
+- **`description-fidelity`** — a separate runner asks a model to classify which
+  skill a query should match, given the skill listing. It measures whether the
+  skill's `description` discriminates the query, not runtime dispatch.
+
+Headless `claude -p` does not reliably auto-trigger every skill — advisory
+skills the model is not pushed to invoke (and `user-invocable: false` skills)
+under-trigger regardless of description quality, so `runtime` measurement
+returns a false zero for them. Those skills use `description-fidelity` instead.
+
+`run_trigger_evals.py` runs `runtime` skills only; it reports any
+`description-fidelity` skill as skipped. The `description-fidelity` runner is
+not yet implemented.
 
 **Write realistic queries.** On-the-nose queries (keyword-bait like "trigger
 code-review now") pass trivially. The `also_not_triggered` confusion cases carry

--- a/evals/fixtures/temp-project.staged.patch
+++ b/evals/fixtures/temp-project.staged.patch
@@ -1,0 +1,9 @@
+--- a/calculator.py
++++ b/calculator.py
+@@ -5,2 +5,6 @@ def subtract(a: int, b: int) -> int:
+ def subtract(a: int, b: int) -> int:
+     return a - b
++
++
++def multiply(a: int, b: int) -> int:
++    return a * b

--- a/evals/fixtures/temp-project/README.md
+++ b/evals/fixtures/temp-project/README.md
@@ -1,0 +1,3 @@
+# sample-app
+
+A small utility library providing basic arithmetic operations.

--- a/evals/fixtures/temp-project/calculator.py
+++ b/evals/fixtures/temp-project/calculator.py
@@ -1,0 +1,6 @@
+def add(a: int, b: int) -> int:
+    return a + b
+
+
+def subtract(a: int, b: int) -> int:
+    return a - b

--- a/evals/fixtures/temp-project/tests/test_calculator.py
+++ b/evals/fixtures/temp-project/tests/test_calculator.py
@@ -1,0 +1,9 @@
+import calculator
+
+
+def test_add() -> None:
+    assert calculator.add(2, 3) == 5
+
+
+def test_subtract() -> None:
+    assert calculator.subtract(5, 3) == 2

--- a/evals/run_trigger_evals.py
+++ b/evals/run_trigger_evals.py
@@ -17,6 +17,7 @@ import argparse
 import json
 import os
 import select
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -27,13 +28,21 @@ from datetime import date
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+EVALS_DIR = Path(__file__).resolve().parent
 SKILLS_DIR = REPO_ROOT / "claude" / ".claude" / "skills"
 PLUGINS_DIR = REPO_ROOT / "plugins"
 
-SAMPLE_TIMEOUT_S = 30
-DEFAULT_SAMPLES = 3
+SAMPLE_TIMEOUT_S = 90
+DEFAULT_SAMPLES = 10
 DEFAULT_WORKERS = 4
 DEFAULT_MODEL = "claude-sonnet-4-6"
+
+# Measurement method declared per case file. `runtime` skills are measured by
+# this harness, which spawns `claude -p` and watches for the Skill tool to fire.
+# `description-fidelity` skills are measured by a separate runner — see
+# evals/README.md. A case file must declare one of these.
+RUNTIME_METHOD = "runtime"
+VALID_METHODS = frozenset((RUNTIME_METHOD, "description-fidelity"))
 
 # Skill-tool detection: Claude Code auto-triggers a skill by calling the Skill tool.
 # Read is NOT included — its input is a file path, not a skill name.
@@ -67,7 +76,61 @@ def load_case_file(path: Path) -> dict:
         data = json.load(f)
     if "skill_name" not in data or "cases" not in data:
         raise ValueError(f"Invalid trigger-cases.json at {path}: missing skill_name or cases")
+    method = data.get("method")
+    if method not in VALID_METHODS:
+        raise ValueError(
+            f"Invalid trigger-cases.json at {path}: 'method' must be one of "
+            f"{sorted(VALID_METHODS)}, got {method!r}"
+        )
     return data
+
+
+def partition_case_files(case_files: list[Path]) -> tuple[list[Path], list[tuple[str, str]]]:
+    """Split case files into runtime-measurable and skipped (non-runtime).
+
+    Returns (runtime_files, skipped); skipped holds (skill_name, method) pairs
+    for skills this harness cannot measure. Raises via load_case_file() on any
+    file with a missing or invalid method.
+    """
+    runtime_files: list[Path] = []
+    skipped: list[tuple[str, str]] = []
+    for case_file in case_files:
+        data = load_case_file(case_file)
+        if data["method"] == RUNTIME_METHOD:
+            runtime_files.append(case_file)
+        else:
+            skipped.append((data["skill_name"], data["method"]))
+    return runtime_files, skipped
+
+
+def format_skip_notice(skipped: list[tuple[str, str]]) -> str:
+    """One-line report of skills excluded because they are not runtime-measurable."""
+    names = ", ".join(sorted(name for name, _ in skipped))
+    return (
+        f"Skipped {len(skipped)} skill(s) not measured by the runtime harness: "
+        f"{names}. See evals/README.md for the measurement method each skill uses."
+    )
+
+
+def seed_temp_project_git(project_dir: Path) -> None:
+    """Copy the committed fixture skeleton into project_dir and set up git state.
+
+    Static content (README, calculator.py, tests/) comes from
+    evals/fixtures/temp-project/. The staged-but-uncommitted diff comes from
+    evals/fixtures/temp-project.staged.patch. Git identity is pinned via -c
+    flags so this does not depend on machine git config.
+    """
+    fixture_dir = EVALS_DIR / "fixtures" / "temp-project"
+    staged_patch = EVALS_DIR / "fixtures" / "temp-project.staged.patch"
+
+    shutil.copytree(fixture_dir, project_dir, dirs_exist_ok=True)
+
+    git = ["git", "-c", "user.email=eval@example.com", "-c", "user.name=Eval Harness"]
+    subprocess.run([*git, "init", "-q"], cwd=project_dir, check=True)
+    subprocess.run([*git, "add", "-A"], cwd=project_dir, check=True)
+    subprocess.run([*git, "commit", "-q", "-m", "initial"], cwd=project_dir, check=True)
+    subprocess.run(["git", "apply", str(staged_patch)], cwd=project_dir, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=project_dir, check=True)
 
 
 def build_temp_project(skills_dir: Path, plugins_dir: Path) -> Path:
@@ -90,6 +153,7 @@ def build_temp_project(skills_dir: Path, plugins_dir: Path) -> Path:
             if ps.is_dir():
                 (plugin_skills / plugin_dir.name).symlink_to(ps)
     (dot_claude / "settings.json").write_text(json.dumps({"hooks": {}}))
+    seed_temp_project_git(tmp)
     return tmp
 
 
@@ -364,10 +428,17 @@ def main() -> int:
             print("No trigger-cases.json files found. Run --skill <name> or author case files first.", file=sys.stderr)
             return 1
 
+    runtime_files, skipped = partition_case_files(case_files)
+    if skipped:
+        print(format_skip_notice(skipped))
+    if not runtime_files:
+        print("No runtime-measurable skills to run.")
+        return 0
+
     tmp_project = build_temp_project(SKILLS_DIR, PLUGINS_DIR)
     try:
         skill_results = []
-        for case_file in case_files:
+        for case_file in runtime_files:
             sr = run_skill(case_file, tmp_project, args.model, args.samples, args.workers, args.verbose)
             skill_results.append(sr)
 
@@ -386,7 +457,6 @@ def main() -> int:
         return 0  # always 0 — measurement, not a gate
 
     finally:
-        import shutil
         shutil.rmtree(tmp_project, ignore_errors=True)
 
 


### PR DESCRIPTION
## Summary

A smoke test of the skill trigger-fidelity harness found it measures `code-review` correctly (5/5) but returns a uniform 0/10 for the advisory skills `test-conventions` and `test-evaluation`. That zero is a measurement artifact of a confirmed won't-fix Claude Code limitation (anthropics/claude-code#34648 — headless `claude -p` does not reliably auto-trigger skills, especially advisory `user-invocable: false` ones), not a skill defect.

This PR splits the harness measurement model so it stops emitting false FAILs, and ships the verified `code-review` fix. A follow-up PR adds the `description-fidelity` runner.

## What shipped

- **Schema** — each `trigger-cases.json` declares a required `method`: `runtime` (measured here via `claude -p` auto-dispatch) or `description-fidelity` (measured by a separate runner, not yet built). `load_case_file()` rejects a missing or unknown method.
- **Harness** — `discover_case_files()` results are partitioned by method; only `runtime` skills run. Non-runtime skills are reported with a one-line skip notice instead of a false FAIL.
- **code-review** — marked `runtime`; keeps the fixture-seeding helper and the K=10 / 90s-timeout changes that make its real-diff measurement reliable.
- **test-conventions / test-evaluation** — marked `description-fidelity`.
- **Tests** — method validation, mode partitioning, skip-notice text, and an end-to-end skip-path test (no `claude -p`).
- **Docs** — `evals/README.md` documents the two measurement methods and the K=10 sampling noise floor.

## Test plan

- [ ] Reviewer judgment: confirm the two-mode split is the right seam, vs. converting every skill to description-fidelity. Rationale: runtime measurement observes real auto-dispatch and is strictly more faithful when a skill is runtime-triggerable; collapsing to one mode would discard that signal for `code-review`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)