### PR TITLE
Add description-fidelity measurement mode to skill eval harness

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,19 +37,20 @@ ruff check claude/.claude/  # lint
 
 CI runs both on every PR and main push. Both must pass before the PR can be reviewed.
 
-## Trigger-fidelity evals
+## Skill evals
 
-`evals/run_trigger_evals.py` measures how reliably each skill auto-triggers
-(or stays silent) for its declared TRIGGER / DO NOT TRIGGER conditions. It
-runs `claude -p` locally using your Claude subscription auth — no API key,
-no CI wiring, no per-token charge on Max plan.
+`evals/run_skill_evals.py` measures each skill's `trigger-cases.json` against
+its declared TRIGGER / DO NOT TRIGGER conditions, via one of two per-skill
+methods (`runtime` or `description-fidelity`). It runs `claude -p` locally
+using your Claude subscription auth — no API key, no CI wiring, no per-token
+charge on Max plan.
 
 ```bash
 # Run the 3 pilot skills:
-python evals/run_trigger_evals.py --skill code-review --skill test-conventions --skill test-evaluation
+python evals/run_skill_evals.py --skill code-review --skill test-conventions --skill test-evaluation
 
 # Run a single skill after editing its TRIGGER block:
-python evals/run_trigger_evals.py --skill <name>
+python evals/run_skill_evals.py --skill <name>
 ```
 
 See `evals/README.md` for the full usage guide, output format, and how to

--- a/claude/.claude/skills/test-conventions/evals/trigger-cases.json
+++ b/claude/.claude/skills/test-conventions/evals/trigger-cases.json
@@ -26,6 +26,12 @@
       "id": "fix-single-assertion",
       "query": "Update this assertion to match the new API response shape: assert response.status_code == 200",
       "should_trigger": false
+    },
+    {
+      "id": "adding-tests-to-partially-covered-module",
+      "query": "I'm adding test coverage for the refund path in our payment module. It already has a couple of tests for the happy path — how should I structure the new ones?",
+      "should_trigger": true,
+      "also_not_triggered": ["test-evaluation"]
     }
   ]
 }

--- a/claude/.claude/skills/test-evaluation/evals/trigger-cases.json
+++ b/claude/.claude/skills/test-evaluation/evals/trigger-cases.json
@@ -4,7 +4,7 @@
   "cases": [
     {
       "id": "evaluating-existing-suite-quality",
-      "query": "Look at our existing test suite and assess the coverage quality and test pyramid shape.",
+      "query": "Our test suite has grown messy over the last few releases and I'm not confident it actually catches regressions anymore. Can you go through it and tell me where it's weak?",
       "should_trigger": true
     },
     {
@@ -27,6 +27,12 @@
       "query": "Review our test code and tell me which areas have weak coverage and which tests are redundant.",
       "should_trigger": true,
       "also_not_triggered": ["code-review"]
+    },
+    {
+      "id": "assess-before-extending-suite",
+      "query": "Before I add any more tests to the checkout flow, I want to know whether the tests we already have are solid. Can you assess them?",
+      "should_trigger": true,
+      "also_not_triggered": ["test-conventions"]
     }
   ]
 }

--- a/claude/.claude/skills/tests/test_trigger_detector.py
+++ b/claude/.claude/skills/tests/test_trigger_detector.py
@@ -1,32 +1,33 @@
-"""Unit tests for the stream-json trigger detector in evals/run_trigger_evals.py.
+"""Unit tests for the offline-testable parts of evals/run_skill_evals.py.
 
-Feeds committed fixture files (synthetic, hand-authored stream-json fixtures) to
-detect_trigger_in_lines() and asserts the correct fired-skill name.
-Deterministic, no claude -p call — CI-safe.
+Covers the runtime-mode stream-json trigger detector, the case-file `method`
+schema, and the description-fidelity classification parser / scorer. All
+deterministic — no claude -p call, CI-safe. Runtime-mode detector tests feed
+committed synthetic stream-json fixtures from evals/fixtures/.
 
-The fixtures live in evals/fixtures/. pyproject.toml adds 'evals' to the
-pytest pythonpath so `import run_trigger_evals` resolves correctly.
+pyproject.toml adds 'evals' to the pytest pythonpath so `import run_skill_evals`
+resolves correctly.
 """
 
 from __future__ import annotations
 
 import json
 import subprocess
-import sys
 import tempfile
 from pathlib import Path
 
 import pytest
-from run_trigger_evals import (
+from run_skill_evals import (
     detect_trigger_in_lines,
-    format_skip_notice,
     load_case_file,
+    parse_classification_answer,
+    parse_skill_frontmatter,
     partition_case_files,
+    score_classification,
     seed_temp_project_git,
 )
 
 FIXTURES_DIR = Path(__file__).resolve().parents[4] / "evals" / "fixtures"
-HARNESS = Path(__file__).resolve().parents[4] / "evals" / "run_trigger_evals.py"
 
 
 def _lines(fixture_name: str) -> list[str]:
@@ -144,7 +145,7 @@ class TestCaseFileMethod:
                 assert load_case_file(path)["method"] == method
 
     def test_partition_splits_by_method(self) -> None:
-        """Runtime files run; description-fidelity files are reported as skipped."""
+        """partition_case_files separates runtime files from description-fidelity files."""
         with tempfile.TemporaryDirectory() as tmp_str:
             tmp = Path(tmp_str)
             runtime = self._write_case_file(
@@ -155,36 +156,107 @@ class TestCaseFileMethod:
                 tmp, "descfid.json",
                 {"skill_name": "df", "method": "description-fidelity", "cases": []},
             )
-            runtime_files, skipped = partition_case_files([runtime, descfid])
+            runtime_files, description_fidelity_files = partition_case_files([runtime, descfid])
             assert runtime_files == [runtime]
-            assert skipped == [("df", "description-fidelity")]
-
-    def test_format_skip_notice_names_skills(self) -> None:
-        notice = format_skip_notice(
-            [
-                ("test-evaluation", "description-fidelity"),
-                ("test-conventions", "description-fidelity"),
-            ]
-        )
-        assert "test-conventions" in notice
-        assert "test-evaluation" in notice
-        assert "README" in notice
+            assert description_fidelity_files == [descfid]
 
 
-class TestSkipNoticeWiring:
-    def test_description_fidelity_skill_skipped_with_notice(self) -> None:
-        """`--skill` on a description-fidelity skill prints the skip notice, exits 0.
+class TestParseSkillFrontmatter:
+    """assemble_skill_listing() relies on this minimal stdlib frontmatter parser."""
 
-        test-conventions declares method=description-fidelity, so the runtime
-        harness runs no samples — this exercises the skip path end-to-end
-        without spawning claude -p.
+    @staticmethod
+    def _write_skill(directory: Path, name: str, body: str) -> Path:
+        skill_dir = directory / name
+        skill_dir.mkdir()
+        path = skill_dir / "SKILL.md"
+        path.write_text(body)
+        return path
+
+    def test_inline_description(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_str:
+            path = self._write_skill(
+                Path(tmp_str), "my-skill",
+                "---\nname: my-skill\ndescription: A one-line description.\n---\nbody\n",
+            )
+            name, desc = parse_skill_frontmatter(path)
+            assert name == "my-skill"
+            assert desc == "A one-line description."
+
+    def test_folded_block_description_stops_at_next_key(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_str:
+            path = self._write_skill(
+                Path(tmp_str), "folded-skill",
+                "---\nname: folded-skill\ndescription: >\n  First line of the\n"
+                "  folded description.\nuser-invocable: false\n---\nbody\n",
+            )
+            name, desc = parse_skill_frontmatter(path)
+            assert name == "folded-skill"
+            assert desc == "First line of the folded description."
+            assert "user-invocable" not in desc
+
+    def test_missing_frontmatter_falls_back_to_dir_name(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_str:
+            path = self._write_skill(Path(tmp_str), "bare-skill", "no frontmatter here\n")
+            name, desc = parse_skill_frontmatter(path)
+            assert name == "bare-skill"
+            assert desc == ""
+
+
+VALID_NAMES = frozenset({"code-review", "test-conventions", "test-evaluation", "plan-it"})
+
+
+class TestParseClassificationAnswer:
+    """Offline tests for the description-fidelity classifier-answer parser."""
+
+    def test_bare_skill_name(self) -> None:
+        assert parse_classification_answer("code-review", VALID_NAMES) == "code-review"
+
+    def test_bare_skill_name_with_whitespace(self) -> None:
+        assert parse_classification_answer("  test-conventions\n", VALID_NAMES) == "test-conventions"
+
+    def test_literal_none(self) -> None:
+        assert parse_classification_answer("none\n", VALID_NAMES) is None
+
+    def test_empty_output(self) -> None:
+        assert parse_classification_answer("", VALID_NAMES) is None
+
+    def test_unknown_word(self) -> None:
+        assert parse_classification_answer("refactoring", VALID_NAMES) is None
+
+    def test_quoted_name(self) -> None:
+        assert parse_classification_answer('"test-evaluation"', VALID_NAMES) == "test-evaluation"
+
+    def test_prose_wrapped_name(self) -> None:
+        """Best-effort fallback when the model ignores the one-line constraint."""
+        answer = "I would use the code-review skill for this request."
+        assert parse_classification_answer(answer, VALID_NAMES) == "code-review"
+
+
+class TestScoreClassification:
+    """description-fidelity scoring maps a named skill to the (fired, also_fired) shape."""
+
+    def test_target_skill_named(self) -> None:
+        fired, also = score_classification("test-conventions", "test-conventions", ["test-evaluation"])
+        assert fired == "test-conventions"
+        assert also == []
+
+    def test_guarded_adjacent_skill_named_is_violation(self) -> None:
+        """A should_trigger:false-style case where the model names a guarded skill.
+
+        test-evaluation is the target; the model instead names test-conventions,
+        which the case guards via also_not_triggered. It must score as a
+        violation (also_fired), exactly as a runtime misfire does — not a pass.
         """
-        result = subprocess.run(
-            [sys.executable, str(HARNESS), "--skill", "test-conventions"],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        assert result.returncode == 0, result.stderr
-        assert "Skipped" in result.stdout
-        assert "test-conventions" in result.stdout
+        fired, also = score_classification("test-conventions", "test-evaluation", ["test-conventions"])
+        assert fired is None
+        assert also == ["test-conventions"]
+
+    def test_unrelated_skill_named_is_no_violation(self) -> None:
+        fired, also = score_classification("plan-it", "test-evaluation", ["test-conventions"])
+        assert fired is None
+        assert also == []
+
+    def test_none_named(self) -> None:
+        fired, also = score_classification(None, "code-review", ["plan-review"])
+        assert fired is None
+        assert also == []

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -54,11 +54,13 @@ Persistent per-user: add to `~/.claude/settings.local.json`:
 
 `settings.local.json` overrides `settings.json` at the same scope; the repo's `"off"` entry does not win. Remove the entry (or set to `"on"`) to restore. Reference: [Claude Code skills — Override skill visibility from settings](https://code.claude.com/docs/en/skills.md).
 
-## Trigger-fidelity evals
+## Skill evals
 
-`evals/run_trigger_evals.py` is a local harness that measures whether each
-skill's TRIGGER prose reliably causes the model to invoke the skill (or stay
-silent) for a set of test queries. See `evals/README.md` for usage.
+`evals/run_skill_evals.py` is a local harness that measures each skill's
+`trigger-cases.json` against its declared TRIGGER / DO NOT TRIGGER conditions —
+either by observing live auto-dispatch (`runtime`) or by asking a model to
+classify which skill a query should match (`description-fidelity`). See
+`evals/README.md` for usage and the two-method model.
 
 ## Skill architecture notes
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,8 +1,10 @@
-# Skill Trigger-Fidelity Evals
+# Skill Evals
 
-A local harness that measures how reliably each skill auto-triggers (or stays
-silent) when given a test query. Answers: "does this skill's TRIGGER prose
-actually cause the model to invoke it?"
+A local harness that measures each skill's `trigger-cases.json` against its
+declared TRIGGER / DO NOT TRIGGER conditions. It runs one of two measurement
+methods per skill — `runtime` or `description-fidelity` — and reports a
+per-case pass rate. See [Measurement methods](#measurement-methods) for which
+method fits which skill.
 
 ## Why local only — never CI
 
@@ -11,8 +13,8 @@ subscription auth. This means:
 
 - **No `ANTHROPIC_API_KEY` required.** Max-plan OAuth auth is used automatically.
 - **No per-token charge** beyond your subscription.
-- **No CI wiring.** Trigger-fidelity is a probabilistic model classification, not
-  a deterministic computation. A single-sample binary pass/fail produces a
+- **No CI wiring.** Both methods produce a probabilistic model classification,
+  not a deterministic computation. A single-sample binary pass/fail produces a
   flaky CI signal; the harness treats output as a human-read pass-rate report
   (`triggered 7/10`), not a gate. Running it in CI would also require
   `--dangerously-skip-permissions` on a public repo — a security footgun.
@@ -21,25 +23,25 @@ subscription auth. This means:
 
 ```bash
 # Run all skills that have a trigger-cases.json:
-python evals/run_trigger_evals.py
+python evals/run_skill_evals.py
 
 # Run one skill:
-python evals/run_trigger_evals.py --skill code-review
+python evals/run_skill_evals.py --skill code-review
 
 # Run the test-conventions / test-evaluation adjacency pair:
-python evals/run_trigger_evals.py --skill test-conventions --skill test-evaluation
+python evals/run_skill_evals.py --skill test-conventions --skill test-evaluation
 
 # Tune sampling:
-python evals/run_trigger_evals.py --skill code-review --samples 5
+python evals/run_skill_evals.py --skill code-review --samples 5
 
 # Spot-compare with Opus:
-python evals/run_trigger_evals.py --skill code-review --model claude-opus-4-7
+python evals/run_skill_evals.py --skill code-review --model claude-opus-4-7
 
 # Verbose (prints each case as it completes):
-python evals/run_trigger_evals.py --verbose
+python evals/run_skill_evals.py --verbose
 
 # Write machine-readable results:
-python evals/run_trigger_evals.py --json /tmp/results.json
+python evals/run_skill_evals.py --json /tmp/results.json
 ```
 
 Default model: `claude-sonnet-4-6`. Sonnet is a stricter classifier than Opus,
@@ -50,22 +52,31 @@ model used.
 ## Reading the output
 
 ```
-Skill trigger-fidelity   model=claude-sonnet-4-6  K=10   2026-05-15
+Skill eval   model=claude-sonnet-4-6  K=10   2026-05-15
 
-code-review                                              4/5
+code-review                              runtime                4/5
   code-written-commit-pending         triggers      10/10  PASS
   explicit-user-code-review-request   triggers       8/10  PASS
   cosmetic-typo-fix                   does-not-trig  0/10  PASS
   plan-only-no-code                   does-not-trig  2/10  FAIL  (plan-review fired 7/10)
   vs-skill-review-skill-md-only       does-not-trig  0/10  PASS
+test-conventions                         description-fidelity   6/6
+  planning-tests-new-feature          triggers      10/10  PASS
+  adding-tests-to-partially-covered…  triggers       9/10  PASS
 
-summary: 1 skills, 5 cases | pass 4/5 | review the 1 FAIL cases above
+summary: 2 skills, 7 cases | pass 5/7 | review the 2 FAIL cases above
 ```
 
+- The second column on each skill line is the **measurement method** —
+  `runtime` or `description-fidelity`. The two are distinct signals; the
+  column keeps them from being conflated.
 - **PASS**: trigger rate ≥ 50% for should-trigger cases; < 50% for should-not.
   Plus no `also_not_triggered` skill fired in any sample.
 - **FAIL + parenthetical**: adjacent skill stole the trigger — the actionable signal
   for tightening the DO NOT TRIGGER prose.
+- Under `description-fidelity` the `triggers` / `does-not-trig` per-case label
+  reads as "the classifier named this skill" / "named a different skill or
+  none" — there is no live dispatch in that mode.
 - Exit code is always `0` — measurement, not a gate.
 
 **Noise floor.** Triggering is probabilistic, so the pass rate carries sampling
@@ -117,22 +128,26 @@ Schema:
 
 ## Measurement methods
 
-Each `trigger-cases.json` declares a `method`:
+Each `trigger-cases.json` declares a `method`. `run_skill_evals.py` runs both
+in one invocation, routing per case file and labelling each skill's mode in the
+report:
 
-- **`runtime`** — this harness spawns `claude -p` and watches for the skill's
+- **`runtime`** — the harness spawns `claude -p` and watches for the skill's
   `Skill` tool call to fire. It measures real auto-dispatch in a live session.
-- **`description-fidelity`** — a separate runner asks a model to classify which
-  skill a query should match, given the skill listing. It measures whether the
-  skill's `description` discriminates the query, not runtime dispatch.
+- **`description-fidelity`** — the harness asks a model, in a plain `claude -p`
+  classification prompt, which one skill a query should match given the full
+  skill listing. It measures whether the skill's `description` discriminates
+  the query, not runtime dispatch.
 
 Headless `claude -p` does not reliably auto-trigger every skill — advisory
 skills the model is not pushed to invoke (and `user-invocable: false` skills)
 under-trigger regardless of description quality, so `runtime` measurement
 returns a false zero for them. Those skills use `description-fidelity` instead.
 
-`run_trigger_evals.py` runs `runtime` skills only; it reports any
-`description-fidelity` skill as skipped. The `description-fidelity` runner is
-not yet implemented.
+The two methods measure genuinely different properties and are not
+interchangeable. `runtime` is strictly more faithful when available — it
+observes the real dispatch decision — so a skill that *can* trigger headlessly
+keeps `runtime` rather than being downgraded to classification.
 
 **Write realistic queries.** On-the-nose queries (keyword-bait like "trigger
 code-review now") pass trivially. The `also_not_triggered` confusion cases carry
@@ -140,6 +155,8 @@ the real signal — write queries that read like genuine user turns where the
 boundary between adjacent skills is ambiguous.
 
 ## How detection works
+
+### runtime
 
 The harness runs `claude -p <query>` from a throwaway project whose
 `.claude/skills/` is symlinked to the working-tree `claude/.claude/skills/`.
@@ -155,9 +172,27 @@ content_block_stop  → parse accumulated JSON; compare input["skill"] == skill_
 
 Early-terminates the subprocess once the target skill fires and no `also_not`
 guards remain to observe; reads to timeout when misfire guards are active so every
-block is seen. Detection logic is unit-tested via synthetic hand-authored
-stream-json fixtures in `evals/fixtures/` — see
-`claude/.claude/skills/tests/test_trigger_detector.py`.
+block is seen.
+
+### description-fidelity
+
+The harness assembles a skill listing — every skill's `name` and `description`
+frontmatter — and builds one `claude -p` prompt per case: the listing, the
+case query, and an instruction to name the single skill that should handle the
+query, or `none`. It runs from an empty project (no skills symlinked) so
+`claude -p` answers the question rather than auto-dispatching. The reply is
+parsed to one skill name; that name is scored against `should_trigger` and
+`also_not_triggered` exactly as a runtime fire is — a reply naming a guarded
+adjacent skill is an `also_not_triggered` violation.
+
+This path is plain question-answering, not skill auto-dispatch, so it is
+unaffected by the headless auto-trigger limitation that makes `runtime`
+unreliable for advisory skills.
+
+The `method` schema, the classification-answer parser, and the runtime
+stream-json detector are unit-tested offline (synthetic inputs, no `claude -p`)
+in `claude/.claude/skills/tests/test_trigger_detector.py`; the runtime fixtures
+live in `evals/fixtures/`.
 
 ## Linting
 

--- a/evals/run_skill_evals.py
+++ b/evals/run_skill_evals.py
@@ -1,8 +1,14 @@
-"""Skill trigger-fidelity harness for claude-config.
+"""Skill eval harness for claude-config.
 
-Runs `claude -p` against per-skill trigger-cases.json files and reports
-how reliably each skill auto-triggers (or stays silent) for its declared
-TRIGGER / DO NOT TRIGGER conditions.
+Measures each skill's trigger-cases.json against its declared TRIGGER /
+DO NOT TRIGGER conditions, using one of two methods declared per case file:
+
+- runtime: spawn `claude -p` and watch for the Skill tool to fire. Measures
+  real auto-dispatch; faithful only when the skill triggers headlessly.
+- description-fidelity: ask `claude -p`, in a plain classification prompt,
+  which skill a query should match given the full skill listing. Measures
+  whether the skill's description discriminates the query — not runtime
+  dispatch. Used for advisory skills the runtime substrate cannot reach.
 
 LOCAL USE ONLY — never run in CI. Uses the session's Claude subscription
 auth (no ANTHROPIC_API_KEY required; no per-token charge on Max plan).
@@ -16,6 +22,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import select
 import shutil
 import subprocess
@@ -37,12 +44,13 @@ DEFAULT_SAMPLES = 10
 DEFAULT_WORKERS = 4
 DEFAULT_MODEL = "claude-sonnet-4-6"
 
-# Measurement method declared per case file. `runtime` skills are measured by
-# this harness, which spawns `claude -p` and watches for the Skill tool to fire.
-# `description-fidelity` skills are measured by a separate runner — see
-# evals/README.md. A case file must declare one of these.
+# Measurement method declared per case file. `runtime` spawns `claude -p` and
+# watches for the Skill tool to fire; `description-fidelity` asks `claude -p` to
+# classify which skill a query should match. See evals/README.md. A case file
+# must declare exactly one of these.
 RUNTIME_METHOD = "runtime"
-VALID_METHODS = frozenset((RUNTIME_METHOD, "description-fidelity"))
+DESCRIPTION_FIDELITY_METHOD = "description-fidelity"
+VALID_METHODS = frozenset((RUNTIME_METHOD, DESCRIPTION_FIDELITY_METHOD))
 
 # Skill-tool detection: Claude Code auto-triggers a skill by calling the Skill tool.
 # Read is NOT included — its input is a file path, not a skill name.
@@ -85,31 +93,20 @@ def load_case_file(path: Path) -> dict:
     return data
 
 
-def partition_case_files(case_files: list[Path]) -> tuple[list[Path], list[tuple[str, str]]]:
-    """Split case files into runtime-measurable and skipped (non-runtime).
+def partition_case_files(case_files: list[Path]) -> tuple[list[Path], list[Path]]:
+    """Split case files by measurement method.
 
-    Returns (runtime_files, skipped); skipped holds (skill_name, method) pairs
-    for skills this harness cannot measure. Raises via load_case_file() on any
-    file with a missing or invalid method.
+    Returns (runtime_files, description_fidelity_files). Raises via
+    load_case_file() on any file with a missing or invalid method.
     """
     runtime_files: list[Path] = []
-    skipped: list[tuple[str, str]] = []
+    description_fidelity_files: list[Path] = []
     for case_file in case_files:
-        data = load_case_file(case_file)
-        if data["method"] == RUNTIME_METHOD:
+        if load_case_file(case_file)["method"] == RUNTIME_METHOD:
             runtime_files.append(case_file)
         else:
-            skipped.append((data["skill_name"], data["method"]))
-    return runtime_files, skipped
-
-
-def format_skip_notice(skipped: list[tuple[str, str]]) -> str:
-    """One-line report of skills excluded because they are not runtime-measurable."""
-    names = ", ".join(sorted(name for name, _ in skipped))
-    return (
-        f"Skipped {len(skipped)} skill(s) not measured by the runtime harness: "
-        f"{names}. See evals/README.md for the measurement method each skill uses."
-    )
+            description_fidelity_files.append(case_file)
+    return runtime_files, description_fidelity_files
 
 
 def seed_temp_project_git(project_dir: Path) -> None:
@@ -155,6 +152,192 @@ def build_temp_project(skills_dir: Path, plugins_dir: Path) -> Path:
     (dot_claude / "settings.json").write_text(json.dumps({"hooks": {}}))
     seed_temp_project_git(tmp)
     return tmp
+
+
+# --- description-fidelity measurement -------------------------------------
+#
+# This path does not exercise skill auto-dispatch. It asks `claude -p` a plain
+# question — "which skill should handle this query?" — given the skill listing
+# as prompt data. Plain question-answering is unaffected by the headless
+# auto-trigger limitation (anthropics/claude-code#34648), so it is an honest
+# fallback for advisory skills the `runtime` substrate cannot measure.
+
+
+def parse_skill_frontmatter(skill_md_path: Path) -> tuple[str, str]:
+    """Extract (name, description) from a SKILL.md YAML frontmatter block.
+
+    Minimal stdlib parser — handles inline scalars and `>`/`|` block scalars.
+    Avoids a PyYAML dependency so this module imports cleanly under CI, which
+    installs only pytest and ruff. Falls back to the directory name when the
+    `name` key is absent or there is no frontmatter.
+    """
+    text = skill_md_path.read_text()
+    fallback_name = skill_md_path.parent.name
+    if not text.startswith("---"):
+        return fallback_name, ""
+    try:
+        closing = text.index("\n---", 3)
+    except ValueError:
+        return fallback_name, ""
+    lines = text[3:closing].splitlines()
+
+    name = fallback_name
+    description = ""
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if line.startswith("name:"):
+            value = line.split(":", 1)[1].strip()
+            if value:
+                name = value
+            i += 1
+        elif line.startswith("description:"):
+            value = line.split(":", 1)[1].strip()
+            if value and value not in (">", "|", ">-", "|-", ">+", "|+"):
+                description = value
+                i += 1
+            else:
+                # Block scalar: gather blank or indented continuation lines,
+                # stopping at the next top-level key.
+                block: list[str] = []
+                i += 1
+                while i < len(lines) and (not lines[i].strip() or lines[i][:1] in (" ", "\t")):
+                    block.append(lines[i].strip())
+                    i += 1
+                description = " ".join(part for part in block if part)
+        else:
+            i += 1
+    return name, description
+
+
+def assemble_skill_listing() -> tuple[str, frozenset[str]]:
+    """Build the skill listing shown to the classifier and the set of valid names.
+
+    Reads name + description frontmatter from every SKILL.md under SKILLS_DIR
+    and the plugin skill dirs — the same paths discover_case_files() globs — so
+    adjacent skills compete in the classification prompt exactly as they do in
+    a live session's skill listing.
+    """
+    skill_md_paths = sorted(SKILLS_DIR.glob("*/SKILL.md"))
+    if PLUGINS_DIR.exists():
+        skill_md_paths += sorted(PLUGINS_DIR.glob("*/skills/*/SKILL.md"))
+
+    entries: list[str] = []
+    names: list[str] = []
+    for path in skill_md_paths:
+        name, description = parse_skill_frontmatter(path)
+        names.append(name)
+        entries.append(f"- {name}: {description}")
+    return "\n".join(entries), frozenset(names)
+
+
+def build_isolated_project() -> Path:
+    """Create a throwaway project with no skills, for description-fidelity runs.
+
+    The classification prompt carries the skill listing as data and asks a
+    plain question; `claude -p` must answer it, not auto-dispatch a skill. An
+    empty project (no .claude/skills/) keeps project-scope skills and hooks out
+    of the way. settings.json disables hooks.
+    """
+    tmp = Path(tempfile.mkdtemp(prefix="claude-eval-df-"))
+    dot_claude = tmp / ".claude"
+    dot_claude.mkdir()
+    (dot_claude / "settings.json").write_text(json.dumps({"hooks": {}}))
+    return tmp
+
+
+def build_classification_prompt(skill_listing: str, query: str) -> str:
+    """Construct the single-query classification prompt for description-fidelity.
+
+    The answer is constrained to one line — one skill name or the literal
+    `none` — so parse_classification_answer() is deterministic.
+    """
+    return (
+        "You are classifying which Claude Code skill, if any, should handle a "
+        "user request.\n\n"
+        "Below is the full list of available skills with their descriptions. "
+        "Each description states when the skill should and should not be "
+        "used.\n\n"
+        f"<skills>\n{skill_listing}\n</skills>\n\n"
+        "A user has made this request:\n\n"
+        f"<request>\n{query}\n</request>\n\n"
+        "Which single skill should handle this request? Reply with exactly one "
+        "line containing only the skill name, or the literal word none if no "
+        "skill applies. Do not explain."
+    )
+
+
+def parse_classification_answer(raw_output: str, valid_skill_names: frozenset[str]) -> str | None:
+    """Parse a classifier reply into a skill name, or None for 'none'/unparseable.
+
+    Accepts the constrained one-line answer (a bare skill name or `none`) and,
+    as a best-effort fallback, a prose-wrapped name. Returning the *named*
+    skill — not a boolean — lets description-fidelity score also_not_triggered
+    violations the same way runtime mode does.
+    """
+    text = raw_output.strip()
+    if not text:
+        return None
+
+    last_line = ""
+    for line in reversed(text.splitlines()):
+        if line.strip():
+            last_line = line.strip().strip("\"'`. ").lower()
+            break
+    if last_line == "none":
+        return None
+    if last_line in valid_skill_names:
+        return last_line
+
+    # Best-effort fallback for a prose-wrapped answer. Longest name first so a
+    # name that is a substring of another cannot mask the longer match.
+    for name in sorted(valid_skill_names, key=len, reverse=True):
+        if re.search(rf"\b{re.escape(name)}\b", text):
+            return name
+    return None
+
+
+def score_classification(
+    named_skill: str | None, skill_name: str, also_not: list[str]
+) -> tuple[str | None, list[str]]:
+    """Map a classifier's named skill to the (fired, also_fired) scoring shape.
+
+    Shared by run_description_fidelity_sample() and its unit tests. A named
+    skill listed in also_not is an also_not_triggered violation — scored
+    exactly as a runtime misfire is.
+    """
+    fired = skill_name if named_skill == skill_name else None
+    also_fired = [excluded for excluded in also_not if excluded == named_skill]
+    return fired, also_fired
+
+
+def run_description_fidelity_sample(args: tuple) -> tuple[str | None, list[str]]:
+    """Run one classification sample. Called from worker processes.
+
+    Returns the same (fired_skill_or_None, also_fired) shape as
+    run_single_sample() so run_case() scores both methods identically.
+    """
+    query, skill_name, also_not, isolated_project, skill_listing, valid_names, model = args
+
+    env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+    prompt = build_classification_prompt(skill_listing, query)
+
+    try:
+        proc = subprocess.run(
+            ["claude", "-p", prompt, "--model", model],
+            cwd=str(isolated_project),
+            env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=SAMPLE_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired:
+        return None, []
+
+    named = parse_classification_answer(proc.stdout, valid_names)
+    return score_classification(named, skill_name, also_not)
 
 
 def detect_trigger_in_lines(
@@ -286,7 +469,8 @@ def run_single_sample(args: tuple) -> tuple[str | None, list[str]]:
 def run_case(
     case: dict,
     skill_name: str,
-    tmp_project: Path,
+    method: str,
+    run_context: dict,
     model: str,
     samples: int,
     workers: int,
@@ -300,10 +484,19 @@ def run_case(
     fired_count = 0
     also_fired_totals: dict[str, int] = {}
 
-    sample_args = [(query, skill_name, also_not, tmp_project, model)] * samples
+    if method == RUNTIME_METHOD:
+        sample_fn = run_single_sample
+        sample_arg: tuple = (query, skill_name, also_not, run_context["tmp_project"], model)
+    else:
+        sample_fn = run_description_fidelity_sample
+        sample_arg = (
+            query, skill_name, also_not, run_context["isolated_project"],
+            run_context["skill_listing"], run_context["valid_names"], model,
+        )
+    sample_args = [sample_arg] * samples
 
     with ProcessPoolExecutor(max_workers=workers) as pool:
-        futures = [pool.submit(run_single_sample, a) for a in sample_args]
+        futures = [pool.submit(sample_fn, a) for a in sample_args]
         for fut in as_completed(futures):
             fired_skill, also_fired = fut.result()
             if fired_skill == skill_name:
@@ -339,7 +532,7 @@ def run_case(
 
 def run_skill(
     case_file: Path,
-    tmp_project: Path,
+    run_context: dict,
     model: str,
     samples: int,
     workers: int,
@@ -347,19 +540,21 @@ def run_skill(
 ) -> dict:
     data = load_case_file(case_file)
     skill_name = data["skill_name"]
+    method = data["method"]
     cases = data["cases"]
 
     if verbose:
-        print(f"\n{skill_name}", flush=True)
+        print(f"\n{skill_name}  [{method}]", flush=True)
 
     case_results = []
     for case in cases:
-        result = run_case(case, skill_name, tmp_project, model, samples, workers, verbose)
+        result = run_case(case, skill_name, method, run_context, model, samples, workers, verbose)
         case_results.append(result)
 
     passed = sum(1 for r in case_results if r["passed"])
     return {
         "skill_name": skill_name,
+        "method": method,
         "cases": case_results,
         "passed": passed,
         "total": len(case_results),
@@ -368,11 +563,11 @@ def run_skill(
 
 def print_report(skill_results: list[dict], model: str, samples: int, verbose: bool) -> None:
     today = date.today().isoformat()
-    print(f"\nSkill trigger-fidelity   model={model}  K={samples}   {today}\n")
+    print(f"\nSkill eval   model={model}  K={samples}   {today}\n")
 
     if not verbose:
         for sr in skill_results:
-            print(f"{sr['skill_name']:<50} {sr['passed']}/{sr['total']}")
+            print(f"{sr['skill_name']:<40} {sr['method']:<22} {sr['passed']}/{sr['total']}")
             for cr in sr["cases"]:
                 triggered_label = "triggers" if cr["should_trigger"] else "does-not-trig"
                 status = "PASS" if cr["passed"] else "FAIL"
@@ -392,7 +587,7 @@ def print_report(skill_results: list[dict], model: str, samples: int, verbose: b
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Skill trigger-fidelity harness (local only, never CI)")
+    parser = argparse.ArgumentParser(description="Skill eval harness (local only, never CI)")
     parser.add_argument(
         "--skill", action="append", dest="skills", metavar="NAME",
         help="Skill name to test (repeatable; default: all with trigger-cases.json)",
@@ -428,19 +623,38 @@ def main() -> int:
             print("No trigger-cases.json files found. Run --skill <name> or author case files first.", file=sys.stderr)
             return 1
 
-    runtime_files, skipped = partition_case_files(case_files)
-    if skipped:
-        print(format_skip_notice(skipped))
-    if not runtime_files:
-        print("No runtime-measurable skills to run.")
-        return 0
+    runtime_files, description_fidelity_files = partition_case_files(case_files)
 
-    tmp_project = build_temp_project(SKILLS_DIR, PLUGINS_DIR)
+    tmp_project: Path | None = None
+    isolated_project: Path | None = None
     try:
         skill_results = []
-        for case_file in runtime_files:
-            sr = run_skill(case_file, tmp_project, args.model, args.samples, args.workers, args.verbose)
-            skill_results.append(sr)
+
+        # runtime files first, then description-fidelity — each measured by its
+        # own substrate, both reported in one table with a `method` column.
+        if runtime_files:
+            tmp_project = build_temp_project(SKILLS_DIR, PLUGINS_DIR)
+            runtime_context = {"tmp_project": tmp_project}
+            for case_file in runtime_files:
+                skill_results.append(
+                    run_skill(case_file, runtime_context, args.model, args.samples, args.workers, args.verbose)
+                )
+
+        if description_fidelity_files:
+            isolated_project = build_isolated_project()
+            skill_listing, valid_names = assemble_skill_listing()
+            description_fidelity_context = {
+                "isolated_project": isolated_project,
+                "skill_listing": skill_listing,
+                "valid_names": valid_names,
+            }
+            for case_file in description_fidelity_files:
+                skill_results.append(
+                    run_skill(
+                        case_file, description_fidelity_context,
+                        args.model, args.samples, args.workers, args.verbose,
+                    )
+                )
 
         print_report(skill_results, args.model, args.samples, args.verbose)
 
@@ -457,7 +671,10 @@ def main() -> int:
         return 0  # always 0 — measurement, not a gate
 
     finally:
-        shutil.rmtree(tmp_project, ignore_errors=True)
+        if tmp_project is not None:
+            shutil.rmtree(tmp_project, ignore_errors=True)
+        if isolated_project is not None:
+            shutil.rmtree(isolated_project, ignore_errors=True)
 
 
 if __name__ == "__main__":

--- a/plugins/skill-review/.claude-plugin/plugin.json
+++ b/plugins/skill-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "skill-review",
   "description": "Behavioral-equivalence audit for SKILL.md changes. Gates git commit when staged changes include a SKILL.md. Install at project scope in repos that author SKILL.md files.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": {
     "name": "Cordova Strategy"
   },

--- a/plugins/skill-review/skills/skill-review/REFERENCES.md
+++ b/plugins/skill-review/skills/skill-review/REFERENCES.md
@@ -21,17 +21,17 @@ regressions. The `run_loop.py` description optimizer makes sense when
 you genuinely can't tell whether a wording change improves accuracy
 without measuring it.
 
-**Update:** trigger-fidelity evals have been adopted as a standalone local
-harness (`evals/run_trigger_evals.py`) that adapts `run_eval.py`'s
-stream-json detection mechanism. The `skill-creator` *plugin* remains
-disabled — the mechanism is adopted but the plugin's voice and length
-conventions still conflict with this repo. The key distinction: this repo's
-harness is for testing trigger *fidelity* of existing skills at local/manual
-cadence, not for optimizing descriptions via the `run_loop.py` search loop.
+**Update:** skill evals have been adopted as a standalone local harness
+(`evals/run_skill_evals.py`) that adapts `run_eval.py`'s stream-json detection
+mechanism. The `skill-creator` *plugin* remains disabled — the mechanism is
+adopted but the plugin's voice and length conventions still conflict with this
+repo. The key distinction: this repo's harness measures the trigger fidelity
+of existing skills at local/manual cadence, not optimizing descriptions via
+the `run_loop.py` search loop.
 
 The original conditions have changed: the skill set has grown to ~23 skills
 used across many independent projects, meaning mis-fires now happen in
-sessions the owner doesn't observe. `evals/run_trigger_evals.py` covers this
+sessions the owner doesn't observe. `evals/run_skill_evals.py` covers this
 without CI security risks (local auth, no `--dangerously-skip-permissions`),
 without per-token budget (Max-plan OAuth), and without flaky CI signals (the
 output is a human-read pass-rate report, not a binary gate).

--- a/plugins/skill-review/skills/skill-review/SKILL.md
+++ b/plugins/skill-review/skills/skill-review/SKILL.md
@@ -67,7 +67,7 @@ the adjacent skills whose surfaces overlap — a `claude-hook-review`
 description that doesn't list `review-permissions` under DO NOT TRIGGER
 will dual-fire on every hook-settings turn.
 
-After a `TRIGGER`-block change, run `python evals/run_trigger_evals.py --skill <name>` and confirm rates held before committing.
+After a `TRIGGER`-block change, run `python evals/run_skill_evals.py --skill <name>` and confirm rates held before committing.
 
 ## 3. Voice and structure
 


### PR DESCRIPTION
## Summary

PR B of the skill eval-harness work (follows #259). PR A split the harness `method` field into `runtime` and `description-fidelity` but only `runtime` had a runner — `test-conventions` and `test-evaluation` were skipped. This adds the `description-fidelity` runner so both advisory skills are measured.

**Harness (`evals/run_skill_evals.py`, renamed from `run_trigger_evals.py`)**
- New `description-fidelity` runner: builds one `claude -p` classification prompt per case carrying the full skill listing (name + description frontmatter from every `SKILL.md`), asks which one skill a query should match, parses the reply to a skill name, and scores it against `should_trigger` / `also_not_triggered` exactly as a runtime fire is — a reply naming a guarded adjacent skill is a violation.
- Plain question-answering is unaffected by the headless skill auto-dispatch limitation (`anthropics/claude-code#34648`) that makes `runtime` unreliable for advisory skills — re-confirmed empirically this session.
- `run_skill` / `run_case` route per case file's `method`; the report labels each skill's mode in a new column. Shared K-sampling, report, and CLI are reused across modes.
- Minimal stdlib frontmatter parser — deliberately avoids a PyYAML dependency, which CI does not install.

**Case files**
- Naturalized `test-evaluation`'s `evaluating-existing-suite-quality` query (was on-the-nose keyword-bait).
- Added reciprocal `test-conventions` ↔ `test-evaluation` adjacency cases — the write-new-tests vs evaluate-existing-tests boundary, each guarding the other via `also_not_triggered`.

**Rename fan-out**
- `run_trigger_evals.py` → `run_skill_evals.py` now that it runs both modes; all references updated (`evals/README.md`, `CONTRIBUTING.md`, `docs/skills.md`, the `skill-review` plugin `SKILL.md` + `REFERENCES.md`, the test import).
- `skill-review` plugin bumped 1.0.1 → 1.0.2 for the SKILL.md reference fix.

**Tests** — offline unit tests (no `claude -p`) for the classification-answer parser, the scorer (incl. the guarded-adjacent-skill violation path), and the frontmatter parser.

## Test plan

- [x] `pytest claude/.claude/` — 896 passed
- [x] `ruff check claude/.claude/ evals/` — clean
- [x] `python evals/run_skill_evals.py --skill code-review --skill test-conventions --samples 2` — both methods route correctly, 11/11
- [x] `python evals/run_skill_evals.py --skill test-evaluation --samples 3` — 6/6, naturalized query + new adjacency case score correctly
- [ ] Reviewer: optional full local run `python evals/run_skill_evals.py` (local-only, never CI — spawns `claude -p`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)