### PR TITLE
feat(check-runner): classify block type in BLOCKED verdicts

### DIFF
--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -27,7 +27,11 @@ Use the `Agent` tool with `subagent_type: check-runner` to run the checks (full 
 
 **The dispatch prompt must include the absolute working directory** (e.g. `Working directory: /absolute/path/to/worktree`). check-runner has no guaranteed cwd; directory-sensitive commands run from the wrong tree produce misleading failures. Do not enumerate setup or state-mutating commands in the list — db resets, migrations, container start/stop, seed scripts, package installs — perform setup yourself before dispatching.
 
-If the subagent reports a check was blocked by permissions, do NOT fall back to running it directly in the parent — that defeats the dispatch (parent context inhales the output) and silently bypasses the permission gate. Stop, surface the exact missing allow-rule (e.g. `Bash(npm run verify)`), and wait for the user to either pre-approve it in the appropriate scope's `permissions.allow` or run the command themselves.
+If the subagent reports a check was `BLOCKED`, do NOT fall back to running it directly in the parent — that defeats the dispatch (parent context inhales the output) and silently bypasses the gate that stopped it. Branch on the `block_type` the verdict carries:
+
+- `SETTINGS_DENIAL` — a missing or declined permission rule. Before recommending an allow-rule, confirm an existing rule does not already cover the command (don't propose a dead rule). Surface the exact rule needed — exact-match, not a glob (per the Safety section), e.g. `Bash(npm run verify)` — and wait for the user to pre-approve it in the appropriate scope's `permissions.allow` or run the command themselves.
+- `HOOK_BLOCK` — a PreToolUse hook blocked the call; this is not a settings gap. Diagnose from the hook's verbatim stderr in the verdict; do not add an allow-rule.
+- `UNKNOWN_BLOCK` — surface the verbatim message and ask the user; an interactive-prompt decline can land here. Do not guess a remediation.
 
 ### Codebase discovery
 

--- a/claude/.claude/agents/check-runner.md
+++ b/claude/.claude/agents/check-runner.md
@@ -31,9 +31,14 @@ Emitting the spool path before the command ensures the path is known even when t
 **Never read back the spool in a separate Bash call. Never locate a spool file with a glob or `ls` pattern.** Stale spool files from prior sessions accumulate under the same slug prefix in `${TMPDIR:-/tmp}/`; a glob matches them all and contaminates the verdict. The only spool content used in the structured verdict is what the creating call emits inline.
 
 Return a structured verdict using the inline output:
-- Per-command: name, exit code, pass/fail.
+- Per-command: name, exit code, status — one of PASS, FAIL, TIMEOUT, `BLOCKED`, or `NOT RUN — out of charter`.
 - Smallest failure excerpt for each failed command — the `tail` output from the creating call (up to ~50 lines). The subagent does not read the spool directly; if the parent needs more context, it reads the spool file.
-- Overall PASS or FAIL.
+- Overall PASS or FAIL. A `BLOCKED` command sets the overall verdict to FAIL, consistent with the out-of-charter refusal rule above.
+- For each `BLOCKED` command, a `block_type` field — exactly one of:
+  - `SETTINGS_DENIAL` — the harness reported the call denied for a missing or declined permission rule.
+  - `HOOK_BLOCK` — a PreToolUse hook blocked the call (the harness surfaced a hook's stderr alongside a block decision).
+  - `UNKNOWN_BLOCK` — blocked, but the signal matches neither marker cleanly.
+  Discriminate only on those generic markers, never on a specific hook's wording. Carry the harness/hook message verbatim alongside `block_type`: never paraphrase it, and never synthesize a `Bash(...)` allow-rule string the harness did not emit. If you cannot tell which marker applies, use `UNKNOWN_BLOCK` and quote the message as-is.
 - The spool file paths (emitted inline by the creating call).
 
 Do not interpret failures or recommend fixes — that is the parent's job.
@@ -42,6 +47,6 @@ Do not interpret failures or recommend fixes — that is the parent's job.
 
 **Secret-redaction hygiene.** Before returning failure-excerpt lines to the parent, drop any line matching obvious secret shapes (case-insensitive): `Bearer ...`, GitHub tokens (`ghp_…`/`gho_…`/`ghu_…`/`ghs_…`/`ghr_…`), Stripe keys (`sk_live_…`/`sk_test_…`), Slack (`xox[baprs]-…`), JWT prefix (`eyJ…`), AWS access keys (`AKIA[0-9A-Z]{16}`), and lines containing `*_KEY=` / `*_TOKEN=` / `*_SECRET=` / `aws_secret_access_key` / `gcp_credentials` / `azure_client_secret`. This is best-effort, not a security boundary — it keeps the most common test-runner secret echoes out of the parent transcript.
 
-**Permission denials.** If a Bash call you make is denied (the harness reports a missing allow rule at execution time), do NOT retry with a modified command shape and do NOT fall back to a different command. Stop and return a verdict listing the denied command and the harness's deny message. The parent will surface the missing allow rule to the user.
+**Permission denials.** If a Bash call you make is denied (the harness reports a missing or declined permission rule at execution time), do NOT retry with a modified command shape and do NOT fall back to a different command. Stop and return a verdict listing the command with status `BLOCKED` and `block_type: SETTINGS_DENIAL`, carrying the harness's deny message verbatim. Do not invent an allow-rule name — quote what the harness emitted. The parent decides what to surface to the user.
 
-**Hook blocks.** The same applies when a PreToolUse hook blocks a command (the harness reports the hook's stderr and a non-zero block decision): do not modify system state to make the block go away — even if the hook's own message suggests a recovery command. Stop and return a verdict listing the blocked command and the hook's block message verbatim. Let the parent decide — it has the full context to diagnose and ask the user; you do not.
+**Hook blocks.** The same applies when a PreToolUse hook blocks a command (the harness reports the hook's stderr alongside a non-zero block decision): do not modify system state to make the block go away — even if the hook's own message suggests a recovery command. Stop and return a verdict listing the command with status `BLOCKED` and `block_type: HOOK_BLOCK`, carrying the hook's block message verbatim. A hook block is not a missing permission rule — never report it as one. If the harness's signal clearly matches neither marker — no permission-rule citation, no hook stderr — use `block_type: UNKNOWN_BLOCK` and still quote the message verbatim. Let the parent decide — it has the full context to diagnose and ask the user; you do not.


### PR DESCRIPTION
## Summary

A `check-runner` subagent (running on Haiku) hit a command a PreToolUse hook blocked, and reported the block as a missing `permissions.allow` rule — the dispatching parent then recommended adding that rule to settings. Both conclusions were wrong: a hook block is not a settings-permission gap. check-runner's body already had separate "Permission denials" and "Hook blocks" prose sections, but prose alone didn't hold — Haiku collapsed the two causes into one summarized verdict.

This change replaces the summarizable prose with a structured field the agent fills, and rebalances the parent-side guidance that previously assumed every block was a permission gap.

## What shipped

**`claude/.claude/agents/check-runner.md`**
- Adds a `BLOCKED` per-command status alongside PASS / FAIL / TIMEOUT / `NOT RUN — out of charter`. A `BLOCKED` command sets the overall verdict to FAIL.
- Adds a structured `block_type` field on each `BLOCKED` command — one of `SETTINGS_DENIAL`, `HOOK_BLOCK`, or `UNKNOWN_BLOCK` — carried with the verbatim harness/hook message. Explicit anti-synthesis rule: never invent a `Bash(...)` allow-rule string; quote what the harness emitted; fall back to `UNKNOWN_BLOCK` when neither marker matches.
- The "Permission denials" and "Hook blocks" sections now map to `SETTINGS_DENIAL` and `HOOK_BLOCK` respectively. Discrimination keys only off generic, project-agnostic markers — never a specific hook's wording — keeping the globally-stowed agent platform-agnostic.

**`claude/.claude/CLAUDE.md` — "Heavy command output"**
- Rewrites the blocked-check paragraph to branch on `block_type`: `SETTINGS_DENIAL` → confirm no existing rule already covers the command before recommending an exact-match allow-rule; `HOOK_BLOCK` → not a settings gap, diagnose from the hook's stderr; `UNKNOWN_BLOCK` → surface verbatim and ask. The "do NOT fall back to running it directly in the parent" rule is retained.

## Test plan

- [ ] No executable code in the diff — markdown / agent config only; `/ready-for-review` step 2 skipped per its scope rule. `/plan-review` and `/code-review` (cumulative) both passed clean.
- [ ] Behavioral (manual, post-merge): dispatch check-runner at a hook-blocked command; confirm the verdict carries status `BLOCKED`, `block_type: HOOK_BLOCK`, and the hook's stderr quoted verbatim — not a synthesized `Bash(...)` rule. Repeat against a genuine missing-allow-rule command; confirm `SETTINGS_DENIAL`.

## Note for the reviewer

A companion change ships separately in another repo — the coordination-lock PreToolUse hook there will add a self-identifying line to its block message. It is independent; this PR does not depend on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)