### PR TITLE
docs: guide general-purpose subagent model routing under auto mode

### DIFF
--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -63,6 +63,7 @@ This does not apply to *comprehension* reads: when you need a file's content in 
 - **Opus:** judgment-heavy reasoning, plan-mode planning, and parent-dispatcher orchestration.
 - **Sonnet (default):** all code reading, code writing, and specialist reviewer agents. Enforced via `model: sonnet` frontmatter in each agent file.
 - **Haiku:** narrow, deterministic skills only. Never for code authoring or judgment.
+- **Always dispatch `general-purpose` with an explicit `model`.** It is the one routinely-dispatched built-in with no model of its own, so it inherits the parent — and a session cannot detect its own permission mode to know whether that parent is an auto-mode Opus. Default to `model: sonnet`: a no-op when the parent is already Sonnet, and it keeps delegated work off Opus when the parent is not. Pass `model: opus` only when the delegated task genuinely needs Opus-level reasoning. Do not pass `model` to the other agents — `Explore` is pinned to Haiku, and `staff-*` / `ciso-reviewer` / `check-runner` carry their own `model:` frontmatter.
 
 ## Safety
 

--- a/claude/.claude/skills/transcript-analysis/SKILL.md
+++ b/claude/.claude/skills/transcript-analysis/SKILL.md
@@ -31,7 +31,7 @@ Sequence: 0 0 5 0 0 0 3 0 0 0 0 0
 ## Caveats
 
 - The `N failed` count is a coarse proxy: it matches any `N failed` in tool output, including pre-existing failures and intentional baseline runs. Treat the sequence view as the primary read; the aggregate rate is corroborating.
-- Subagent (`isSidechain`) turns are excluded from `fail-seq` and `struggle`. Reviewer/Explore agents run on Sonnet but are not the debugging surface these subcommands measure.
+- Subagent (`isSidechain`) turns are excluded from `fail-seq` and `struggle` — reviewer, `Explore`, and `check-runner` agents are not the debugging surface these subcommands measure.
 - Durations from `duration` are wall-clock dominated by idle gaps. Look at `Active(min)`, not `Span(min)`.
 - `pr-link` requires `gh` and network access. All other subcommands are local-only and make no writes.
 - A model-vs-model comparison is only meaningful when there are multiple all-Opus and all-Sonnet execution branches. One or two branches per model is directional, not a controlled A/B.

--- a/docs/auto-mode.md
+++ b/docs/auto-mode.md
@@ -121,6 +121,45 @@ operations will route to the classifier instead of auto-approving. Narrow rules
 like `Bash(npm test)` carry over unchanged. Dropped rules are restored when you
 leave auto mode.
 
+## Subagent delegation under auto mode
+
+Auto mode anchors the session to one model for its entire lifetime — there is
+no plan-mode-to-execution model switch the way `opusplan` provides. On Max that
+anchor is Opus (the only auto-eligible session model), so every subagent that
+*inherits* the parent model runs on Opus too.
+
+Subagent model is resolved in this order — the first that applies wins:
+
+1. `CLAUDE_CODE_SUBAGENT_MODEL` environment variable (global override)
+2. The `model` parameter on the `Agent` dispatch
+3. The `model:` frontmatter in the agent's definition file
+4. The parent / main-conversation model (inherited)
+
+The routinely-dispatched built-in subagents resolve as follows:
+
+| Agent | Model under an Opus auto-mode parent | Why |
+|---|---|---|
+| `Explore` | Haiku | Pinned by Claude Code; read-only search |
+| `staff-*`, `ciso-reviewer` | Sonnet | `model: sonnet` frontmatter in `~/.claude/agents/` |
+| `check-runner` | Haiku | `model: haiku` frontmatter |
+| `general-purpose` | **Opus (inherited)** | No model of its own — falls through to the parent |
+
+So dispatching `general-purpose` for delegated execution or whole-file
+discovery from an Opus auto-mode parent runs that work on Opus — roughly 5x the
+per-token cost of Sonnet. To keep it off Opus, pass an explicit `model: sonnet`
+on the `Agent` dispatch; resolution step 2 overrides the inherited parent at
+step 4.
+
+Since a session cannot reliably tell whether it is in auto mode, treat this as
+unconditional: always dispatch `general-purpose` with an explicit `model`. See
+the Model Routing section of the global `CLAUDE.md`.
+
+Do **not** reach for `CLAUDE_CODE_SUBAGENT_MODEL` to solve this. It sits at
+resolution step 1 and overrides *every* subagent's model — including
+`check-runner`'s deliberate Haiku pin and the `staff-*` reviewers' Sonnet pin.
+The per-dispatch `model` parameter is the targeted instrument; the env var is a
+blunt global hammer.
+
 ## Inspection and tuning
 
 ```bash


### PR DESCRIPTION
## Problem

Auto mode anchors the session to a single model for its entire lifetime — there is no plan-mode-to-execution model switch the way `opusplan` provides. On Max, that anchor is Opus (the only auto-eligible session model). The `general-purpose` subagent is the one routinely-dispatched built-in with no `model:` of its own, so it falls through to the parent and runs delegated execution / whole-file discovery on Opus — roughly 5x the per-token cost of Sonnet.

A rule gated on "in auto mode" is unfollowable: a session cannot detect its own permission mode (no env var exposes it). So the fix is unconditional.

## Change

- **`claude/.claude/CLAUDE.md`** — one bullet under `## Model Routing`: always dispatch `general-purpose` with an explicit `model`, defaulting to `sonnet` (`opus` only when the delegated task needs Opus-level reasoning). Unconditional because passing `model: sonnet` is a harmless no-op when the parent is already Sonnet and the needed fix when it is Opus. Names the agents that must *not* get a `model` override (`Explore` is Haiku-pinned; `staff-*` / `ciso-reviewer` / `check-runner` carry their own frontmatter).
- **`docs/auto-mode.md`** — new "Subagent delegation under auto mode" section: the four-step subagent model resolution order, a per-built-in resolution table, and why `CLAUDE_CODE_SUBAGENT_MODEL` is the wrong instrument (it overrides every subagent, including the deliberate pins).
- **`claude/.claude/skills/transcript-analysis/SKILL.md`** — one-line correction in the Caveats section: the `fail-seq`/`struggle` caveat claimed reviewer and Explore subagents run on Sonnet; Explore runs on Haiku. Dropped the non-load-bearing model attribution and listed the excluded agent types (reviewer, `Explore`, `check-runner`) accurately.

## Verification

All factual claims in the doc table were checked:
- `staff-*` / `ciso-reviewer` → `sonnet`, `check-runner` → `haiku` — confirmed against `claude/.claude/agents/*.md` frontmatter.
- `Explore` → Haiku — confirmed empirically against three `agentType: "Explore"` subagent transcripts, all `claude-haiku-4-5-20251001`.
- The per-dispatch `model` param overriding auto-mode parent inheritance, and the auto-mode classifier covering subagent Bash calls, were verified in earlier standalone test sessions.

## Out of scope

- `/plan-it` and `/plan-review` dispatch `general-purpose` internally and would run it on Opus under an auto-mode session — a larger skill-body change, not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)