### PR TITLE
feat(hooks): detect git/gh commands past global flags in redaction gate

### DIFF
--- a/claude/.claude/hooks/deny-private-project-refs.sh
+++ b/claude/.claude/hooks/deny-private-project-refs.sh
@@ -7,13 +7,15 @@
 # repo-root CLAUDE.md redaction rule ("Redact private-project-
 # identifying content").
 #
-# NOTE — `if`-dispatch is advisory; the real gate is the internal regex
-# at the top of this script. settings.json wires `if` entries
-# (`Bash(git commit *)`, `Bash(gh pr create *)`, `Bash(gh pr edit *)`,
-# `Bash(gh api *)`) for zero-cost early dispatch, but any drift between
-# those patterns and the IS_GIT_COMMIT / IS_GH_PR / IS_GH_API regexes
-# here creates silent coverage gaps. Update both surfaces when extending
-# coverage.
+# Dispatch: wired on the PreToolUse `Bash` matcher with NO `if`-condition,
+# so it runs for every Bash tool call and filters internally. A narrowing
+# `if: "Bash(git commit *)"` would let ordinary, executable forms such as
+# `git -c key=val commit` and `git -C <path> commit` slip past the early
+# dispatch unscanned. Command detection word-walks each shell fragment
+# (split on `&&`/`;`/`|`/`$()`/backticks) past global git flags, env-var
+# prefixes, and gh subcommand flags written ahead of the subcommand, then
+# exits immediately — before any git or scan work — when no gated surface
+# (git commit / gh pr create|edit / mutating gh api) is present.
 #
 # Scope and limits:
 # - Catches the mechanical category (tracker IDs shaped like [A-Z]{2,}-\d+).
@@ -61,8 +63,23 @@
 #   that `--fill` then republishes.
 # - `gh pr create --body "$(cat file)"` or backtick command substitution
 #   inside --body/--title hides the actual content behind shell
-#   expansion the hook doesn't execute. Static regex match sees only
-#   the literal `$(...)` string.
+#   expansion the hook doesn't execute. The content scan sees only the
+#   literal `$(...)` string.
+# - Wrapper forms that evaluate the real command behind a nested shell
+#   boundary — `eval "git commit ..."`, `xargs git commit`,
+#   `sh -c 'git commit ...'`. The command word lives inside a quoted
+#   string the hook does not execute; same unscannable class as the
+#   `$(...)` body case above.
+# - A backslash-escaped `\git` invocation (used to bypass a shell alias)
+#   is not recognized as a git command: fragment detection matches a
+#   word equal to `git` or ending in `/git`, and `\git` is neither.
+#   Closing this belongs in a _lib.sh change — the word test is shared
+#   code used by several hooks.
+# - `git -C <path> commit` aimed at a *different* repository is still
+#   detected as a commit, but the staged-diff scan runs against the
+#   session's current repository, not the `-C` target. `-C` into a
+#   subdirectory of the same repo is unaffected (scan pathspecs are
+#   repo-root-relative).
 # - `gh api graphql` is a separate surface from the REST `gh api
 #   <path>` calls covered above. A tracker-ID literal in `-f query=`
 #   / `-F variables=` / `--input` is still caught by the same flag-
@@ -125,10 +142,6 @@
 
 set -uo pipefail
 
-INPUT=$(cat)
-COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
-JQ_EXIT=$?
-
 emit_deny() {
   local reason="$1"
   local reason_json
@@ -137,56 +150,126 @@ emit_deny() {
     "$reason_json"
 }
 
+# emit_deny is defined before sourcing _lib.sh so a missing _lib.sh can
+# still deny rather than silently allow.
+if ! . "$(dirname "$0")/_lib.sh" 2>/dev/null; then
+  emit_deny "Blocked by redaction gate: could not source _lib.sh — hook cannot evaluate command detection safely."
+  exit 0
+fi
+
+INPUT=$(cat)
+TOOL_NAME=$(printf '%s\n' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+JQ_EXIT=$?
+
 # Fail-closed on malformed input. Matches the posture of
 # require-worktree-for-git-writes.sh: if we can't parse stdin, we can't
-# tell what's about to run, so deny rather than silently allow.
+# tell what's about to run, so deny rather than silently allow. JQ_EXIT
+# is captured from the .tool_input.command extraction deliberately: jq
+# parses the whole document, and that filter additionally surfaces a
+# type error when .tool_input is not an object — so a zero exit here
+# means both extractions ran against well-formed JSON.
 if [ "$JQ_EXIT" -ne 0 ]; then
   emit_deny "Blocked by redaction gate: could not parse tool-input JSON. Refusing to evaluate redaction under malformed input."
   exit 0
 fi
 
-# Identify which gated surface (if any) the command touches. A single
-# chained command can touch multiple
-# (`git commit ... && gh pr create ...`,
-# `gh pr edit ... && gh api ... -X POST`), in which case all matching
-# scan paths run.
+# Defense-in-depth: only act on Bash calls. settings.json already matches
+# the Bash tool, but the hook does not rely on that alone (see repo
+# CLAUDE.md, "Hook defense-in-depth").
+if [ "$TOOL_NAME" != "Bash" ]; then
+  exit 0
+fi
+
+# Word-walk a single shell fragment and report which gated `gh` surface it
+# invokes: `pr` for `gh pr create` / `gh pr edit`, `api` for `gh api`, and
+# empty for everything else (non-gh fragments and non-gated gh subcommands
+# such as `gh pr comment`). The `gh` word test (`gh` or `*/gh`) mirrors
+# _lib_fragment_invokes_git, so absolute paths and env-var prefixes are
+# seen through.
+#
+# gh's root command has no value-taking global flags (only `--help` /
+# `--version`), but cobra still lets a subcommand's own flags be written
+# *before* the subcommand — `gh -X POST api ...` and `gh --repo o/r pr
+# create ...` both parse. So the walk cannot assume the first bare word
+# after `gh` is the subcommand. Instead it keys on the command path:
+#   - `pr` surface: a word `pr` immediately followed by `create` / `edit`.
+#     A two-word command path is always contiguous (cobra resolves it as a
+#     unit); hoisted flags land before `pr` or after `create`/`edit`, never
+#     between them.
+#   - `api` surface: any word `api` after `gh`. A bare `api` that is really
+#     a flag value rather than the subcommand is harmless — the caller's
+#     body-flag check still has to pass before IS_GH_API is set.
+# Globbing is disabled so wildcards in the command text do not expand.
+# Trailing non-[alnum/_/-] is stripped from each word (fragment splitting
+# can leave `create)` from a paren group).
+fragment_gh_gated_surface() {
+  local fragment="$1"
+  local saved_opts=$-
+  set -f
+  local past_gh=false prev="" word stripped surface=""
+  for word in $fragment; do
+    if ! $past_gh; then
+      case "$word" in
+        gh|*/gh) past_gh=true ;;
+      esac
+      continue
+    fi
+    stripped="${word%%[^a-zA-Z0-9_-]*}"
+    case "$stripped" in
+      create|edit) if [ "$prev" = "pr" ]; then surface="pr"; break; fi ;;
+      api) surface="api"; break ;;
+    esac
+    prev="$stripped"
+  done
+  if [[ "$saved_opts" != *f* ]]; then set +f; fi
+  printf '%s' "$surface"
+}
+
+# Identify which gated surface(s) the command touches. A single chained
+# command can touch several (`git commit ... && gh pr create ...`,
+# `gh pr edit ... && gh api ... -X POST`); every matching scan path runs.
+# Detection word-walks each shell fragment so global git flags (`-c`,
+# `-C`, `--git-dir`, ...), gh subcommand flags written ahead of the
+# subcommand, env-var prefixes, absolute paths, and
+# `&&`/`;`/`|`/`$()`/backtick chains cannot hide the command word.
 IS_GIT_COMMIT=0
 IS_GH_PR=0
 IS_GH_API=0
-if printf '%s\n' "$COMMAND" | grep -qE '(^|&&?|;|\|\|?)\s*git\s+commit(\s|$)'; then
-  IS_GIT_COMMIT=1
-fi
-if printf '%s\n' "$COMMAND" | grep -qE '(^|&&?|;|\|\|?)\s*gh\s+pr\s+(create|edit)(\s|$)'; then
-  IS_GH_PR=1
-fi
-# `gh api` defaults to GET, but auto-promotes to POST whenever any
-# request-body flag is supplied. Per gh's docs: "adding request
-# parameters will automatically switch the request method to POST."
-# So a call worth scanning is any of:
-#  - explicit `-X` / `--method` POST/PATCH/PUT/DELETE (`-X POST`, `-X=POST`,
-#    `--method POST`, `--method=POST`, and the bare `-XPOST` short-flag
-#    concatenation gh accepts)
-#  - any `-f` / `-F` / `--field` / `--raw-field` / `--input` flag (each
-#    of which auto-POSTs even with no `-X`)
-# Gate dispatch on flags, not on the endpoint shape — endpoint
-# allowlisting is fragile and the next leak path could be a new
-# endpoint. `[^A-Za-z]` is used as the trailing method boundary
-# instead of `\b` for grep-portability and style consistency with the
-# `(\s|$)` end-anchors on the IS_GIT_COMMIT and IS_GH_PR regexes.
-# Note: the body-flag check is global to the command string, not
-# scoped to the gh api segment of a chained command — a `-X POST`
-# elsewhere in the chain would also dispatch the gh api branch. This
-# is intentionally fail-toward-scan; a false positive on dispatch
-# costs one redundant scan, a false negative ships a leak.
-if printf '%s\n' "$COMMAND" | grep -qE '(^|&&?|;|\|\|?)\s*gh\s+api(\s|$)'; then
-  if printf '%s\n' "$COMMAND" \
-      | grep -qiE '((-X|--method)(=|[[:space:]]+)|-X)(POST|PATCH|PUT|DELETE)([^A-Za-z]|$)'; then
-    IS_GH_API=1
-  elif printf '%s\n' "$COMMAND" \
-      | grep -qE '(^|[[:space:]])(-f|-F|--field|--raw-field|--input)(=|[[:space:]]+)'; then
-    IS_GH_API=1
+while IFS= read -r fragment; do
+  [ -z "$fragment" ] && continue
+  if _lib_fragment_invokes_git "$fragment" \
+      && [ "$(_lib_extract_git_subcmd "$fragment")" = "commit" ]; then
+    IS_GIT_COMMIT=1
   fi
-fi
+  case "$(fragment_gh_gated_surface "$fragment")" in
+    pr)
+      IS_GH_PR=1
+      ;;
+    api)
+      # `gh api` defaults to GET but auto-promotes to POST whenever any
+      # request-body flag is supplied (per gh docs: "adding request
+      # parameters will automatically switch the request method to
+      # POST"). Scan only a body-bearing call: explicit `-X` / `--method`
+      # POST/PATCH/PUT/DELETE (`-X POST`, `-X=POST`, `--method POST`,
+      # `--method=POST`, bare `-XPOST`), or any `-f` / `-F` / `--field` /
+      # `--raw-field` / `--input` flag. Dispatch keys on flags, not the
+      # endpoint path — endpoint allowlisting is fragile, and the next
+      # leak path could be a new endpoint. The flag check is global to the
+      # command string, not scoped to the gh-api fragment — intentionally
+      # fail-toward-scan: a false positive costs one redundant scan, a
+      # false negative ships a leak. `[^A-Za-z]` is the trailing method
+      # boundary (grep-portable substitute for `\b`).
+      if printf '%s\n' "$COMMAND" \
+          | grep -qiE '((-X|--method)(=|[[:space:]]+)|-X)(POST|PATCH|PUT|DELETE)([^A-Za-z]|$)'; then
+        IS_GH_API=1
+      elif printf '%s\n' "$COMMAND" \
+          | grep -qE '(^|[[:space:]])(-f|-F|--field|--raw-field|--input)(=|[[:space:]]+)'; then
+        IS_GH_API=1
+      fi
+      ;;
+  esac
+done <<< "$(_lib_split_fragments "$COMMAND")"
 
 if [ "$IS_GIT_COMMIT" -eq 0 ] && [ "$IS_GH_PR" -eq 0 ] && [ "$IS_GH_API" -eq 0 ]; then
   exit 0

--- a/claude/.claude/hooks/tests/test_deny_private_project_refs.py
+++ b/claude/.claude/hooks/tests/test_deny_private_project_refs.py
@@ -1953,3 +1953,155 @@ class TestDenyPrivateProjectRefs:
         assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
         reason = payload["hookSpecificOutput"]["permissionDecisionReason"]
         assert "Tip: this command chains" not in reason
+
+    # -- Command-detection evasion resistance ------------------------------
+    # Surface detection word-walks shell fragments instead of matching
+    # `git commit` / `gh pr` as a literal substring, so a global git flag,
+    # an env-var prefix, an absolute path, or a `$()` wrapper between the
+    # command word and its subcommand cannot hide a gated call. Mirrors
+    # test_deny_pii_in_commits.py's git-flag detection cases.
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "git -c user.name=ci commit -m 'Fix WIDGET-123'",
+            "git -C /tmp commit -m 'Fix WIDGET-123'",
+            "git --git-dir=/tmp/g --work-tree=/tmp/w commit -m 'Fix WIDGET-123'",
+            "GIT_DIR=/tmp/g git commit -m 'Fix WIDGET-123'",
+        ],
+        ids=["c-config-flag", "C-path-flag", "git-dir-equals-flag", "env-var-prefix"],
+    )
+    def test_git_commit_flag_evasion_forms_denied(self, claude_config_repo, command):
+        """A commit with a global flag or env-var prefix between `git` and
+        `commit` must still be detected and its message scanned. Detection
+        keys on the command shape; for the `-C` form the staged-diff scan
+        still targets the session repo, not the `-C` path (a documented
+        known gap), so these cases deny on the message token alone."""
+        assert run_hook(DENY_PRIVATE_PROJECT_REFS_HOOK, bash_input(command), cwd=claude_config_repo) == "deny"
+
+    def test_git_commit_config_flag_clean_message_allowed(self, claude_config_repo):
+        """A `git -c` commit with a clean message is not falsely flagged —
+        the regex-to-word-walk swap preserves the allow path."""
+        assert (
+            run_hook(
+                DENY_PRIVATE_PROJECT_REFS_HOOK,
+                bash_input("git -c core.pager=cat commit -m 'Refactor the parser'"),
+                cwd=claude_config_repo,
+            )
+            == "allow"
+        )
+
+    def test_git_non_commit_subcommand_with_flag_and_token_allowed(self, claude_config_repo):
+        """A non-commit git subcommand carrying a tracker-shaped token is
+        not gated — the word-walk extracts the real subcommand (`log`),
+        not `commit`, so a global flag cannot cause a false dispatch."""
+        assert (
+            run_hook(
+                DENY_PRIVATE_PROJECT_REFS_HOOK,
+                bash_input("git -c core.pager=cat log --grep WIDGET-123"),
+                cwd=claude_config_repo,
+            )
+            == "allow"
+        )
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "GH_TOKEN=ci gh pr create --body 'Fixes WIDGET-123'",
+            "/usr/bin/gh pr edit 1 --body 'Fixes WIDGET-123'",
+            "OUT=$(gh pr create --body 'Fixes WIDGET-123')",
+            "OUT=`gh pr create --body 'Fixes WIDGET-123'`",
+        ],
+        ids=["env-var-prefix", "absolute-path", "command-substitution", "backtick-substitution"],
+    )
+    def test_gh_pr_evasion_forms_denied(self, claude_config_repo, command):
+        """gh pr forms with an env-var prefix, an absolute path, or wrapped
+        in `$()` / backticks must still dispatch the PR-body scan. `$()` and
+        backticks are separate fragment-split branches in _lib_split_fragments,
+        so both are exercised."""
+        assert run_hook(DENY_PRIVATE_PROJECT_REFS_HOOK, bash_input(command), cwd=claude_config_repo) == "deny"
+
+    def test_gh_api_command_substitution_form_denied(self, claude_config_repo):
+        """A mutating `gh api` call wrapped in `$()` is split into its own
+        fragment and detected — the literal regex over the whole command
+        string would not have matched the `gh api` inside `$()`."""
+        command = "OUT=$(gh api repos/x/y/issues/1/comments -X POST -f body='Fixes WIDGET-123')"
+        assert run_hook(DENY_PRIVATE_PROJECT_REFS_HOOK, bash_input(command), cwd=claude_config_repo) == "deny"
+
+    def test_gh_non_gated_subcommand_with_env_prefix_allowed(self, claude_config_repo):
+        """An env-var-prefixed non-gated gh subcommand (`gh pr comment`)
+        carrying a tracker token is not gated — fragment_gh_gated_surface
+        keys on the command path (`pr` followed by `create`/`edit`), so
+        `pr comment` resolves to no gated surface."""
+        assert (
+            run_hook(
+                DENY_PRIVATE_PROJECT_REFS_HOOK,
+                bash_input("GH_TOKEN=ci gh pr comment 1 --body 'has WIDGET-123'"),
+                cwd=claude_config_repo,
+            )
+            == "allow"
+        )
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "gh -X POST api repos/x/y/issues/1/comments -f body='Fixes WIDGET-123'",
+            "gh --method POST api repos/x/y/issues/1/comments -f body='Fixes WIDGET-123'",
+        ],
+        ids=["method-short-flag-before-api", "method-long-flag-before-api"],
+    )
+    def test_gh_api_flag_before_subcommand_denied(self, claude_config_repo, command):
+        """cobra lets `gh api`'s own flags be written before the `api`
+        subcommand word. A mutating `gh api` whose `-X` / `--method`
+        precedes `api` must still dispatch the body scan — detection keys
+        on the `api` command word, not on `gh` being adjacent to it."""
+        assert run_hook(DENY_PRIVATE_PROJECT_REFS_HOOK, bash_input(command), cwd=claude_config_repo) == "deny"
+
+    def test_gh_pr_flag_before_subcommand_denied(self, claude_config_repo):
+        """`gh pr create` accepts `--repo` written before the `pr create`
+        command path. A PR-body tracker token must still be detected — the
+        `pr`/`create` pair stays contiguous, so adjacency detection holds."""
+        assert (
+            run_hook(
+                DENY_PRIVATE_PROJECT_REFS_HOOK,
+                bash_input("gh --repo owner/repo pr create --body 'Fixes WIDGET-123'"),
+                cwd=claude_config_repo,
+            )
+            == "deny"
+        )
+
+    def test_gh_non_gated_subcommand_mentioning_pr_allowed(self, claude_config_repo):
+        """A non-gated gh subcommand whose argument text merely contains the
+        word `pr` (here `gh issue create`, with `pr` in the title) is not
+        falsely gated — `gh pr` detection requires `pr` immediately followed
+        by `create`/`edit`, and here `create` precedes the stray `pr`."""
+        assert (
+            run_hook(
+                DENY_PRIVATE_PROJECT_REFS_HOOK,
+                bash_input("gh issue create --title 'open a pr' --body 'tracking WIDGET-123'"),
+                cwd=claude_config_repo,
+            )
+            == "allow"
+        )
+
+    def test_missing_lib_sh_fails_closed(self, claude_config_repo, tmp_path):
+        """Command detection depends on _lib.sh. If the hook cannot source
+        it, it must deny (fail-closed), not exit 0 — a broken _lib.sh must
+        not silently turn the redaction gate into a no-op. Exercised by
+        running a copy of the hook from a directory with no _lib.sh
+        alongside it, so `. "$(dirname "$0")/_lib.sh"` fails."""
+        isolated_hook = tmp_path / "deny-private-project-refs.sh"
+        isolated_hook.write_bytes(DENY_PRIVATE_PROJECT_REFS_HOOK.read_bytes())
+        isolated_hook.chmod(0o755)
+        result = subprocess.run(
+            [str(isolated_hook)],
+            input=json.dumps(bash_input("git commit -m 'Fix WIDGET-123'")),
+            capture_output=True,
+            text=True,
+            cwd=claude_config_repo,
+            check=False,
+        )
+        assert result.stdout.strip(), "expected a deny verdict when _lib.sh is unsourceable"
+        payload = json.loads(result.stdout)
+        assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
+        assert "_lib.sh" in payload["hookSpecificOutput"]["permissionDecisionReason"]

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -97,25 +97,6 @@
           {
             "type": "command",
             "command": "~/.claude/hooks/deny-private-project-refs.sh",
-            "if": "Bash(git commit *)",
-            "statusMessage": "Scanning for private-project refs..."
-          },
-          {
-            "type": "command",
-            "command": "~/.claude/hooks/deny-private-project-refs.sh",
-            "if": "Bash(gh pr create *)",
-            "statusMessage": "Scanning for private-project refs..."
-          },
-          {
-            "type": "command",
-            "command": "~/.claude/hooks/deny-private-project-refs.sh",
-            "if": "Bash(gh pr edit *)",
-            "statusMessage": "Scanning for private-project refs..."
-          },
-          {
-            "type": "command",
-            "command": "~/.claude/hooks/deny-private-project-refs.sh",
-            "if": "Bash(gh api *)",
             "statusMessage": "Scanning for private-project refs..."
           },
           {


### PR DESCRIPTION
## What

Harden `deny-private-project-refs.sh` — the redaction gate that blocks
private-project tracker IDs from reaching this public repo — so evasive
`git commit` / `gh pr` / `gh api` invocations can no longer slip past it.

Regex command-detection is replaced with word-walking fragment detection:
the gate now sees through `git -c` / `-C` / `--git-dir`, env-var prefixes,
absolute paths, and `$()` / backtick command chains. The four `if`-gated
`settings.json` hook entries collapse into one unconditional entry, so the
hook fires on every Bash call and filters internally — closing the gap
where `if: "Bash(git commit *)"` never even dispatched on `git -c … commit`.

## gh detection

`fragment_gh_gated_surface` keys on the contiguous command path — `pr`
immediately followed by `create` / `edit`, or the `api` word. cobra lets a
subcommand's own flags be written ahead of the subcommand
(`gh -X POST api …`, `gh --repo owner/repo pr create …` both parse), so the
walk cannot assume the first bare word after `gh` is the subcommand. This
evasion form was surfaced by the code-review security pass and is closed
here, not left as a known gap.

## Tests

New evasion-resistance cases in `test_deny_private_project_refs.py`: deny
paths for every evasion form (global flag prefixes, env-var prefixes,
absolute paths, `$()` / backtick chains, gh flags-before-subcommand), allow
paths confirming the regex→word-walk swap is behavior-preserving, and a
fail-closed test for an unsourceable `_lib.sh`. Full suite: 993 passing,
lint clean.

## Review

`/plan-review` and `/code-review` complete; `claude-hook-review` plus
ciso-reviewer, staff-sdet, and staff-platform-engineer consulted on the
hook's security boundary and operational footprint.

## Known gaps (documented in the hook header, not closed here)

Shell-evaluation-boundary wrappers (`eval`, `xargs`, `sh -c`, `$()` body
content) and `\git` alias-escape remain documented known gaps — closing the
latter belongs in a separate `_lib.sh` PR, since that word test is shared
by several hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
