### PR TITLE
fix(marker): resolve live Claude PID from ancestor walk

### DIFF
--- a/claude/.claude/hooks/tests/test_marker_script.py
+++ b/claude/.claude/hooks/tests/test_marker_script.py
@@ -24,9 +24,10 @@ class TestMarkerScriptSessionMissing:
     """When the session file ($HOME/.claude/sessions/$PPID) does not exist,
     every write/activate/deactivate subcommand must exit 2 and write nothing.
     This guards against the silent-empty-suffix regression: without explicit
-    || exit 2 on the command-substitution call sites, exit 2 inside
-    _resolve_session_id() only exits the subshell — the parent continues and
-    writes a malformed marker with an empty session-id suffix."""
+    || exit 2 on the command-substitution call sites, the return 2 inside
+    _resolve_session_id() only sets the subshell exit status — the parent
+    continues and writes a malformed marker with an empty session-id
+    suffix."""
 
     @pytest.mark.parametrize(
         "args",
@@ -306,3 +307,51 @@ class TestMarkerScriptEmptyStagedGuard:
         assert result.returncode == 0, result.stderr
         marker_dir = isolated_home / ".claude" / "skill-review-markers"
         assert len(list(marker_dir.iterdir())) == 1
+
+
+class TestMarkerScriptStalePidLookup:
+    """Regression guard: `activate` must stamp the live Claude PID into the
+    active-bypass marker even when ~/.claude/sessions/ holds stale entries
+    from prior (crashed) sessions. The PID is resolved from the process
+    ancestor walk, not by content-scanning the sessions directory, so stale
+    files cannot mislead it."""
+
+    def _seed_session(self, home, sid="test-session-stale"):
+        sessions_dir = home / ".claude" / "sessions"
+        sessions_dir.mkdir(parents=True, exist_ok=True)
+        (sessions_dir / str(os.getpid())).write_text(sid)
+        return sid, sessions_dir
+
+    def test_activate_ignores_stale_session_entry(self, isolated_home, git_repo):
+        """A stale sessions/ entry whose filename sorts lexically before the
+        live PID — what the old reverse-lookup directory scan would have
+        picked first — must not end up in the active marker."""
+        sid, sessions_dir = self._seed_session(isolated_home)
+        # Leading-zero filename: capture-session-id.sh only ever writes bare
+        # PIDs, so a "0"-prefixed name is never a real entry, and it sorts
+        # lexically before every str(os.getpid()) (which never starts with
+        # "0"). The pre-fix directory scan would have stamped this into the
+        # marker; the ancestor walk never reads it.
+        stale = sessions_dir / "08888888"
+        stale.write_text(sid)
+        result = _run(["activate", "plan-review"], cwd=git_repo, home=isolated_home)
+        assert result.returncode == 0, result.stderr
+        active_file = isolated_home / ".claude" / ".plan-review-active.d" / sid
+        assert active_file.exists()
+        content = active_file.read_text().strip()
+        assert content == str(os.getpid()), (
+            f"activate must stamp the live ancestor PID, not the stale "
+            f"sessions entry; got {content!r}"
+        )
+
+    def test_write_arm_still_resolves_session_id(self, isolated_home, git_repo):
+        """The refactored _resolve_session_id keeps its signature: a `write`
+        arm (which needs only the session id) resolves and writes its
+        marker with the correct session-id suffix."""
+        sid, _ = self._seed_session(isolated_home)
+        result = _run(["write", "code-review"], cwd=git_repo, home=isolated_home)
+        assert result.returncode == 0, result.stderr
+        marker_dir = isolated_home / ".claude" / "review-markers"
+        files = list(marker_dir.iterdir())
+        assert len(files) == 1
+        assert files[0].name.endswith(f".{sid}")

--- a/claude/.claude/scripts/marker.sh
+++ b/claude/.claude/scripts/marker.sh
@@ -27,42 +27,43 @@ Valid (subcommand, skill) combinations:
 EOF
 }
 
-_resolve_session_id() {
+_walk_session() {
   local sid pid
   # Walk up the process ancestor chain looking for a session file. Direct
   # invocation resolves in one step ($PPID = Claude Code PID). Script
   # invocation from the Bash tool resolves in two steps ($PPID = Bash tool
   # shell, grandparent = Claude Code PID). The loop handles any depth.
+  # On the first ancestor with a readable session file, print
+  # "<session_id> <pid>": that $pid is the live Claude main-process PID,
+  # since the walk reached it as a process ancestor of this script.
   pid=$PPID
   while [ -n "$pid" ] && [ "$pid" != "0" ] && [ "$pid" != "1" ]; do
     sid=$(cat "$HOME/.claude/sessions/$pid" 2>/dev/null)
     if [ -n "$sid" ]; then
-      printf '%s' "$sid"
+      printf '%s %s' "$sid" "$pid"
       return 0
     fi
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' \t')
   done
   printf 'marker.sh: SESSION_ID empty — capture-session-id.sh SessionStart hook did not run. Abort without writing a marker.\n' >&2
-  exit 2
+  return 2
 }
 
-_resolve_claude_pid_for_session() {
-  # Reverse-lookup: find the PID whose sessions file contains SESSION_ID.
-  # Returns the PID string, or "unknown" on failure (fails closed at hook time).
-  local session_id="$1"
-  local sessions_dir="$HOME/.claude/sessions"
-  local claude_pid=""
-  if [ -d "$sessions_dir" ]; then
-    local f
-    for f in "$sessions_dir"/*; do
-      [ -f "$f" ] || continue
-      if [ "$(cat "$f" 2>/dev/null)" = "$session_id" ]; then
-        claude_pid=$(basename "$f")
-        break
-      fi
-    done
-  fi
-  printf '%s' "${claude_pid:-unknown}"
+_resolve_session_id() {
+  local out
+  out=$(_walk_session) || return 2
+  printf '%s' "${out%% *}"
+}
+
+_resolve_claude_pid() {
+  # The live Claude main-process PID for this session — the ancestor whose
+  # session file the walk matched. Written into the active-bypass marker so
+  # require-*.sh hooks can liveness-check it with kill -0. Resolving it from
+  # the ancestor walk (not by content-scanning ~/.claude/sessions/) keeps it
+  # immune to stale per-session files left behind after a crash.
+  local out
+  out=$(_walk_session) || return 2
+  printf '%s' "${out##* }"
 }
 
 _resolve_repo_hash() {
@@ -162,25 +163,25 @@ case "$SUBCOMMAND" in
     case "$SKILL" in
       plan-review)
         SESSION_ID=$(_resolve_session_id) || exit 2
-        CLAUDE_PID=$(_resolve_claude_pid_for_session "$SESSION_ID")
+        CLAUDE_PID=$(_resolve_claude_pid) || exit 2
         mkdir -p "$HOME/.claude/.plan-review-active.d"
         printf '%s\n' "$CLAUDE_PID" > "$HOME/.claude/.plan-review-active.d/$SESSION_ID"
         ;;
       ready-for-review)
         SESSION_ID=$(_resolve_session_id) || exit 2
-        CLAUDE_PID=$(_resolve_claude_pid_for_session "$SESSION_ID")
+        CLAUDE_PID=$(_resolve_claude_pid) || exit 2
         mkdir -p "$HOME/.claude/.ready-for-review-active.d"
         printf '%s\n' "$CLAUDE_PID" > "$HOME/.claude/.ready-for-review-active.d/$SESSION_ID"
         ;;
       respond-pr)
         SESSION_ID=$(_resolve_session_id) || exit 2
-        CLAUDE_PID=$(_resolve_claude_pid_for_session "$SESSION_ID")
+        CLAUDE_PID=$(_resolve_claude_pid) || exit 2
         mkdir -p "$HOME/.claude/.respond-pr-active.d"
         printf '%s\n' "$CLAUDE_PID" > "$HOME/.claude/.respond-pr-active.d/$SESSION_ID"
         ;;
       memory-skill)
         SESSION_ID=$(_resolve_session_id) || exit 2
-        CLAUDE_PID=$(_resolve_claude_pid_for_session "$SESSION_ID")
+        CLAUDE_PID=$(_resolve_claude_pid) || exit 2
         mkdir -p "$HOME/.claude/.memory-skill-active.d"
         printf '%s\n' "$CLAUDE_PID" > "$HOME/.claude/.memory-skill-active.d/$SESSION_ID"
         ;;

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -82,3 +82,5 @@ If a skill's active-bypass gate refuses to release after the skill has finished,
 ~/.claude/scripts/marker.sh clear-stale          # evict dead-PID entries
 ~/.claude/scripts/marker.sh clear-stale --dry-run # report without removing
 ```
+
+`activate` resolves the live PID from the process ancestor tree, so a stale `~/.claude/sessions/` entry left by a crashed or restarted session cannot be stamped into a freshly written marker. `clear-stale` remains the tool for markers left behind by sessions that ended without `deactivate`.


### PR DESCRIPTION
## Problem

`marker.sh activate` resolved the Claude PID stamped into the active-bypass
marker by content-scanning `~/.claude/sessions/` for the file whose contents
matched `SESSION_ID` (`_resolve_claude_pid_for_session`). A crashed or
restarted session can leave a stale per-session file behind; the directory
scan could match the stale file first and stamp a **dead PID** into a freshly
written marker. A dead PID defeats the `kill -0` liveness check that
`require-*.sh` hooks and `clear-stale` rely on.

## Fix

Resolve the PID from the process ancestor walk that already runs to resolve
the session id — the walk reaches the live Claude main process *as a process
ancestor* of the script, so a stale `sessions/` file can no longer be matched
by content.

- `_walk_session` now prints `"<session_id> <pid>"` and `return`s 2 on failure
  (rather than `exit`ing) so command-substitution call sites guard with `|| exit 2`.
- Two thin resolvers — `_resolve_session_id`, `_resolve_claude_pid` — extract
  each field. `_resolve_session_id` keeps its original signature for the
  non-`activate` subcommands that need only the session id.
- `_resolve_claude_pid_for_session` (the reverse directory scan) is deleted.

## Tests

- `TestMarkerScriptStalePidLookup` — `activate` ignores a stale `sessions/`
  entry that sorts lexically before the live PID (what the old scan would have
  picked first); `write` arm still resolves the session id correctly.
- `TestMarkerScriptSessionMissing` docstring updated for `return`-vs-`exit`
  wording.

`pytest claude/.claude/` → 978 passed; `ruff check claude/.claude/` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)