### PR TITLE
docs: correct auto-mode subagent table heading

### DIFF
--- a/docs/auto-mode.md
+++ b/docs/auto-mode.md
@@ -135,7 +135,8 @@ Subagent model is resolved in this order — the first that applies wins:
 3. The `model:` frontmatter in the agent's definition file
 4. The parent / main-conversation model (inherited)
 
-The routinely-dispatched built-in subagents resolve as follows:
+The routinely-dispatched built-in and repo-shipped subagents resolve as
+follows:
 
 | Agent | Model under an Opus auto-mode parent | Why |
 |---|---|---|


### PR DESCRIPTION
## Summary

Follow-up #1 from the `code-writer` PR review (`/tmp/code-writer-followups.md`).

The table under "Subagent delegation under auto mode" in `docs/auto-mode.md`
was introduced by *"The routinely-dispatched built-in subagents resolve as
follows:"* — but the table lists custom, repo-shipped agents (`staff-*`,
`ciso-reviewer`) alongside the genuinely built-in `Explore` and
`general-purpose`. Reworded the intro to *"...built-in and repo-shipped
subagents..."*.

Pre-existing mismatch — predates the `code-writer` PR; left out of that PR's
scope to avoid scope creep.

## Test plan

Doc-only copy fix; no behavioral change. No tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)