### PR TITLE
docs: add property-based delegation test to global CLAUDE.md

### DIFF
--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -21,6 +21,21 @@
 - Use descriptive variable and function names. No generic names.
 - When a session crosses ~60% context usage (visible via statusline `.context_window.used_percentage`) AND the current task is incomplete, proactively suggest the user run `/handoff`. Do not run it yourself — it's a user-invoked slash command. If the user agrees, the command writes `/tmp/<slug>-handoff.md` and provides the resume incantation. Run `analyze-context` if unsure about the threshold. (See README's "Threshold reference" section for the why-60%.)
 
+### Delegation: hold conclusions, not transcripts
+
+The parent session's context is the expensive resource — it is re-read on every turn, for the rest of the session, so verbose tool output left there is paid for again and again. Treat a subagent as a function call: the parent keeps the *return value*, not the callee's stack. Before running a `Bash` command — or starting a sequence of them — toward a question, apply two tests:
+
+- **Output test:** will my reasoning consume this command's *output*, or only a *conclusion drawn from it*? Conclusion-only ⇒ the output is scratch.
+- **Judgment test:** does choosing this command, and the next one after seeing its result, need parent-grade judgment? If a cheaper model could run the loop, it should.
+
+Both pointing to delegate ⇒ dispatch the **objective** — not the individual command — to a subagent: "find out X; report findings." The subagent runs the whole probe loop in its own context; the parent gets back the findings. The two subsections below name the right subagent for two common objectives — `check-runner` for check suites, `Explore`/`general-purpose` for code search — and the test above covers every other case: multi-step diagnostics, log correlation, verbose `git diff`/state-survey bursts.
+
+**Operational trigger:** when you notice you are about to run the *second or third* `Bash` command toward the same question, stop — dispatch the question instead of continuing inline.
+
+**Stays inline — do not over-delegate:** a single targeted lookup; a comprehension read whose content feeds your own writing, review, or design; `Edit`/`Write` sequences (judgment-dense, not scratch); output you must reason over line by line (a failure you are debugging, a diff you must design against).
+
+**No permission cost.** A subagent runs under the parent's permission mode. Under auto mode, its read-only diagnostics are evaluated by the same classifier that clears the parent's — delegating read-heavy work adds no permission prompts and needs no `permissions.allow` entries. Dispatch `general-purpose` with an explicit `model` (see Model Routing and `docs/auto-mode.md`).
+
 ### Heavy command output
 
 Use the `Agent` tool with `subagent_type: check-runner` to run the checks (full test suites, lint, typecheck, build) — not `Bash` in the parent directly. **Enumerate the exact command strings in the dispatch prompt** (e.g. "Run these commands: `pytest claude/.claude/`, `ruff check claude/.claude/`") — not "run the checks" or "run the suite". The subagent writes full output to `${TMPDIR:-/tmp}/<command-slug>-<epoch-ms>.txt` and returns a structured verdict plus the file paths; the parent reads the file for more detail rather than re-running. This applies to suite-level runs; commands scoped to a single test file or single test name during interactive debugging can stay inline.


### PR DESCRIPTION
## What

Adds a `### Delegation: hold conclusions, not transcripts` subsection to the global `claude/.claude/CLAUDE.md`, placed under `## Working Style` immediately before `### Heavy command output`.

## Why

The global `CLAUDE.md` routes delegation by *task type*: `### Heavy command output` (check suites → `check-runner`) and `### Codebase discovery` (code search → `Explore`/`general-purpose`). Type-indexing names individual slices and leaves the unnamed majority of read-heavy `Bash` work running inline on an auto-mode Opus parent — verbose output the parent only needs a conclusion from, re-billed on every turn. Adding one more task-type subsection would name one more slice and leave a fresh un-named "other".

## How

The new subsection states a generative principle and a two-part test, applied to *objectives* not individual commands:

- **Output test** — does the parent's reasoning consume the command's output, or only a conclusion drawn from it?
- **Judgment test** — does choosing the command (and the next) need parent-grade judgment?

Both pointing to delegate ⇒ dispatch the objective to a subagent. The two existing subsections survive unchanged as named instances of the principle (their titles are untouched — `README.md` references "Heavy command output" by title). `Edit`/`Write` is explicitly excluded as a delegation target — those runs are short and judgment-dense.

The subsection cross-references `## Model Routing` and `docs/auto-mode.md` for the dispatch-cost mechanics rather than restating them.

## Verification

- `pytest claude/.claude/` — 995 passed
- `ruff check claude/.claude/` — clean
- `/code-review` (clean) and `/ai-instruction-and-memory-files` audit (behavior test, no PR/ticket refs, correct CLAUDE.md-vs-skill routing) both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)