### PR TITLE
feat(hooks): garbage-collect stale ~/.claude/sessions/ files

### DIFF
--- a/claude/.claude/hooks/capture-session-id.sh
+++ b/claude/.claude/hooks/capture-session-id.sh
@@ -68,4 +68,83 @@ for _active_dir in "$HOME/.claude"/.*-active.d; do
   fi
 done
 
+# Garbage-collect stale bare-PID files from ~/.claude/sessions/.
+#
+# Throttled to once per 24 hours via ~/.claude/.sessions-gc-stamp so the
+# sweep does not run on every SubagentStart in an agentic session. The
+# stamp lives outside sessions/ to keep that directory purely bare-PID
+# files plus Claude Code's <pid>.json sidecars.
+#
+# Fail-open: every find/kill/rm non-zero exit is swallowed. The sweep is
+# best-effort tidiness — a failure must never propagate to the hook's
+# top-level exit and must never block session startup.
+_gc_stamp="$HOME/.claude/.sessions-gc-stamp"
+_sessions_dir="$HOME/.claude/sessions"
+
+# Check whether a fresh stamp exists (mtime under 24 hours old).
+# `find FILE -mtime -1` exits 0 and prints the path when mtime < 24h.
+_stamp_fresh=$(find "$_gc_stamp" -mtime -1 2>/dev/null)
+if [ -z "$_stamp_fresh" ]; then
+  # Stamp is absent or stale — run the sweep, then refresh the stamp.
+  (
+    # Precompute sets for the age-based checks. The directory is flat so
+    # no -maxdepth is needed. Both find calls are best-effort; failure
+    # produces an empty variable, which means those entries are simply
+    # skipped rather than deleted — safe and fail-open.
+    _old_files=$(find "$_sessions_dir" -type f -mtime +30 2>/dev/null || true)
+    _fresh_files=$(find "$_sessions_dir" -type f -mmin -5 2>/dev/null || true)
+
+    for _session_file in "$_sessions_dir"/*; do
+      # Guard against empty-directory no-match (nullglob not set).
+      [ -e "$_session_file" ] || continue
+
+      _b=${_session_file##*/}
+
+      # Only bare-PID filenames pass (excludes <pid>.json sidecars and
+      # anything else Claude Code may write). This is the single gate
+      # every deletion must pass.
+      [[ "$_b" =~ ^[0-9]+$ ]] || continue
+
+      # Never touch the lookup file just written by this run.
+      [ "$_b" = "$CLAUDE_PID" ] && continue
+
+      # Skip files younger than 5 minutes (floor against clock skew and
+      # a just-written sibling file whose mtime we can't perfectly order).
+      # Match whole newline-bounded paths: an unbounded substring match
+      # would let PID 123 match a list containing PID 1234.
+      case $'\n'"$_fresh_files"$'\n' in
+        *$'\n'"$_session_file"$'\n'*) continue ;;
+      esac
+
+      # Delete: superseded prior incarnation of this session (Leak A).
+      # `$(<file)` reads without a subprocess; a vanished file yields an
+      # empty string, and the subshell's 2>/dev/null swallows the notice.
+      _file_content=$(<"$_session_file")
+      if [ "$_file_content" = "$SESSION_ID" ]; then
+        rm -f "$_session_file" 2>/dev/null || true
+        continue
+      fi
+
+      # Delete: mapped process is gone (Leak B, common case).
+      if ! kill -0 "$_b" 2>/dev/null; then
+        rm -f "$_session_file" 2>/dev/null || true
+        continue
+      fi
+
+      # Delete: mtime older than 30 days covers PID-reuse where kill -0
+      # passes for an unrelated live process (Leak B, ceiling). Match
+      # whole newline-bounded paths so PID 123 cannot match PID 1234.
+      case $'\n'"$_old_files"$'\n' in
+        *$'\n'"$_session_file"$'\n'*) rm -f "$_session_file" 2>/dev/null || true ;;
+      esac
+    done
+  ) 2>/dev/null || true
+
+  # Refresh the throttle stamp regardless of sweep outcome. A failed
+  # write is harmless — the sweep is idempotent and simply re-runs next
+  # session — but emit a diagnostic per this hook's stderr convention.
+  touch "$_gc_stamp" 2>/dev/null || \
+    echo "[capture-session-id] could not write GC throttle stamp $_gc_stamp; sweep will re-run next session" >&2
+fi
+
 exit 0

--- a/claude/.claude/hooks/tests/test_capture_session_id.py
+++ b/claude/.claude/hooks/tests/test_capture_session_id.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
+import time
 from pathlib import Path
 
 from helpers import HOOKS_DIR
@@ -88,3 +90,174 @@ class TestCaptureSessionId:
         assert result.returncode == 0
         assert len(self._sessions_files(isolated_home)) == 1
         assert result.stderr == ""
+
+
+class TestCaptureSessionIdGC:
+    """Garbage-collection sweep inside capture-session-id.sh.
+
+    The hook sweeps ~/.claude/sessions/ at most once per 24 hours
+    (throttled via ~/.claude/.sessions-gc-stamp). Each test ensures the
+    stamp is absent/stale before invoking the hook so the sweep runs.
+
+    Dead-PID idiom: PID 99999999 is above Linux pid_max and is
+    effectively guaranteed to be dead on any test host.
+    """
+
+    DEAD_PID = "99999999"
+    GC_STAMP_NAME = ".sessions-gc-stamp"
+
+    def _sessions_dir(self, home: Path) -> Path:
+        return home / ".claude" / "sessions"
+
+    def _gc_stamp(self, home: Path) -> Path:
+        return home / ".claude" / self.GC_STAMP_NAME
+
+    def _seed_session_file(self, home: Path, pid: str, content: str) -> Path:
+        """Write a bare-PID lookup file with given content."""
+        sessions_dir = self._sessions_dir(home)
+        sessions_dir.mkdir(parents=True, exist_ok=True)
+        f = sessions_dir / pid
+        f.write_text(content + "\n")
+        return f
+
+    def _age_file(self, path: Path, seconds_ago: int) -> None:
+        """Set a file's mtime to `seconds_ago` seconds in the past."""
+        t = time.time() - seconds_ago
+        os.utime(path, (t, t))
+
+    def _run(self, session_id: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [str(CAPTURE_SESSION_ID_HOOK)],
+            input=json.dumps({"session_id": session_id}),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def _ensure_sweep_runs(self, home: Path) -> None:
+        """Remove the GC stamp so the sweep is not throttled."""
+        stamp = self._gc_stamp(home)
+        if stamp.exists():
+            stamp.unlink()
+
+    def test_superseded_file_is_deleted(self, isolated_home):
+        """A file whose content equals the captured session_id (but with a
+        different PID) is a superseded prior incarnation and must be removed."""
+        sid = "session-superseded-test"
+        stale = self._seed_session_file(isolated_home, "10000001", sid)
+        self._age_file(stale, 600)  # 10 minutes old — past the 5-min floor
+        self._ensure_sweep_runs(isolated_home)
+
+        result = self._run(sid)
+
+        assert result.returncode == 0
+        assert not stale.exists(), "superseded file (same session_id, old PID) must be deleted"
+
+    def test_dead_pid_file_is_deleted(self, isolated_home):
+        """A bare-PID file whose PID is dead must be removed."""
+        stale = self._seed_session_file(isolated_home, self.DEAD_PID, "some-other-uuid")
+        self._age_file(stale, 600)  # 10 minutes old
+        self._ensure_sweep_runs(isolated_home)
+
+        result = self._run("current-session-id")
+
+        assert result.returncode == 0
+        assert not stale.exists(), "dead-PID file must be deleted"
+
+    def test_live_pid_file_is_kept(self, isolated_home):
+        """A bare-PID file for a live process with unrelated content must survive."""
+        live_pid = str(os.getpid())
+        live_file = self._seed_session_file(isolated_home, live_pid, "unrelated-session-id")
+        self._age_file(live_file, 600)  # 10 minutes old
+        self._ensure_sweep_runs(isolated_home)
+
+        result = self._run("current-session-id")
+
+        assert result.returncode == 0
+        assert live_file.exists(), "live-PID file with unrelated content must be kept"
+
+    def test_json_sidecar_is_never_touched(self, isolated_home):
+        """Claude Code's <pid>.json sidecars must never be deleted — the
+        basename filter rejects anything that is not purely numeric."""
+        sessions_dir = self._sessions_dir(isolated_home)
+        sessions_dir.mkdir(parents=True, exist_ok=True)
+        sidecar = sessions_dir / f"{self.DEAD_PID}.json"
+        sidecar.write_text('{"pid": 99999999, "sessionId": "some-id"}\n')
+        self._age_file(sidecar, 600)
+        self._ensure_sweep_runs(isolated_home)
+
+        result = self._run("current-session-id")
+
+        assert result.returncode == 0
+        assert sidecar.exists(), "<pid>.json sidecar must never be touched by the sweep"
+
+    def test_just_written_file_survives(self, isolated_home):
+        """The lookup file the hook writes for this run must never be deleted
+        by the sweep (guarded by CLAUDE_PID == this run's PID)."""
+        self._ensure_sweep_runs(isolated_home)
+
+        result = self._run("current-session-id")
+
+        assert result.returncode == 0
+        sessions_dir = self._sessions_dir(isolated_home)
+        assert sessions_dir.exists(), "sessions dir must be created"
+        files = list(sessions_dir.iterdir())
+        # The hook writes exactly the lookup file for this run; sweep must not delete it.
+        lookup_files = [f for f in files if f.name.isdigit()]
+        assert len(lookup_files) >= 1, "the just-written lookup file must survive the sweep"
+
+    def test_file_older_than_30_days_with_live_pid_is_deleted(self, isolated_home):
+        """A file aged past 30 days with a live PID (own pid, kill -0 passes)
+        must be deleted to close the PID-reuse case."""
+        live_pid = str(os.getpid())
+        old_file = self._seed_session_file(isolated_home, live_pid, "old-session-id")
+        # Age to 31 days ago.
+        self._age_file(old_file, 31 * 24 * 3600)
+        self._ensure_sweep_runs(isolated_home)
+
+        result = self._run("current-session-id")
+
+        assert result.returncode == 0
+        assert not old_file.exists(), "file older than 30 days must be deleted even with live PID"
+
+    def test_dead_pid_file_younger_than_5_minutes_is_kept(self, isolated_home):
+        """A dead-PID file under 5 minutes old must be kept (conservative
+        floor against a just-written sibling file or clock skew)."""
+        young_file = self._seed_session_file(isolated_home, self.DEAD_PID, "young-uuid")
+        # Age to 2 minutes ago — within the 5-min floor.
+        self._age_file(young_file, 120)
+        self._ensure_sweep_runs(isolated_home)
+
+        result = self._run("current-session-id")
+
+        assert result.returncode == 0
+        assert young_file.exists(), "dead-PID file under 5 minutes old must be kept"
+
+    def test_throttle_suppresses_sweep_within_24h(self, isolated_home):
+        """When ~/.claude/.sessions-gc-stamp has a fresh mtime, the sweep
+        must be skipped entirely, leaving a seeded dead-PID file untouched."""
+        stale = self._seed_session_file(isolated_home, self.DEAD_PID, "should-survive")
+        self._age_file(stale, 600)  # 10 minutes old — would be deleted without throttle
+
+        # Write a fresh stamp (mtime now).
+        stamp = self._gc_stamp(isolated_home)
+        stamp.touch()
+
+        result = self._run("current-session-id")
+
+        assert result.returncode == 0
+        assert stale.exists(), "throttle must prevent sweep — dead-PID file must survive"
+
+    def test_hook_exits_0_in_all_gc_scenarios(self, isolated_home):
+        """Hook must exit 0 even when the sessions directory is populated
+        with a mix of stale, live, and sidecar files."""
+        sessions_dir = self._sessions_dir(isolated_home)
+        sessions_dir.mkdir(parents=True, exist_ok=True)
+        self._seed_session_file(isolated_home, self.DEAD_PID, "dead-session")
+        self._age_file(sessions_dir / self.DEAD_PID, 600)
+        (sessions_dir / f"{self.DEAD_PID}.json").write_text('{"pid":99999999}\n')
+        self._ensure_sweep_runs(isolated_home)
+
+        result = self._run("current-session-id")
+
+        assert result.returncode == 0

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -22,7 +22,7 @@ Full descriptions for every hook in `claude/.claude/hooks/`. For the gate summar
 
 ## Utility hooks
 
-- **`capture-session-id.sh`** (SessionStart, SubagentStart) — at session and subagent start, writes the session's `session_id` to `~/.claude/sessions/<claude-pid>` so skills running as Bash tool calls (which don't see the hook payload) can look up their own session id via the bash tool's `$PPID`. Used by both `/respond-pr` and `/code-review` to compute per-session marker filenames.
+- **`capture-session-id.sh`** (SessionStart, SubagentStart) — at session and subagent start, writes the session's `session_id` to `~/.claude/sessions/<claude-pid>` so skills running as Bash tool calls (which don't see the hook payload) can look up their own session id via the bash tool's `$PPID`. Used by both `/respond-pr` and `/code-review` to compute per-session marker filenames. The hook also self-prunes superseded and orphaned bare-PID files from `~/.claude/sessions/`, throttled to once per 24 hours via `~/.claude/.sessions-gc-stamp`.
 - **`ask-review-permissions.sh`** — asks before `Edit`/`Write`/`MultiEdit` to `.claude/settings*.json`, nudging toward `/review-permissions` when the edit touches `permissions.allow`.
 - **`session-marker-dashboard.sh`** (SessionStart) — at session start, emits a summary of any active bypass markers (`/respond-pr`, `/ready-for-review`) into the resumed session's context so stale bypasses are visible.
 - **`enforce-marker-script-shape.sh`** — PreToolUse `Bash` gate that denies any `marker.sh` invocation not exactly matching the allowlisted shape pattern (`~/.claude/scripts/marker.sh <subcommand> <skill>`). Blocks chains (`&&`, `;`), redirects, env-var prefixes, and extra arguments. Defense-in-depth against prompt-injection escalation through the `marker.sh` allow rules.
@@ -82,3 +82,5 @@ If a skill's active-bypass gate refuses to release after the skill has finished,
 ~/.claude/scripts/marker.sh clear-stale          # evict dead-PID entries
 ~/.claude/scripts/marker.sh clear-stale --dry-run # report without removing
 ```
+
+`clear-stale` operates only on active-bypass marker directories (`.*-active.d/`); it does not touch `~/.claude/sessions/`, which is GC'd automatically by `capture-session-id.sh`.


### PR DESCRIPTION
## Summary

`capture-session-id.sh` writes a bare-PID `session_id` mapping file to `~/.claude/sessions/` on every SessionStart/SubagentStart and never removed superseded ones, so the directory grew without bound (~895 files observed).

This adds a throttled garbage-collection sweep to the hook:

- Runs at most once per 24h, gated by a `~/.claude/.sessions-gc-stamp` timestamp sentinel — kept outside `sessions/` so that directory stays purely bare-PID files plus Claude Code's own `<pid>.json` sidecars.
- Deletes superseded prior incarnations of the current session, files whose PID is dead (`kill -0`), and files older than 30 days (the PID-reuse ceiling — `kill -0` can pass for an unrelated recycled PID).
- A 5-minute mtime floor protects a just-written sibling session's file; a `^[0-9]+$` basename filter excludes Claude Code's `<pid>.json` sidecars and is the single gate every deletion passes.
- Fails open — a SessionStart hook that fails closed would block session startup.

`marker.sh` is intentionally untouched. Retiring the bare-PID mechanism in favor of Claude Code's `<pid>.json` sidecars was considered and deferred — see the commit message.

## Test plan

- [ ] With a populated `~/.claude/sessions/`, start a fresh session; confirm stale bare-PID files are pruned while every `<pid>.json` sidecar survives.
- [ ] Start a second session within 24h; confirm the sweep is throttled (file count unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)