### PR TITLE
fix(skills): correct uncited length-target claims in ai-instruction-and-memory-files and skill-review

### DIFF
--- a/claude/.claude/skills/ai-instruction-and-memory-files/REFERENCES.md
+++ b/claude/.claude/skills/ai-instruction-and-memory-files/REFERENCES.md
@@ -1,11 +1,24 @@
 # References — ai-instruction-and-memory-files
 
 Primary sources that informed the rules in SKILL.md. Not loaded at skill runtime;
-read manually when verifying a rule or adding new guidance.
+read manually when verifying a rule or adding new guidance. Tier matters — an
+official Anthropic doc outweighs a practitioner blog; keep that distinction when
+citing a claim.
+
+**Official (Anthropic):**
 
 - [Claude Code — How Claude remembers your project](https://code.claude.com/docs/en/memory)
+  — the "under 200 lines per CLAUDE.md file" size threshold, CLAUDE.md-loaded-not-AGENTS.md,
+  the `@AGENTS.md` import pattern, the auto-memory role split, the MEMORY.md 200-line/25KB load limit.
 - [Claude Code — Best Practices](https://code.claude.com/docs/en/best-practices)
+  — CLAUDE.md is advisory while hooks are deterministic; the over-specified-CLAUDE.md failure mode.
 - [claude-code CHANGELOG.md](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md)
-- [agents.md standard](https://agents.md)
-- [Context Rot — Chroma Research](https://research.trychroma.com/context-rot)
+  — zero AGENTS.md entries, confirming AGENTS.md support was never added.
+
+**Practitioner / research (not Anthropic — weigh accordingly):**
+
+- [agents.md standard](https://agents.md) — supporting-tools list; Claude Code is absent from it.
+- [Context Rot — Chroma Research](https://www.trychroma.com/research/context-rot)
+  — model performance degrades as input length grows. Uses no word-count compliance threshold.
 - [Writing a good CLAUDE.md — HumanLayer](https://www.humanlayer.dev/blog/writing-a-good-claude-md)
+  — practitioner "under 300 lines" consensus, explicitly described as not rigorously investigated.

--- a/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
+++ b/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
@@ -22,7 +22,7 @@ While active, `require-memory-skill.sh` bypasses for this session (<60 min fresh
 
 Before writing any file under `memory/`, check in order:
 
-1. **Grep CLAUDE.md and AGENTS.md** (project tree + `~/.claude/`) for keywords from the rule. If covered → edit the source, don't write to memory. Restating a covered rule is pure load. (See §3 compliance asymmetry, §5 anti-duplication heuristic.)
+1. **Grep CLAUDE.md and AGENTS.md** (project tree + `~/.claude/`) for keywords from the rule. If covered → edit the source, don't write to memory. Restating a covered rule is pure load. (See §3 advisory vs deterministic, §5 anti-duplication heuristic.)
 2. **Does this rule fire only inside a specific named skill's workflow?** If yes → that skill's `SKILL.md`, not memory. Skill bodies load at the moment the rule applies; memory loads every session whether the session uses that workflow or not.
 3. **Confirm the content fits a genuine memory use:** personal preference (user type), feedback calibration with the *why* — corrections *and* validated judgment calls (feedback type), past-incident context not captured in code or commit messages (project type), or pointer to an external system (reference type).
 
@@ -80,14 +80,16 @@ criteria for `.lovable/**` changes, see the `lovable-cloud-knowledge` skill.
 
 ## 2. Length targets
 
-Per [Claude Code Best Practices](https://code.claude.com/docs/en/best-practices),
-[HumanLayer](https://www.humanlayer.dev/blog/writing-a-good-claude-md),
-and [Chroma's Context Rot research](https://research.trychroma.com/context-rot):
-
-- Target: **under 200 lines per file**.
-- Diminishing returns past 300 lines. 1000+ words correlates negatively with compliance.
-- Attention decay hits the **middle** of long files — "lost in the middle." Burying critical rules past line ~150 reduces their effective load.
-- Compliance with prose rules tops out around **70%**. Structural tests and hooks hit 100%. When a rule can be encoded as either, prefer the mechanical enforcement.
+Official threshold: **under 200 lines per CLAUDE.md file** ([Claude Code
+— memory](https://code.claude.com/docs/en/memory): "Longer files consume
+more context and reduce adherence"). The unit is **lines** — no
+Anthropic source attaches a word-count threshold. Within that cap, line
+count undercounts density (long-paragraph lines bury rules), and
+attention decays in the middle ("lost in the middle"). Apply the
+**behavior test** below per line; place critical rules near start or end. CLAUDE.md is **advisory** while
+hooks are **deterministic** ([Claude Code Best Practices](https://code.claude.com/docs/en/best-practices):
+hooks "guarantee the action happens") — prefer a hook or structural
+test when a rule can be encoded as one.
 
 ### The behavior test
 
@@ -111,11 +113,11 @@ Claude Code when both files exist. Zero maintenance, single source.
 **Duplicate (defense-in-depth) when:**
 - The content is genuinely critical and one delivery mechanism could fail silently.
 - Different agents reach the file through different load paths and the rule needs to fire in all of them.
-- Example: a security-critical rule appearing in AGENTS.md (prose, ~70% compliance) AND enforced by a pre-commit hook (mechanical, 100% compliance) — the hook catches what prose drift misses.
+- Example: a security-critical rule appearing in AGENTS.md (advisory) AND enforced by a pre-commit hook (deterministic) — the hook catches what prose drift misses.
 
 **Do NOT duplicate when:**
 - An AGENTS.md-aware agent already reads it natively and Claude Code can import it via `@AGENTS.md` — one canonical source covers both.
-- The content is enforced structurally (a test, a hook) — prose duplication adds maintenance without raising compliance above the already-100% structural enforcement.
+- The content is enforced structurally (a test, a hook) — prose duplication adds maintenance without raising adherence above the deterministic enforcement.
 - The rule is process discipline enforced by `/pre-merge`, commit-review hooks, or other mechanical gates.
 
 ## 4. Quick decision flow when editing
@@ -172,8 +174,8 @@ Index discipline:
 | Rule that fires only inside a specific skill's flow              | That skill's SKILL.md (not CLAUDE.md, not auto-memory) |
 | Past incident "why" not captured in code, tests, or commit msgs  | Auto-memory (feedback or project type)           |
 | Pointer to external systems (Linear, Grafana, etc.)              | Auto-memory (reference type)                     |
-| Restatement of a rule already in CLAUDE.md / AGENTS.md           | **Nowhere — delete it** (§3 compliance asymmetry)|
-| Rule already enforced by a hook or structural test               | **Nowhere — enforcement is 100%, prose is load** |
+| Restatement of a rule already in CLAUDE.md / AGENTS.md           | **Nowhere — delete it** (§3 advisory vs deterministic)|
+| Rule already enforced by a hook or structural test               | **Nowhere — the hook enforces it; prose is load**|
 
 ### Anti-duplication heuristic
 

--- a/plugins/skill-review/.claude-plugin/plugin.json
+++ b/plugins/skill-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "skill-review",
   "description": "Behavioral-equivalence audit for SKILL.md changes. Gates git commit when staged changes include a SKILL.md. Install at project scope in repos that author SKILL.md files.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": {
     "name": "Cordova Strategy"
   },

--- a/plugins/skill-review/skills/skill-review/SKILL.md
+++ b/plugins/skill-review/skills/skill-review/SKILL.md
@@ -86,8 +86,8 @@ After a `TRIGGER`-block change, run `python evals/run_skill_evals.py --skill <na
 ## 4. Length and the behavior test
 
 Target under **200 lines per file** (diminishing returns past 300).
-Prose-rule compliance tops out around ~70%; structural tests and
-hooks hit 100%. When a rule can be encoded mechanically, prefer
+Skill bodies are advisory; hooks and structural tests are
+deterministic. When a rule can be encoded mechanically, prefer
 mechanical enforcement.
 
 **The behavior test.** For every line: does removing this line


### PR DESCRIPTION
## Summary

Citation correctness fix to two skills' length-target sections.

**`ai-instruction-and-memory-files` §2** rewritten:
- Drops "1000+ words correlates negatively with compliance" — research traced this only to an unverifiable practitioner blog citing an uncited GitHub study. No Anthropic source uses a word-count threshold.
- Drops "~70% prose compliance / 100% hooks compliance" — neither figure appears in any cited source.
- The official **"under 200 lines per CLAUDE.md file"** rule is verbatim Anthropic from [code.claude.com/docs/en/memory](https://code.claude.com/docs/en/memory) — kept and now cited inline with a verbatim quote fragment.
- Adds explicit "line count alone undercounts density" caveat with the directive to "place critical rules near start or end" (preserves the "lost in the middle" arming from the original).
- The advisory/deterministic distinction is sourced verbatim to [Best Practices](https://code.claude.com/docs/en/best-practices): hooks "guarantee the action happens."

**Sibling fixes** in the same skill (§3 example, §3 don't-duplicate bullet, §5 routing cell, and two stale "§3 compliance asymmetry" back-pointer labels) for consistency.

**Cross-skill sibling fix** in `plugins/skill-review/skills/skill-review/SKILL.md` §4 — same uncited "~70%/100%" pair removed with parallel framing.

**REFERENCES.md** tier-grouped (Official Anthropic vs Practitioner) with per-source annotation of what each backs. Chroma URL canonicalized.

## Why

A prior session looked at a 106-line / 2,519-word stowed CLAUDE.md and called it "fine, under 200 lines," invoking the now-removed "1000+ words" claim to half-wave-off the density concern. Two problems:
- The word-count claim has no primary source (research traced it to a practitioner blog citing an uncited GitHub study).
- Line count alone undercounts density when each line is a long paragraph — the official docs themselves prefer "headers and bullets" over "dense paragraphs."

§2 now states "line count alone undercounts density" explicitly and points to the per-line behavior test as the binding density control.

## Plugin install

After merge, refresh skill-review in consuming repos with:

```
claude plugin install skill-review@claude-config --scope project
```

## Pre-existing observation (informational, out of scope)

`skill-review/SKILL.md` §4 currently sets its length target at **200 lines** — that's the CLAUDE.md threshold per Anthropic. The skill reviews SKILL.md files, for which Anthropic's official guidance is **500 lines** ([agent-skills/best-practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices)). Either deliberately stricter house style or a confusion between the two file-type thresholds. Separate decision for a future PR.

## Test plan

- [x] `/skill-review` — clean (behavioral-equivalence audit preserved every directive; HumanLayer 300-line ceiling lost as acceptable trade-off given the mechanical 200-line skill-length gate is enforced)
- [x] `/code-review` — clean
- [x] `/plugin-semver` — clean (skill-review patch bump 1.0.2 → 1.0.3)
- [x] Mechanical skill-length gate — passes (`ai-instruction-and-memory-files/SKILL.md` exactly 200 lines)
- [x] `pytest claude/.claude/` — 996 passed on the 213-line intermediate state; final re-verification on 200-line compressed state in progress at PR-open
- [x] `ruff check claude/.claude/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)