### PR TITLE
feat(agents): conditional test-shipping rule for code-writer

### DIFF
--- a/claude/.claude/agents/code-writer.md
+++ b/claude/.claude/agents/code-writer.md
@@ -45,7 +45,11 @@ language and stack:
   loop body. Batch it or hoist it out of the loop.
 - Data crossing a trust boundary (request input, external response,
   caller-supplied identifier) is validated before use.
-- New behavior ships with a test that names the specific case it guards.
+- New behavior ships with a test that names the specific case it guards — but
+  only when the codebase already shows a test convention (a tests directory, a
+  runner config, sibling test files following a pattern). When no such
+  convention exists, flag the coverage gap in **Still uncertain** rather than
+  introduce test scaffolding the project does not have.
 
 This baseline is what you check while writing. It does not replace the
 self-review pass below.


### PR DESCRIPTION
## Summary

Surfaced by the manual smoke test for the `code-writer` agent (PR #271): with an unconditional "new behavior ships with a test" baseline rule, the agent created `test_operations.py` (plus `__pycache__/` and `.pytest_cache/`) in a scratch project that had no test infrastructure. The agent's behavior was prompt-compliant — the rule said ship tests — but the result conflicted with the global "minimal targeted changes" principle, and the agent's first dispatch produced more files than the dispatch prompt requested.

This narrows the rule to fire only when the codebase already shows a test convention (a tests directory, a runner config, sibling test files following a pattern). When no such convention exists, the agent flags the coverage gap in the **Still uncertain** section of its return rather than introducing test scaffolding the project does not have.

Real repos retain the test-with-new-code default; scratch contexts and repos without test infrastructure stop getting unrequested test files.

## Why not a fuller rewrite

The original proposal was a two-clause edit that would have also forbidden the agent from executing tests / build tooling. On re-reading the agent file, that clause contradicted the Charter's existing explicit permission to "run narrowly-scoped, read-only checks on what you changed — the single test file you touched" (line 24-27). The execution permission is correct as-is; only the unconditional "always ship a test" baseline needed scoping.

## Test plan

- [ ] Re-run `/tmp/code-writer-smoke-test.md` from a fresh session with cwd `/tmp/code-writer-smoke` (so `git init` works), and confirm the agent writes `operations.py` only — no `test_operations.py`, no `__pycache__/`, no `.pytest_cache/` — and surfaces the coverage gap in the **Still uncertain** section.
- [ ] Optional second dispatch in a repo that *does* have test infrastructure (a pytest-configured project) to confirm the agent still ships a test in that case.
- [ ] Smoke-test brief `/tmp/code-writer-smoke-test.md` checklist item "It stayed in scope — only `operations.py` was created" can now be enforced literally; if the agent ever writes a test file under this branch's rules, the convention-detection logic itself has misfired and needs investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)