### PR TITLE
feat(agents): require code-writer to name test-coverage gap in Still uncertain

### DIFF
--- a/claude/.claude/agents/code-writer.md
+++ b/claude/.claude/agents/code-writer.md
@@ -100,8 +100,11 @@ concrete:
   you applied and what you found and fixed, or "clean." If the change was
   trivial enough to skip the deep pass, say so and why.
 - **Still uncertain:** anything you could not fully verify — an assumption you
-  made, a contract you could not trace, a decision the parent should confirm. If
-  there is nothing, say "nothing." The parent uses this to target its review.
+  made, a contract you could not trace, a decision the parent should confirm.
+  If you shipped new behavior without a test because the codebase has no test
+  convention (per the baseline rule), name the test-coverage gap as an
+  explicit item — do not omit it. If there is nothing else, say "nothing."
+  The parent uses this to target its review.
 
 No padding, no praise, no restating the dispatch prompt. If the change is
 incomplete or blocked, say so plainly with the reason.


### PR DESCRIPTION
## Summary

The Implementation baseline rule already directs `code-writer` to flag the coverage gap in **Still uncertain** when the codebase has no test convention, but the baseline section is what the agent applies while writing — by the time it composes the return, that directive is no longer the active surface. Observed effect: returns populated **Still uncertain** with domain concerns (idempotency, concurrency, etc.) and silently omitted the test-coverage gap that branch-2 of the conditional rule was supposed to surface.

This puts the cue at the surface the agent reads when composing the return.

## What shipped

`claude/.claude/agents/code-writer.md` — Return format section, **Still uncertain** bullet:

- Adds an explicit case: "If you shipped new behavior without a test because the codebase has no test convention (per the baseline rule), name the test-coverage gap as an explicit item — do not omit it."
- Changes the closer from "If there is nothing" to "If there is nothing else" to keep the two clauses compatible.

## Test plan

- [ ] Re-run the code-writer smoke test in a fresh session; expect **Still uncertain** to name the test-coverage gap explicitly when the dispatched task hits the no-test-convention branch.

## Related

Follow-up to #279 (which scoped the writing-time rule to repos with a test convention). That PR removed the over-aggressive ship-tests-always behavior; this PR surfaces the alternative branch that the rule directed at **Still uncertain** but the agent was silently dropping. Two distinct gaps in opposite directions, not stacked defenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)