### PR TITLE
feat(lovable-cloud-migration-sync): add edge-runtime mount precondition

### DIFF
--- a/plugins/lovable-cloud/skills/lovable-cloud-migration-sync/SKILL.md
+++ b/plugins/lovable-cloud/skills/lovable-cloud-migration-sync/SKILL.md
@@ -92,6 +92,30 @@ with the user.
 
 ### 5. Verify locally before deleting
 
+**Precondition: confirm the edge runtime is mounted on the current worktree.**
+The local Supabase edge runtime container is bind-mounted to the
+`supabase/functions` directory of whichever worktree last ran `supabase start`.
+If the mount points at a different worktree — or the mounted path was removed
+when an old worktree was deleted — every edge-function invocation returns 503
+`BOOT_ERROR`. That surfaces as a wave of verification-suite failures that look
+like real regressions but are an environment mismatch, and `check-runner` is a
+stateless subagent that cannot detect it.
+
+Check the current bind-mount target:
+
+```bash
+docker inspect $(docker ps --format '{{.Names}}' | grep '^supabase_edge_runtime_') \
+  --format '{{range .Mounts}}{{if eq .Type "bind"}}{{.Source}}{{end}}{{end}}'
+```
+
+Compare to `$PWD/supabase/functions` and confirm the mounted path exists on
+disk. If the mount does not match the current worktree, or the path is gone,
+restart the stack from the current worktree before dispatching `check-runner`:
+
+```bash
+supabase stop && supabase start
+```
+
 Run the full verification — `supabase db reset` followed by your project's
 verification commands — via the `Agent` tool with `subagent_type: check-runner`.
 See `~/.claude/CLAUDE.md` "Heavy command output" for the rationale and


### PR DESCRIPTION
## Summary

- Adds an explicit precondition to Step 5 of `lovable-cloud-migration-sync`: confirm the local Supabase edge runtime container is bind-mounted to the current worktree's `supabase/functions` (and that the path exists on disk) before dispatching `check-runner`.
- Provides the `docker inspect` check command and `supabase stop && supabase start` as the remediation when the mount points elsewhere or the path is gone.
- Documents why this belongs in the parent and not in `check-runner`: the subagent is stateless and cannot detect a stale bind mount; the failure mode (a wave of 503 `BOOT_ERROR` responses) looks like a regression and is easy to misattribute to pre-existing failures on `main`.

## Scope

Limited to Step 5 of this one skill. The mount-discipline rule is specific to Lovable Cloud's per-worktree Supabase wrapper; the plugin's shared docs deliberately do not absorb it.

## Test plan

- [ ] Read the diff and confirm Step 5's precondition reads cleanly without prior-PR context.
- [ ] Confirm no project-identifying content survived from the briefing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)