### PR TITLE
chore(skills): disable /loop, /run, /schedule, /verify bundled skills

### DIFF
--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -43,10 +43,14 @@
     "fewer-permission-prompts": "off",
     "init": "off",
     "keybindings-help": "off",
+    "loop": "off",
     "review": "off",
+    "run": "off",
+    "schedule": "off",
     "security-review": "off",
     "simplify": "off",
-    "update-config": "off"
+    "update-config": "off",
+    "verify": "off"
   },
   "hooks": {
     "SessionStart": [

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -27,7 +27,7 @@ Each skill lives in `claude/.claude/skills/<skill-name>/SKILL.md`. A skill direc
 
 ## Bundled skills disabled by default
 
-Claude Code ships a set of bundled skills alongside its custom-skill support. Eight bundled skills are disabled in this repo's `settings.json` via `skillOverrides: "off"`. The reason in each case is either redundancy with a more capable repo-specific skill or low utility relative to the description-budget cost. All skill descriptions contribute to the `skillListingBudgetFraction` context allocation; `/doctor` reports a warning when the budget overflows and descriptions are dropped. The disabled skills freed budget for the always-relevant `user-invocable: false` skills that auto-trigger during the engineering workflow.
+Claude Code ships a set of bundled skills alongside its custom-skill support. Twelve bundled skills are disabled in this repo's `settings.json` via `skillOverrides: "off"`. The reason in each case is either redundancy with a more capable repo-specific skill or low utility relative to the description-budget cost. All skill descriptions contribute to the `skillListingBudgetFraction` context allocation; `/doctor` reports a warning when the budget overflows and descriptions are dropped. The disabled skills freed budget for the always-relevant `user-invocable: false` skills that auto-trigger during the engineering workflow.
 
 | Bundled skill | Why disabled |
 |---|---|
@@ -35,10 +35,14 @@ Claude Code ships a set of bundled skills alongside its custom-skill support. Ei
 | `/fewer-permission-prompts` | One-time setup utility; rarely fires in established sessions. |
 | `/init` | One-time setup; CLAUDE.md is already established, and `/init` advice may conflict with repo conventions. |
 | `/keybindings-help` | One-time setup utility; rarely fires in established sessions. |
+| `/loop` | Recurring-interval task automation. Not part of this repo's skill-authoring / review-pipeline workflow. |
 | `/review` | "Review a PR" — superseded by `/code-review` (specialist reviewer routing) and `/ultrareview`. |
+| `/run` | Launches and drives "this project's app" — claude-config is dotfiles, no app to drive. Out of scope. |
+| `/schedule` | Cron-scheduled remote agents (routines). Not part of this repo's skill-authoring / review-pipeline workflow. |
 | `/security-review` | Superseded by `/code-review` specialist routing (ciso-reviewer agent fires automatically). |
 | `/simplify` | Overlaps with `/code-review`, which spins up domain specialists and produces a structured checklist. |
 | `/update-config` | Bundled generic settings.json editor. Redundant with `/review-permissions` (permissions.allow), `/claude-hook-review` (hooks), and `/skill-review` (skill bodies); remaining env/model/theme edits are trivial direct file changes. |
+| `/verify` | Manual-verification skill that drives the app to confirm a change. Same scope mismatch as `/run` — claude-config skills and hooks are verified via `pytest claude/.claude/`. |
 
 ### Re-enable for your session
 


### PR DESCRIPTION
## Summary

- Adds `loop`, `run`, `schedule`, `verify` to `skillOverrides` (`"off"`) in `claude/.claude/settings.json`.
- Updates `docs/skills.md` count (`Eight` → `Twelve`) and adds matching table rows.

## Why

After the `subagent-delegation` skill landed (#278), the skill-description budget overflowed and `/doctor` started dropping descriptions. These four bundled skills don't fit claude-config's dotfile / skill-authoring workflow:

- `/run` and `/verify` drive a project app — claude-config has no app to drive; skills/hooks are verified via `pytest claude/.claude/`.
- `/loop` and `/schedule` are interval / cron task runners — not part of the review-pipeline workflow.

Disabling them frees ~1350 chars of `skillListingBudgetFraction` (vs ~750 needed), comfortable headroom for future skill additions.

## Test plan

- [x] `pytest claude/.claude/` — passes
- [x] `ruff check claude/.claude/` — passes
- [ ] After merge + stow pull, run `/doctor` and confirm zero descriptions dropped.

## Stow reminder

Files under `claude/` are stow-distributed; every stow user picks this up on next `git pull`. Anyone who actively used `/loop`, `/run`, `/schedule`, or `/verify` can re-enable per skill in `~/.claude/settings.local.json` — the re-enable recipe is documented in the same `docs/skills.md` section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)