### PR TITLE
refactor(lovable-cloud-migration-sync): inline Step 5 check-runner dispatch rules

### DIFF
--- a/plugins/lovable-cloud/.claude-plugin/plugin.json
+++ b/plugins/lovable-cloud/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lovable-cloud",
   "description": "Skills for Lovable Cloud projects — Project/Workspace Knowledge fields, edge-function auth model, and migration-sync workflow.",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "author": {
     "name": "Cordova Strategy"
   },

--- a/plugins/lovable-cloud/skills/lovable-cloud-migration-sync/SKILL.md
+++ b/plugins/lovable-cloud/skills/lovable-cloud-migration-sync/SKILL.md
@@ -92,12 +92,15 @@ with the user.
 
 ### 5. Verify locally before deleting
 
-Run the project's verification suite via the `Agent` tool with
-`subagent_type: check-runner`. The verify entry point is responsible for
-replaying the migration set against a clean database before running tests —
-otherwise the run validates pre-replay state and the migration sync is not
-actually exercised. See `~/.claude/CLAUDE.md` "Heavy command output" for the
-rationale and spool-file convention.
+Run your project's verify entry point (e.g. `npm run verify`, `pytest`,
+`make verify` — whatever its verification command is) via the `Agent`
+tool with `subagent_type: check-runner`. Enumerate the exact command
+string in the dispatch prompt and include the absolute working directory.
+
+The verify entry point is responsible for replaying the migration set
+against a clean database before running tests — otherwise the run
+validates pre-replay state and the migration sync is not actually
+exercised.
 
 The subagent writes each command's full output to
 `${TMPDIR:-/tmp}/<command-slug>-<epoch-ms>.txt` and returns: per-command

--- a/plugins/lovable-cloud/skills/lovable-cloud-migration-sync/SKILL.md
+++ b/plugins/lovable-cloud/skills/lovable-cloud-migration-sync/SKILL.md
@@ -92,16 +92,12 @@ with the user.
 
 ### 5. Verify locally before deleting
 
-Run the full verification — `supabase db reset` followed by your project's
-verification commands — via the `Agent` tool with `subagent_type: check-runner`.
-See `~/.claude/CLAUDE.md` "Heavy command output" for the rationale and
-spool-file convention.
-
-The subagent runs `supabase db reset` first, then the verification commands in
-order. NOTICEs from `DROP IF EXISTS` on not-yet-created objects are expected
-during the reset and harmless — Lovable duplicates run later in timestamp order
-than the originals did, so the reset replays the originals' creation against
-the duplicates' drops.
+Run the project's verification suite via the `Agent` tool with
+`subagent_type: check-runner`. The verify entry point is responsible for
+replaying the migration set against a clean database before running tests —
+otherwise the run validates pre-replay state and the migration sync is not
+actually exercised. See `~/.claude/CLAUDE.md` "Heavy command output" for the
+rationale and spool-file convention.
 
 The subagent writes each command's full output to
 `${TMPDIR:-/tmp}/<command-slug>-<epoch-ms>.txt` and returns: per-command

--- a/plugins/lovable-cloud/skills/lovable-cloud-migration-sync/SKILL.md
+++ b/plugins/lovable-cloud/skills/lovable-cloud-migration-sync/SKILL.md
@@ -92,25 +92,35 @@ with the user.
 
 ### 5. Verify locally before deleting
 
-Run `supabase db reset` followed by your project's verify entry point
+**Run `supabase db reset` inline from the parent session — not the
+check-runner subagent.** The check-runner agent refuses state-mutating
+commands (`db reset`, `db push`, container start/stop, etc.) by
+charter, and a PreToolUse mutation-guard hook also denies them at the
+harness layer when the dispatcher is `check-runner`. Routing the reset
+through the subagent fails BLOCKED with no verify output.
+
+```bash
+cd <absolute repo path> && supabase db reset
+```
+
+The reset replays the full migration set against a clean database;
+without it, the verify run validates pre-replay state and the
+migration sync is not actually exercised. NOTICEs from
+`DROP IF EXISTS` on not-yet-created objects are expected during the
+reset and harmless — Lovable duplicates run later in timestamp order
+than the originals did, so the reset replays the originals' creation
+against the duplicates' drops.
+
+Once the reset completes, dispatch your project's verify entry point
 (e.g. `npm run verify`, `pytest`, `make verify` — whatever its
 verification command is) via the `Agent` tool with
-`subagent_type: check-runner`. Enumerate both commands exactly in the
-dispatch prompt and include the absolute working directory.
+`subagent_type: check-runner`. Enumerate the verify command exactly in
+the dispatch prompt and include the absolute working directory.
 
-The subagent runs `supabase db reset` first to replay the migration set
-against a clean database, then runs the verify entry point. Without the
-reset, the verify run validates pre-replay state and the migration sync
-is not actually exercised. NOTICEs from `DROP IF EXISTS` on
-not-yet-created objects are expected during the reset and harmless —
-Lovable duplicates run later in timestamp order than the originals did,
-so the reset replays the originals' creation against the duplicates'
-drops.
-
-The subagent writes each command's full output to
+The subagent writes the command's full output to
 `${TMPDIR:-/tmp}/<command-slug>-<epoch-ms>.txt` and returns: per-command
 name/exit code/pass-fail, smallest failing excerpt, overall PASS or FAIL, and
-the output file paths. If a step fails, Read the relevant output file rather
+the output file paths. If verify fails, Read the relevant output file rather
 than re-running the suite. Do not proceed to step 6 (delete originals) on FAIL.
 
 **Inline exception.** Single-test re-runs during debugging can stay inline.

--- a/plugins/lovable-cloud/skills/lovable-cloud-migration-sync/SKILL.md
+++ b/plugins/lovable-cloud/skills/lovable-cloud-migration-sync/SKILL.md
@@ -92,15 +92,20 @@ with the user.
 
 ### 5. Verify locally before deleting
 
-Run your project's verify entry point (e.g. `npm run verify`, `pytest`,
-`make verify` — whatever its verification command is) via the `Agent`
-tool with `subagent_type: check-runner`. Enumerate the exact command
-string in the dispatch prompt and include the absolute working directory.
+Run `supabase db reset` followed by your project's verify entry point
+(e.g. `npm run verify`, `pytest`, `make verify` — whatever its
+verification command is) via the `Agent` tool with
+`subagent_type: check-runner`. Enumerate both commands exactly in the
+dispatch prompt and include the absolute working directory.
 
-The verify entry point is responsible for replaying the migration set
-against a clean database before running tests — otherwise the run
-validates pre-replay state and the migration sync is not actually
-exercised.
+The subagent runs `supabase db reset` first to replay the migration set
+against a clean database, then runs the verify entry point. Without the
+reset, the verify run validates pre-replay state and the migration sync
+is not actually exercised. NOTICEs from `DROP IF EXISTS` on
+not-yet-created objects are expected during the reset and harmless —
+Lovable duplicates run later in timestamp order than the originals did,
+so the reset replays the originals' creation against the duplicates'
+drops.
 
 The subagent writes each command's full output to
 `${TMPDIR:-/tmp}/<command-slug>-<epoch-ms>.txt` and returns: per-command


### PR DESCRIPTION
## Summary

- Step 5 of `lovable-cloud-migration-sync` now runs `supabase db reset` inline from the parent session (not the check-runner subagent), then dispatches only the project's verify entry point (e.g. `npm run verify`, `pytest`, `make verify`) via the `Agent` tool with `subagent_type: check-runner`. The check-runner agent refuses state-mutating commands by charter, and the PreToolUse mutation-guard hook (shipped in #287) also denies them at the harness layer — routing the reset through the subagent fails BLOCKED with no verify output.
- Inlines the two `check-runner` dispatch rules Step 5 actually needs (enumerate the exact command; include the absolute working directory) rather than cross-referencing them. The prior pointer to `~/.claude/CLAUDE.md` "Heavy command output" was dead — that section was extracted into the `subagent-delegation` skill in a prior commit.
- Adds explicit rationale for why the reset matters ("without the reset, the verify run validates pre-replay state and the migration sync is not actually exercised") and preserves the NOTICE rationale (DROP IF EXISTS during reset is expected and harmless).
- Adds `pytest` / `make verify` as alternative verify entry points alongside `npm run verify` — explicit acknowledgement that not every Lovable consumer is npm-shaped.
- Bumps `lovable-cloud` plugin 2.1.2 → 2.2.0 (cumulative minor — procedural mechanism in Step 5 changed; no skill, hook, or trigger added/removed).

## Context

Replaces #283, which added an edge-runtime mount precondition to this same Step 5. That was the wrong fix at the wrong layer — edge-runtime mount discipline is a stack-state concern owned by wherever `check-runner` is invoked, not by this skill's body.

An earlier revision of this PR removed `supabase db reset` from Step 5 entirely on the premise that the project's verify entry point would replay the migration set. That premise was incorrect: default Lovable verify scripts (lint + typecheck + tests) do not run `supabase db reset`, so the delegated step would silently skip the replay and the migration sync would validate pre-replay state. A later revision restored the reset as a `check-runner` dispatch — but the check-runner agent's charter explicitly refuses state-mutating commands, and the harness-layer mutation guard from #287 enforces the same. The final shape returns the reset to the parent session, which owns the state mutation directly, and routes only the read-only verify entry point through the subagent.

A follow-up effort (planned in a separate session) will elevate edge-runtime mount enforcement from a private-project repo into the `lovable-cloud` plugin as a `PreToolUse` hook. That hook backs a different invariant (edge-runtime container mount alignment with the calling worktree); migration replay stays the responsibility of this skill's explicit reset step.

## Post-merge install

Consuming repos refresh with:

```
claude plugin install lovable-cloud@claude-config --scope project
```

## Test plan

- [ ] Read the diff and confirm Step 5 reads cleanly without prior-PR context.
- [ ] Confirm `supabase db reset` runs from the parent (not the check-runner subagent) and the WHY rationale survives.
- [ ] Confirm only the verify entry point is dispatched to `check-runner`, not the reset.
- [ ] Confirm no remaining cross-references to the removed "Heavy command output" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)