### PR TITLE
test(skills): enforce description cap and strict YAML frontmatter

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.detect.outputs.changed == 'true'
-        run: pip install 'pytest==8.*' 'ruff==0.6.*'
+        run: pip install 'pytest==8.*' 'ruff==0.6.*' 'pyyaml==6.*'
 
       - name: Run tests
         if: steps.detect.outputs.changed == 'true'

--- a/claude/.claude/skills/code-review/SKILL.md
+++ b/claude/.claude/skills/code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-review
-description: Principal engineer code review of changed/new code before presenting to user. TRIGGER when: code has been written or modified and is about to be presented to the user, or the user explicitly asks for a code review. DO NOT TRIGGER when: the change is cosmetic-only (typo, formatting, copy polish, CSS color/font tweaks with no behavioral delta), when staged changes include only SKILL.md files (use skill-review instead), when staged changes include only plan files in .claude/plans/ (use plan-review instead), or when a fresh review-markers/ entry already covers the staged diff.
+description: "Principal engineer code review of changed/new code before presenting to user. TRIGGER when: code has been written or modified and is about to be presented to the user, or the user explicitly asks for a code review. DO NOT TRIGGER when: the change is cosmetic-only (typo, formatting, copy polish, CSS color/font tweaks with no behavioral delta), when staged changes include only SKILL.md files (use skill-review instead), when staged changes include only plan files in .claude/plans/ (use plan-review instead), or when a fresh review-markers/ entry already covers the staged diff."
 allowed-tools: Read, Grep, Glob, Bash
 ---
 

--- a/claude/.claude/skills/respond-pr/SKILL.md
+++ b/claude/.claude/skills/respond-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: respond-pr
-description: Read and respond to PR review comments on the current branch's pull request. TRIGGER when: replying to PR review comments, OR posting any comment/reply to a GitHub pull request — even as part of a larger task. Enforces required attribution prefix. DO NOT TRIGGER when: on the default branch with no PR open, when there are no unread review comments, or when the conversation is about a different PR than the current branch's.
+description: "Read and respond to PR review comments on the current branch's pull request. TRIGGER when: replying to PR review comments, OR posting any comment/reply to a GitHub pull request — even as part of a larger task. Enforces required attribution prefix. DO NOT TRIGGER when: on the default branch with no PR open, when there are no unread review comments, or when the conversation is about a different PR than the current branch's."
 argument-hint: "[PR number]"
 ---
 

--- a/claude/.claude/skills/tests/test_skills.py
+++ b/claude/.claude/skills/tests/test_skills.py
@@ -32,10 +32,17 @@ import json
 from pathlib import Path
 
 import pytest
+import yaml
 
 SKILLS_DIR = Path(__file__).resolve().parent.parent.parent / "skills"
 # Plugins live two levels above the .claude/ dir: <repo>/plugins/<name>/skills/<skill>/SKILL.md
 _PLUGINS_DIR = SKILLS_DIR.parent.parent.parent / "plugins"
+
+# Per https://code.claude.com/docs/en/skills.md: "the combined `description`
+# and `when_to_use` text is truncated at 1,536 characters in the skill
+# listing to reduce context usage." Configurable via maxSkillDescriptionChars
+# setting; 1,536 is the default the harness applies when no override is set.
+MAX_SKILL_DESCRIPTION_CHARS = 1536
 
 
 def _skill_file(skill_name: str) -> Path:
@@ -65,6 +72,26 @@ def _skill_description(skill_name: str) -> str:
     # Frontmatter lives between the opening --- and the closing ---.
     closing = content.index("---", 3)
     return content[3:closing]
+
+
+def _skill_frontmatter(skill_name: str) -> dict:
+    """Return the parsed YAML frontmatter of a skill's SKILL.md.
+
+    YAML parsing (vs raw-text scanning in _skill_description) is required
+    when measuring field lengths: block-folded scalars (`description: >`)
+    render newlines as spaces, and quoted strings unescape — so the
+    rendered length the harness sees differs from the raw text length.
+
+    Raises yaml.YAMLError on invalid frontmatter — see
+    TestModelInvokableSkillFrontmatterIsStrictYaml for the dedicated check
+    that produces a focused failure message in that case.
+    """
+    skill_file = _skill_file(skill_name)
+    content = skill_file.read_text()
+    if not content.startswith("---"):
+        return {}
+    closing = content.index("---", 3)
+    return yaml.safe_load(content[3:closing]) or {}
 
 
 def _specialist_skills() -> list[str]:
@@ -307,6 +334,65 @@ class TestProjectLayerUsesReadNotSkill:
         assert "Skill tool" not in section, (
             f"{skill_name}/SKILL.md project-layer section still mentions 'Skill tool'; "
             f"Skill() invocation is blocked when the layer carries disable-model-invocation: true"
+        )
+
+
+class TestModelInvokableSkillFrontmatterIsStrictYaml:
+    """Every model-invokable skill's frontmatter must parse as strict YAML.
+
+    The Claude Code harness uses a lenient YAML parser that accepts inline
+    unquoted scalars containing `: ` (e.g., `description: TRIGGER when:
+    ...`). Relying on that leniency is fragile — any parser-strictness
+    change in the harness would silently truncate the description at the
+    first `: `, dropping the TRIGGER / DO NOT TRIGGER blocks. Block-fold
+    (`description: >`) or double-quote any value containing `: `.
+    """
+
+    MODEL_INVOKABLE_SKILLS = _model_invokable_skills()
+
+    @pytest.mark.parametrize("skill_name", MODEL_INVOKABLE_SKILLS)
+    def test_frontmatter_parses_strictly(self, skill_name):
+        skill_file = _skill_file(skill_name)
+        content = skill_file.read_text()
+        assert content.startswith("---"), (
+            f"{skill_name}/SKILL.md is missing the opening YAML frontmatter delimiter"
+        )
+        closing = content.index("---", 3)
+        raw = content[3:closing]
+        try:
+            yaml.safe_load(raw)
+        except yaml.YAMLError as exc:
+            raise AssertionError(
+                f"{skill_name}/SKILL.md frontmatter is not strict YAML: {exc}. "
+                f"If a value contains ': ', block-fold (`description: >`) or "
+                f"double-quote it."
+            ) from exc
+
+
+class TestModelInvokableDescriptionLength:
+    """Enforce the harness's per-skill description-length cap.
+
+    The Claude Code harness truncates each skill listing entry's combined
+    `description` + `when_to_use` at MAX_SKILL_DESCRIPTION_CHARS. A skill
+    that exceeds the cap has the tail of its description silently dropped
+    from the system prompt — losing TRIGGER / DO NOT TRIGGER discipline if
+    that block is what gets cut. User-only command skills
+    (disable-model-invocation: true) are excluded because their descriptions
+    are suppressed from the listing entirely.
+    """
+
+    MODEL_INVOKABLE_SKILLS = _model_invokable_skills()
+
+    @pytest.mark.parametrize("skill_name", MODEL_INVOKABLE_SKILLS)
+    def test_description_within_harness_cap(self, skill_name):
+        fm = _skill_frontmatter(skill_name)
+        description = fm.get("description", "") or ""
+        when_to_use = fm.get("when_to_use", "") or ""
+        rendered = len(description) + len(when_to_use)
+        assert rendered <= MAX_SKILL_DESCRIPTION_CHARS, (
+            f"{skill_name}/SKILL.md description+when_to_use is {rendered} chars, "
+            f"exceeds harness cap of {MAX_SKILL_DESCRIPTION_CHARS}; the tail will "
+            f"be truncated from the system-prompt listing"
         )
 
 


### PR DESCRIPTION
## Summary

- Adds `TestModelInvokableDescriptionLength` — parametrized pytest catching skills whose rendered `description` + `when_to_use` would exceed the harness's 1,536-char per-skill listing cap. The harness silently truncates above that, losing the tail of the description (TRIGGER / DO NOT TRIGGER blocks if they sit at the end). Cap value cited to https://code.claude.com/docs/en/skills.md.
- Adds `TestModelInvokableSkillFrontmatterIsStrictYaml` — parametrized pytest rejecting inline-unquoted frontmatter values containing `: `. The Claude Code harness's parser currently accepts these (e.g. `description: TRIGGER when: ...`), but strict YAML parsers don't — so any future parser-strictness change would silently truncate descriptions at the first `: `, dropping TRIGGER blocks.
- Adds a `_skill_frontmatter()` helper that parses (rather than raw-scans) YAML so block-folded scalars (`description: >`) and quoted strings are measured at their rendered length, not their source-text length.
- Switches `code-review` and `respond-pr` SKILL.md `description:` values to double-quoted form to satisfy the new strict-YAML check (those two were the only skills relying on lenient parsing; verified the harness was reading them in full before the change, so this is fragility removal, not bug fix).
- Adds `pyyaml==6.*` to the CI install line so the new tests' `import yaml` resolves under the workflow's pip environment.

## Test plan

- [x] `pytest claude/.claude/` passes
- [x] `ruff check claude/.claude/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)