### PR TITLE
refactor(claude-md): add prose-placement bullet under Code Comments umbrella

### DIFF
--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -60,7 +60,13 @@
 - Don't add globs (`Bash(pytest *)`, `Bash(npm run *)`) to `permissions.allow`. Globs widen the surface to flag injection, command chaining, and shell-expansion attacks — see `claude/.claude/skills/review-permissions/SKILL.md` checklist items 1–9. Use exact-match rules (`Bash(pytest)`, `Bash(npm run verify)`) instead.
 - `.claude/settings.json` vs `.claude/settings.local.json` scoping: project-shared rules (permissions, hooks, skillOverrides that every engineer on the project needs) go in committed `.claude/settings.json`. Personal-machine-only rules (per-machine tooling, individual preferences) go in gitignored `.claude/settings.local.json`. Before adding a rule, ask: would another engineer on this project need this? If yes → `settings.json`. If no → `settings.local.json`.
 
-## Code Comments and Durable Documentation
+## Code Comments, Documentation, and Prose
+
+### Where to put it
+
+- **Place prose where its reader and altitude match.** Right text in the wrong file is a recurring regression class: a feature deep-dive in a README overview, implementation FYI in an agent spec, a doc back-reference from a skill body. The cost lands on the wrong reader — humans drown at the wrong altitude, the model pays tokens for non-instruction, reviewers ask "why is this here?" Test each paragraph's placement as you write: does it belong here? The fix is almost always relocation, not deletion.
+
+### When to write it and what to include
 
 Code comments and durable in-repo documentation (REFERENCES.md, doc files, README sections) must be readable by a future contributor who has not read the PR description, commit message, or planning document. In particular:
 


### PR DESCRIPTION
## Summary

Restructures the `Code Comments and Durable Documentation` section of
`claude/.claude/CLAUDE.md` into `Code Comments, Documentation, and Prose`
with two subsections:

- **Where to put it** (new) — adds a single bullet on prose placement:
  *Place prose where its reader and altitude match*. Includes the
  failure-mode examples (README altitude mismatch, agent-spec FYI
  dumps, doc back-references from skills) and the write-time test
  *"does it belong here?"*
- **When to write it and what to include** (existing three bullets,
  unchanged: no PR-defined terminology, no `used to be X` framing,
  self-test for survivability).

The existing section was the natural umbrella because durability and
placement are sibling write-time disciplines. Placement comes first:
if you can't decide where, durability is moot.

## Why

Recurring class of PR feedback where prose lands in the wrong file —
e.g. README walkthrough altitude issues (#280), agent-spec
implementation FYI (#287), doc back-references inside skill bodies
(#278). No existing CLAUDE.md rule covered prose **placement**; this
adds the missing write-time discipline so Claude self-corrects before
review-time, rather than relying on the reviewer to catch it.

The new bullet is ~80 words, comparable to other CLAUDE.md bullets
(`Compounding defensive layers` ~75 words, `Default-suspect
over-powered primitives` ~95 words). CLAUDE.md grows 74 → 80 lines —
well under the 200-line cap.

## Test plan

- [x] `pytest claude/.claude/` passes (verified locally — green)
- [x] `ruff check claude/.claude/` passes (verified locally — green)
- [ ] Reviewer agrees `Where to put it` belongs before
  `When to write it and what to include` (placement is foundational
  to durability)
- [ ] Reviewer agrees the umbrella heading
  `Code Comments, Documentation, and Prose` accurately covers both
  subsections (the new bullet applies to all prose, not just durable
  docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)