### PR TITLE
GH-241: extend skill-review gate to agent files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,8 @@ not want to extend. Mirror existing entries when in doubt.
 `/plan-it` is the prescribed entry for plan creation. `/plan-review` and
 `/code-review` are mandatory pipeline steps before PR handoff — both are
 hook-enforced (see README "Workflow" for the full skill invocation order and
-which hook gates each transition). When staged changes include a SKILL.md,
+which hook gates each transition). When staged changes include a SKILL.md
+or an agent file (`claude/.claude/agents/*.md` or `plugins/*/agents/*.md`),
 `/skill-review` is also required; `/code-review` invokes it automatically.
 
 ## Plans in this repo affect all stow users

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ flowchart LR
 - **`/plan-it`** — produce the implementation plan.
 - **`/plan-review`** — review the plan against domain checklists.
 - **`/code-review`** — principal-engineer review with ripple-effect triage.
-- **`/skill-review`** — behavioral-equivalence audit when a `SKILL.md` changes. (Provided by the `skill-review@claude-config` plugin — see [Project-scoped plugins](docs/skills.md#project-scoped-plugins).)
+- **`/skill-review`** — behavioral-equivalence audit when a `SKILL.md` or agent file (`claude/.claude/agents/*.md` or `plugins/*/agents/*.md`) changes. (Provided by the `skill-review@claude-config` plugin — see [Project-scoped plugins](docs/skills.md#project-scoped-plugins).)
 - **`/ready-for-review`** — final tests + cumulative-diff review before push.
 - **`/respond-pr`** — fetch and reply to all PR comments with `[Claude Code]` attribution.
 
@@ -142,7 +142,7 @@ flowchart LR
 |---|---|---|
 | `require-plan-review.sh` | `Write`/`Edit` while an uncommitted or modified plan file exists in `.claude/plans/` | `/plan-review` per-session marker |
 | `require-code-review.sh` | `git commit` | `/code-review` run against current staged state |
-| `require-skill-review.sh` | `git commit` when staged changes include a `SKILL.md` | `/skill-review` behavioral-equivalence audit (ships with `skill-review@claude-config` plugin) |
+| `require-skill-review.sh` | `git commit` when staged changes include a `SKILL.md` or agent file | `/skill-review` behavioral-equivalence audit (ships with `skill-review@claude-config` plugin) |
 | `deny-private-project-refs.sh` | `git commit`, `gh pr create`, `gh pr edit`, mutating `gh api` | Clean the flagged tracker ID or private-project name from the diff/PR body |
 | `deny-pii-in-commits.sh` | `git commit` when PII/PHI is in the staged diff or commit message (opt-in) | Remove the flagged content, or `exclude:` a synthetic-fixture path |
 | `deny-data-file-reads.sh` | `Read` of a data-shaped file (opt-in) | No clear — inspect data files outside Claude |
@@ -173,7 +173,7 @@ This repo exposes a marketplace via `.claude-plugin/marketplace.json`. Each plug
 `./install.sh` registers the `claude-config` marketplace automatically. To register it manually (without running `install.sh`), run `claude plugin marketplace add <path-to-claude-config>`. Then install any of the plugins below at project scope:
 
 - **`lovable-cloud`** — Skills for Lovable Cloud projects: Project/Workspace Knowledge fields, edge-function auth model (ES256 gateway constraint, two-tier auth), and migration-sync workflow. `claude plugin install lovable-cloud@claude-config --scope project`
-- **`skill-review`** — Behavioral-equivalence audit for `SKILL.md` changes; gates `git commit` when staged changes include a `SKILL.md`. `claude plugin install skill-review@claude-config --scope project`
+- **`skill-review`** — Behavioral-equivalence audit for `SKILL.md` and agent-file changes (`claude/.claude/agents/*.md` and `plugins/*/agents/*.md`); gates `git commit` when those files are staged. `claude plugin install skill-review@claude-config --scope project`
 - **`claude-hook-review`** — Review playbook for `.claude/hooks/*.sh` and `settings.json` hook entries: event/matcher selection, path resolution, script skeleton, fail-open/fail-closed posture, dispatch drift, and the 9-item review checklist. `claude plugin install claude-hook-review@claude-config --scope project`
 
 ### Agents

--- a/claude/.claude/hooks/tests/test_marker_script.py
+++ b/claude/.claude/hooks/tests/test_marker_script.py
@@ -308,6 +308,68 @@ class TestMarkerScriptEmptyStagedGuard:
         marker_dir = isolated_home / ".claude" / "skill-review-markers"
         assert len(list(marker_dir.iterdir())) == 1
 
+    # ── skill-review: agent-file coverage (claude/.claude/agents/*.md + plugins/*/agents/*.md) ──
+
+    def _make_stowed_agent(self, repo):
+        """Create a tracked agent file inside the repo at the expected pathspec."""
+        agent_dir = repo / "claude" / ".claude" / "agents"
+        agent_dir.mkdir(parents=True)
+        agent_md = agent_dir / "test-agent.md"
+        agent_md.write_text("---\nname: test-agent\ndescription: x\n---\n\nbody\n")
+        subprocess.run(["git", "add", str(agent_md)], cwd=repo, check=True)
+        subprocess.run(
+            ["git", "commit", "-q", "-m", "add test agent"],
+            cwd=repo,
+            check=True,
+        )
+        return agent_md
+
+    def _make_plugin_agent(self, repo):
+        """Create a tracked plugin agent file at plugins/<name>/agents/<name>.md."""
+        agent_dir = repo / "plugins" / "some-plugin" / "agents"
+        agent_dir.mkdir(parents=True)
+        agent_md = agent_dir / "test-agent.md"
+        agent_md.write_text("---\nname: test-agent\ndescription: x\n---\n\nbody\n")
+        subprocess.run(["git", "add", str(agent_md)], cwd=repo, check=True)
+        subprocess.run(
+            ["git", "commit", "-q", "-m", "add plugin agent"],
+            cwd=repo,
+            check=True,
+        )
+        return agent_md
+
+    def test_skill_review_unstaged_stowed_agent_exits_2(self, isolated_home, git_repo):
+        """Guard fires when staged diff is empty but an unstaged stowed-agent change exists."""
+        self._seed_session(isolated_home)
+        agent_md = self._make_stowed_agent(git_repo)
+        agent_md.write_text("---\nname: test-agent\ndescription: x\n---\n\nmodified\n")
+        result = _run(["write", "skill-review"], cwd=git_repo, home=isolated_home)
+        assert result.returncode == 2
+        assert "git add" in result.stderr
+        assert "/skill-review" in result.stderr
+
+    def test_skill_review_staged_stowed_agent_writes_marker(self, isolated_home, git_repo):
+        """Guard must NOT fire when a stowed-agent change is staged; marker writes successfully."""
+        self._seed_session(isolated_home)
+        agent_md = self._make_stowed_agent(git_repo)
+        agent_md.write_text("---\nname: test-agent\ndescription: x\n---\n\nupdated\n")
+        subprocess.run(["git", "add", str(agent_md)], cwd=git_repo, check=True)
+        result = _run(["write", "skill-review"], cwd=git_repo, home=isolated_home)
+        assert result.returncode == 0, result.stderr
+        marker_dir = isolated_home / ".claude" / "skill-review-markers"
+        assert len(list(marker_dir.iterdir())) == 1
+
+    def test_skill_review_staged_plugin_agent_writes_marker(self, isolated_home, git_repo):
+        """Guard must NOT fire when a plugin-agent change is staged; marker writes successfully."""
+        self._seed_session(isolated_home)
+        agent_md = self._make_plugin_agent(git_repo)
+        agent_md.write_text("---\nname: test-agent\ndescription: x\n---\n\nupdated\n")
+        subprocess.run(["git", "add", str(agent_md)], cwd=git_repo, check=True)
+        result = _run(["write", "skill-review"], cwd=git_repo, home=isolated_home)
+        assert result.returncode == 0, result.stderr
+        marker_dir = isolated_home / ".claude" / "skill-review-markers"
+        assert len(list(marker_dir.iterdir())) == 1
+
 
 class TestMarkerScriptStalePidLookup:
     """Regression guard: `activate` must stamp the live Claude PID into the

--- a/claude/.claude/hooks/tests/test_require_skill_review.py
+++ b/claude/.claude/hooks/tests/test_require_skill_review.py
@@ -48,6 +48,30 @@ def _stage_plugin_skill_change(git_repo):
     )
 
 
+def _stage_stowed_agent_change(git_repo):
+    """Stage an agent change at claude/.claude/agents/<name>.md."""
+    agent_file = git_repo / "claude" / ".claude" / "agents" / "test-agent.md"
+    agent_file.parent.mkdir(parents=True, exist_ok=True)
+    agent_file.write_text("---\nname: test-agent\ndescription: x\n---\n\nbody\n")
+    subprocess.run(
+        ["git", "add", str(agent_file.relative_to(git_repo))],
+        cwd=git_repo,
+        check=True,
+    )
+
+
+def _stage_plugin_agent_change(git_repo):
+    """Stage an agent change at plugins/<name>/agents/<name>.md."""
+    agent_file = git_repo / "plugins" / "some-plugin" / "agents" / "test-agent.md"
+    agent_file.parent.mkdir(parents=True, exist_ok=True)
+    agent_file.write_text("---\nname: test-agent\ndescription: x\n---\n\nbody\n")
+    subprocess.run(
+        ["git", "add", str(agent_file.relative_to(git_repo))],
+        cwd=git_repo,
+        check=True,
+    )
+
+
 class TestRequireSkillReview:
     # The marker layout is ~/.claude/skill-review-markers/<repo-hash>.<session_id>.
     # The hook reads session_id from its JSON payload and checks the
@@ -343,6 +367,92 @@ class TestRequireSkillReview:
                 cwd=git_repo,
             )
             == "deny"
+        )
+
+    def test_stowed_agent_no_marker_denies_commit(self, isolated_home, git_repo):
+        """Stowed agent file (claude/.claude/agents/*.md) is gated like SKILL.md."""
+        _stage_stowed_agent_change(git_repo)
+        assert (
+            run_hook(
+                SKILL_REVIEW_HOOK,
+                bash_input("git commit -m foo", session_id=DEFAULT_TEST_SESSION_ID),
+                cwd=git_repo,
+            )
+            == "deny"
+        )
+
+    def test_stowed_agent_correct_hash_marker_allows(self, isolated_home, git_repo):
+        """Stowed agent file allows when the marker covers the agent diff hash."""
+        _stage_stowed_agent_change(git_repo)
+        write_skill_review_marker(isolated_home, git_repo)
+        assert (
+            run_hook(
+                SKILL_REVIEW_HOOK,
+                bash_input("git commit -m foo", session_id=DEFAULT_TEST_SESSION_ID),
+                cwd=git_repo,
+            )
+            == "allow"
+        )
+
+    def test_plugin_agent_no_marker_denies_commit(self, isolated_home, git_repo):
+        """Plugin-path agent file (plugins/*/agents/*.md) is gated like SKILL.md."""
+        _stage_plugin_agent_change(git_repo)
+        assert (
+            run_hook(
+                SKILL_REVIEW_HOOK,
+                bash_input("git commit -m foo", session_id=DEFAULT_TEST_SESSION_ID),
+                cwd=git_repo,
+            )
+            == "deny"
+        )
+
+    def test_plugin_agent_correct_hash_marker_allows(self, isolated_home, git_repo):
+        """Plugin-path agent file allows when the marker covers the agent diff hash."""
+        _stage_plugin_agent_change(git_repo)
+        write_skill_review_marker(isolated_home, git_repo)
+        assert (
+            run_hook(
+                SKILL_REVIEW_HOOK,
+                bash_input("git commit -m foo", session_id=DEFAULT_TEST_SESSION_ID),
+                cwd=git_repo,
+            )
+            == "allow"
+        )
+
+    def test_mixed_skill_and_agent_stale_skill_only_marker_denies(
+        self, isolated_home, git_repo
+    ):
+        """A marker written for a skill-only diff is stale when an agent file is later
+        staged — the combined hash differs from the skill-only hash, so the gate must deny."""
+        _stage_skill_change(git_repo)
+        write_skill_review_marker(isolated_home, git_repo)
+        # Stage an additional agent file; combined hash now differs from stored marker.
+        _stage_stowed_agent_change(git_repo)
+        assert (
+            run_hook(
+                SKILL_REVIEW_HOOK,
+                bash_input("git commit -m foo", session_id=DEFAULT_TEST_SESSION_ID),
+                cwd=git_repo,
+            )
+            == "deny"
+        )
+
+    def test_agent_marker_survives_non_agent_restaging(self, git_repo, isolated_home):
+        """Re-staging a non-reviewed file does not invalidate an agent-file marker."""
+        _stage_stowed_agent_change(git_repo)
+        write_skill_review_marker(isolated_home, git_repo)
+        # Stage an unrelated file outside the gated pathspecs.
+        unrelated = git_repo / "claude" / ".claude" / "settings.json"
+        unrelated.parent.mkdir(parents=True, exist_ok=True)
+        unrelated.write_text('{"additional": true}')
+        subprocess.run(["git", "add", "claude/.claude/settings.json"], cwd=git_repo, check=True)
+        assert (
+            run_hook(
+                SKILL_REVIEW_HOOK,
+                bash_input("git commit -m test", session_id=DEFAULT_TEST_SESSION_ID),
+                cwd=git_repo,
+            )
+            == "allow"
         )
 
     def test_plugin_lib_sh_matches_stowed_lib_sh(self):

--- a/claude/.claude/scripts/marker.sh
+++ b/claude/.claude/scripts/marker.sh
@@ -134,11 +134,12 @@ case "$SUBCOMMAND" in
       skill-review)
         SESSION_ID=$(_resolve_session_id) || exit 2
         REPO_HASH=$(_resolve_repo_hash) || exit 2
-        _guard_staged_vs_unstaged skill-review 'claude/.claude/skills/**/SKILL.md' 'plugins/*/skills/**/SKILL.md'
+        _guard_staged_vs_unstaged skill-review 'claude/.claude/skills/**/SKILL.md' 'plugins/*/skills/**/SKILL.md' 'claude/.claude/agents/*.md' 'plugins/*/agents/*.md'
         mkdir -p "$HOME/.claude/skill-review-markers"
-        # The pathspecs are load-bearing: scope the hash to SKILL.md diffs only (both stowed
-        # and plugin locations), matching what require-skill-review.sh checks at commit time.
-        git diff --cached -- 'claude/.claude/skills/**/SKILL.md' 'plugins/*/skills/**/SKILL.md' | sha256sum | awk '{print $1}' \
+        # The pathspecs are load-bearing: scope the hash to SKILL.md and agent-file
+        # diffs (both stowed and plugin locations), matching what
+        # require-skill-review.sh checks at commit time.
+        git diff --cached -- 'claude/.claude/skills/**/SKILL.md' 'plugins/*/skills/**/SKILL.md' 'claude/.claude/agents/*.md' 'plugins/*/agents/*.md' | sha256sum | awk '{print $1}' \
           > "$HOME/.claude/skill-review-markers/$REPO_HASH.$SESSION_ID"
         ;;
       plan-review)

--- a/claude/.claude/tests/helpers.py
+++ b/claude/.claude/tests/helpers.py
@@ -221,7 +221,16 @@ def skill_review_marker_path(home: Path, repo: Path, session_id: str = DEFAULT_T
 
 def write_skill_review_marker(home: Path, repo: Path, session_id: str = DEFAULT_TEST_SESSION_ID) -> None:
     diff = subprocess.run(
-        ["git", "diff", "--cached", "--", "claude/.claude/skills/**/SKILL.md", "plugins/*/skills/**/SKILL.md"],
+        [
+            "git",
+            "diff",
+            "--cached",
+            "--",
+            "claude/.claude/skills/**/SKILL.md",
+            "plugins/*/skills/**/SKILL.md",
+            "claude/.claude/agents/*.md",
+            "plugins/*/agents/*.md",
+        ],
         capture_output=True,
         check=True,
         cwd=repo,

--- a/plugins/skill-review/hooks/require-skill-review.sh
+++ b/plugins/skill-review/hooks/require-skill-review.sh
@@ -10,8 +10,8 @@
 # How it works:
 # - The /skill-review skill writes
 #   ~/.claude/skill-review-markers/<repo-hash>.<session_id> with the sha256 hash
-#   of `git diff --cached -- 'claude/.claude/skills/**/SKILL.md' 'plugins/*/skills/**/SKILL.md'` when the review
-#   is clean. The marker lives under $HOME (not inside the repo) so it never
+#   of `git diff --cached -- 'claude/.claude/skills/**/SKILL.md' 'plugins/*/skills/**/SKILL.md' 'claude/.claude/agents/*.md' 'plugins/*/agents/*.md'`
+#   when the review is clean. The marker lives under $HOME (not inside the repo) so it never
 #   pollutes `git status` or risks being accidentally committed.
 # - This hook reads session_id from its JSON payload, recomputes the same
 #   path-scoped diff hash at commit time, and compares against THIS session's
@@ -23,9 +23,9 @@
 #   each other's markers when they stage different diffs. Each session
 #   writes its own marker; the gate checks the calling session's marker
 #   specifically.
-# - The marker is scoped to SKILL.md diffs only (not the full staged diff),
-#   so re-staging non-SKILL.md files after a clean skill-review does not
-#   invalidate the marker.
+# - The marker is scoped to SKILL.md and agent-file diffs only (not the full
+#   staged diff), so re-staging unrelated files after a clean skill-review
+#   does not invalidate the marker.
 
 . "$(dirname "$0")/_lib.sh"
 
@@ -47,9 +47,9 @@ if [ -z "$REPO_ROOT" ]; then
   exit 0
 fi
 
-# Early exit: if no SKILL.md files are staged, this hook is a no-op.
-# Commits that don't touch any skill file are not gated by skill-review.
-SKILL_DIFF=$(git diff --cached --name-only -- 'claude/.claude/skills/**/SKILL.md' 'plugins/*/skills/**/SKILL.md')
+# Early exit: if no SKILL.md or agent files are staged, this hook is a no-op.
+# Commits that don't touch any reviewed instruction file are not gated by skill-review.
+SKILL_DIFF=$(git diff --cached --name-only -- 'claude/.claude/skills/**/SKILL.md' 'plugins/*/skills/**/SKILL.md' 'claude/.claude/agents/*.md' 'plugins/*/agents/*.md')
 if [ -z "$SKILL_DIFF" ]; then
   exit 0
 fi
@@ -62,7 +62,7 @@ fi
 
 REPO_HASH=$(_marker_lib_repo_hash "$REPO_ROOT")
 SESSION_ID=$(printf '%s\n' "$INPUT" | jq -r '.session_id // empty')
-CURRENT_HASH=$(git diff --cached -- 'claude/.claude/skills/**/SKILL.md' 'plugins/*/skills/**/SKILL.md' | sha256sum | awk '{print $1}')
+CURRENT_HASH=$(git diff --cached -- 'claude/.claude/skills/**/SKILL.md' 'plugins/*/skills/**/SKILL.md' 'claude/.claude/agents/*.md' 'plugins/*/agents/*.md' | sha256sum | awk '{print $1}')
 
 # Empty session_id (older Claude Code versions or payload-schema drift) can't
 # key a per-session marker — fall through to deny.
@@ -81,6 +81,6 @@ fi
 # Build the reason as a bash variable so the conditional marker-chain
 # note can be interpolated; jq -Rs handles JSON-encoding safely
 # regardless of what characters appear in the appended note.
-REASON="Commit blocked by skill-review gate: Staged skill changes have not been audited by /skill-review. Run /skill-review on the staged SKILL.md diff; the skill must produce an explicit behavioral-equivalence table for any removed or shortened lines before committing."
+REASON="Commit blocked by skill-review gate: Staged SKILL.md or agent-file changes have not been audited by /skill-review. Run /skill-review on the staged diff; the skill must produce an explicit behavioral-equivalence table for any removed or shortened lines before committing."
 REASON_JSON=$(printf '%s' "$REASON" | jq -Rs .)
 printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' "$REASON_JSON"

--- a/plugins/skill-review/skills/skill-review/REFERENCES.md
+++ b/plugins/skill-review/skills/skill-review/REFERENCES.md
@@ -1,5 +1,31 @@
 # skill-review — References
 
+## Anthropic subagent frontmatter contract
+
+Primary source: <https://code.claude.com/docs/en/sub-agents.md>. Verbatim
+quotes for the rules encoded in §1 (agent frontmatter) and §7 item 1b:
+
+- **Required fields:** "name (required), description (required)" — only
+  these two are required; everything else is optional.
+- **Name vs. filename:** "The name is used to invoke the subagent and
+  doesn't need to match the filename." (Inverse of the SKILL.md rule.)
+- **`tools` (not `allowed-tools`):** "tools (optional, defaults to all
+  inherited tools): Comma-separated list of allowed tools."
+- **`disallowedTools` precedence:** "disallowedTools (optional): Tools
+  the subagent cannot use. This is enforced even if listed in tools."
+- **`model` values:** "model (optional, defaults to inherit): Specify
+  which model to use. Options: sonnet, haiku, opus, or a specific
+  model name like claude-sonnet-4-5. Use inherit to use the same model
+  as the parent."
+- **`maxTurns`:** "maxTurns (optional): Maximum number of turns the
+  subagent can take before stopping."
+
+The TRIGGER / DO NOT TRIGGER framing for agent descriptions is a
+**repo convention**, not a docs requirement — the docs describe the
+description as plain English "when Claude should delegate." Item 1b
+of §7 in SKILL.md applies the convention to routed-reviewer agents
+only; executor-style agents (e.g., `check-runner`) are exempt.
+
 ## Why skill-creator is disabled in this repo
 
 `skill-creator` (Anthropic's `claude-plugins-official` plugin) and

--- a/plugins/skill-review/skills/skill-review/SKILL.md
+++ b/plugins/skill-review/skills/skill-review/SKILL.md
@@ -1,46 +1,48 @@
 ---
 name: skill-review
 description: >
-  Review and audit of SKILL.md files: frontmatter conventions, trigger
-  design, voice, length targets, and cross-reference vs duplication
+  Review and audit of SKILL.md and agent files: frontmatter conventions,
+  trigger design, voice, length targets, and cross-reference vs duplication
   policy. TRIGGER when: authoring or reviewing a .claude/skills/**/SKILL.md
-  change, or auditing trigger accuracy across a skill set.
+  or .claude/agents/*.md change (stowed or under plugins/*), or auditing
+  trigger accuracy across the set.
   DO NOT TRIGGER when: editing
   CLAUDE.md/AGENTS.md (use ai-instruction-and-memory-files), or
-  reviewing non-skill files.
+  reviewing non-instruction files.
 user-invocable: false
 ---
 
-# Skill Review — Architecture & Checklist
+# Skill & Agent Review — Architecture & Checklist
 
-## 1. What makes a skill load
+## 1. What makes a skill or agent load
 
-A skill file is `claude/.claude/skills/<name>/SKILL.md`. Required
-frontmatter:
+This skill covers two file types with a shared quality bar but distinct
+frontmatter contracts:
 
-- **`name`** — must match the directory name; the harness keys on it.
-- **`description`** — loaded into every session for trigger matching.
-  This is the only body content the harness sees until the skill fires.
+- **Skills:** `claude/.claude/skills/<name>/SKILL.md` or `plugins/<plugin>/skills/<name>/SKILL.md`.
+- **Agents:** `claude/.claude/agents/<name>.md` or `plugins/<plugin>/agents/<name>.md`.
 
-Optional frontmatter:
+**Required frontmatter (both):**
 
-- **`allowed-tools`** — comma-separated allowlist (e.g.
-  `Read, Grep, Glob, Bash`). Omit to inherit the session's tools.
-- **`user-invocable`** — `false` hides the skill from the slash-command
-  menu but keeps it auto-triggerable from the description.
-- **`disable-model-invocation`** — `true` removes the description from the
-  always-loaded skill-listing budget; Skill tool invocations still work.
-  Use `true` on add-on skills (`.claude/skills/<parent>-<project>/SKILL.md`)
-  invoked by a parent via Glob+Skill-tool — `test-conventions`, `plan-review`,
-  and `code-review` all use this pattern; auto-trigger is not needed.
+- **`name`** — for skills, must match the directory name; for agents, used as the dispatcher key but need not match the filename.
+- **`description`** — loaded into every session for trigger / dispatch matching. Only body content the harness sees until the file fires.
 
-The harness loads only the description at startup; the body is fetched
-on demand. Description text is always-loaded context budget; body
-text is conditional. Frontmatter overspend hurts more than body overspend.
+**Optional frontmatter — skill-specific:**
 
-Target description shape: one summary sentence (≤80 chars), then `TRIGGER when:` and
-`DO NOT TRIGGER when:` clauses. Do not enumerate body-topic headings in the summary —
-body sections already enumerate; the summary routes.
+- **`allowed-tools`** — comma-separated allowlist (e.g. `Read, Grep, Glob, Bash`). Omit to inherit the session's tools.
+- **`user-invocable`** — `false` hides the skill from the slash-command menu but keeps it auto-triggerable from the description.
+- **`disable-model-invocation`** — `true` removes the description from the always-loaded skill-listing budget; Skill tool invocations still work. Use `true` on add-on skills (`.claude/skills/<parent>-<project>/SKILL.md`) invoked by a parent via Glob+Skill-tool.
+
+**Optional frontmatter — agent-specific:**
+
+- **`tools`** — comma-separated allowlist; spelled `tools`, **not** `allowed-tools` (skill-only field). Omit to inherit.
+- **`disallowedTools`** — comma-separated denylist; takes precedence over `tools`.
+- **`model`** — `sonnet` / `haiku` / `opus`, a full model ID, or `inherit` to follow the parent.
+- **`maxTurns`** — integer cap on the agent's turn budget.
+
+The harness loads only the description at startup; the body is fetched on demand — so frontmatter overspend hurts more than body overspend.
+
+Target description shape: one summary sentence (≤80 chars), then `TRIGGER when:` and `DO NOT TRIGGER when:` clauses; do not duplicate body-topic headings in the summary.
 
 ## 2. Trigger design
 
@@ -71,17 +73,10 @@ After a `TRIGGER`-block change, run `python evals/run_skill_evals.py --skill <na
 
 ## 3. Voice and structure
 
-- **Imperative second person.** "Review the change," "Apply the
-  checklist," not "The reviewer reviews the change."
-- **Declarative numbered items** for checklist content; the dispatcher
-  routes by item number in some skills (see `code-review` Item
-  ownership table).
-- **Section headers are domain or step labels** ("Trigger design,"
-  "Review checklist") — never "Introduction," "Background,"
-  "Conclusion."
-- **Tables for matrices, prose for narratives, bullets for parallel
-  options.** A four-column comparison wants a table; a two-step
-  decision wants prose.
+- **Imperative second person.** "Review the change," not "The reviewer reviews the change."
+- **Declarative numbered items** for checklist content.
+- **Section headers are domain or step labels** — never "Introduction," "Background," "Conclusion."
+- **Tables for matrices, prose for narratives, bullets for parallel options.**
 
 ## 4. Length and the behavior test
 
@@ -137,17 +132,12 @@ If not all three hold, point at the canonical source.
 
 ## 7. Review checklist
 
-1. **Frontmatter** — `name` matches directory; `description` present
-   and contains both `TRIGGER when:` and `DO NOT TRIGGER when:`
-   blocks. `allowed-tools` and `user-invocable` only if needed. Add
-   `disable-model-invocation: true` on add-on skills loaded by a parent
-   via Glob+Skill-tool (`.claude/skills/<parent>-<project>/SKILL.md`).
+1a. **Skill frontmatter** — `name` matches directory; description has both `TRIGGER when:` and `DO NOT TRIGGER when:` blocks; `disable-model-invocation: true` on add-on skills loaded by a parent via Glob+Skill-tool.
+1b. **Agent frontmatter** — `name` need not match the filename; tool allowlist uses `tools` (not `allowed-tools`); `model` is `sonnet`/`haiku`/`opus`/full-ID/`inherit` when not omitted; `disallowedTools` and `maxTurns` valid when used.
 2. **Description scope** — the description's TRIGGER list matches
    what the body actually covers. An overpromising description fires
    on turns the body can't help with.
-3. **Trigger specificity** — TRIGGER conditions use file globs or
-   action verbs, not vague context cues alone. A skill that triggers
-   on "thinking about X" is too soft to fire reliably.
+3. **Trigger specificity** — TRIGGER conditions use file globs or action verbs, not vague context cues alone. A skill that triggers on "thinking about X" is too soft to fire reliably. For agent files, apply this to routed-reviewer agents (`staff-*`, `ciso-reviewer`, `code-writer`); executor-style agents whose description names a single invocation context (e.g., `check-runner`) are exempt — recommend only.
 4. **DO NOT TRIGGER coverage** — adjacent-skill surfaces are named
    explicitly; verify every domain-adjacent skill appears.
 5. **Length** — under the 200-line target. Flag anything that drifts
@@ -158,8 +148,9 @@ If not all three hold, point at the canonical source.
 7. **Voice** — imperative second person; numbered items for
    checklists; section headers that label domains or steps.
 8. **Cross-reference correctness** — referenced skill names exist;
-   referenced section anchors (`§2`, `§3`) match the target file's
-   structure. Renames in the target break these silently.
+   section anchors (`§2`, `§3`) and item numbers used by dispatcher
+   routing tables (`code-review`, `plan-review` Item ownership) match
+   the target's structure. Renames or renumberings break these silently.
 9. **Duplication justification** — content duplicated across skills
    passes the three-condition test in §6. Otherwise, replace the
    duplicate with a pointer.
@@ -198,4 +189,4 @@ blockers), record completion by running this command exactly once:
 ~/.claude/scripts/marker.sh write skill-review
 ```
 
-The pathspecs `claude/.claude/skills/**/SKILL.md` and `plugins/*/skills/**/SKILL.md` are encoded inside `marker.sh write skill-review` so the marker matches what `require-skill-review.sh` checks — covering both stowed skills and project-scoped plugin skills.
+The pathspecs for SKILL.md and agent files (stowed and plugin) are encoded inside `marker.sh write skill-review` so the marker matches what `require-skill-review.sh` checks.


### PR DESCRIPTION
## Summary

Extends `/skill-review` and `require-skill-review.sh` to cover agent files (`claude/.claude/agents/*.md` and `plugins/*/agents/*.md`) alongside `SKILL.md`. Same voice / structure / description-routing quality bar now applies to both file classes.

## What shipped

**Gate scope broadening (must change together):**
- `plugins/skill-review/hooks/require-skill-review.sh` — pathspec list extended at the early-exit grep and the hash-computation site; deny-reason text updated.
- `claude/.claude/scripts/marker.sh` — `marker.sh write skill-review` pathspecs extended at the unstaged-vs-staged guard and the hash-computation site, matching the hook.
- `claude/.claude/tests/helpers.py` — `write_skill_review_marker` pathspecs extended to match.

**Skill body:**
- `plugins/skill-review/skills/skill-review/SKILL.md` (231 → 192 lines) — restructured §1 to a side-by-side skill-vs-agent frontmatter contract; split §7 item 1 into 1a (skill frontmatter) / 1b (agent frontmatter); appended §7 item 3 executor-style exemption for invocation-context agents like `check-runner`; tightened §7 item 8 to include item-number routing dependencies in dispatcher tables (`code-review`, `plan-review`).
- `plugins/skill-review/skills/skill-review/REFERENCES.md` — added Anthropic subagent-docs canonical URL + verbatim quotes for the agent frontmatter rules now encoded in §1 and §7 item 1b.

**Tests:**
- `claude/.claude/hooks/tests/test_require_skill_review.py` — new fixtures `_stage_stowed_agent_change` and `_stage_plugin_agent_change`; 5 new gate tests (stowed-agent deny, stowed-agent allow with marker, plugin-agent deny, plugin-agent allow with marker, mixed skill+agent stale-marker deny, marker survives non-gated restaging).
- `claude/.claude/hooks/tests/test_marker_script.py` — new fixtures `_make_stowed_agent` and `_make_plugin_agent`; 3 new write-recipe tests (unstaged-agent exits 2, staged stowed-agent writes marker, staged plugin-agent writes marker).

**Docs:**
- `CLAUDE.md` (root) — skill-review trigger condition extended to include agent files.
- `README.md` — workflow description, gate table, and plugin description all cite agent files.

## Design decisions resolved (from issue #241)

1. **Extend `skill-review` vs new `agent-review` skill** → extend in place. The frontmatter contract diverges (`tools` vs `allowed-tools`, plus `disallowedTools` / `model` / `maxTurns`), but every other reviewable concern (voice, structure, description routing, length, behavioral-equivalence on compressions) is shared. Split §7 item 1 into 1a/1b instead of forking the skill.
2. **Hook + marker pathspec changes** → extended in place; both the hook and the `marker.sh write skill-review` recipe accept the same 4-pathspec list. The `helpers.py` test helper was updated to match — drift would silently break `test_skill_review_hook_aligned_with_skill_recipe`.
3. **Anthropic docs alignment** → verified against `https://code.claude.com/docs/en/sub-agents.md`; verbatim quotes saved in `REFERENCES.md` for `name` (need not match filename), `tools` / `disallowedTools` / `model` / `maxTurns` fields.

## Out of scope

- **Skill rename to "skill-and-agent-review":** deferred. The skill's directory name is the harness key; renaming requires migrating the plugin path, marker directory layout, and existing markers. Not load-bearing for the gate-coverage fix.
- **Length cap on agent files:** §7 item 5 already targets <200 lines for SKILL.md; same target applies to agent files. No separate cap needed.
- **Pathspec-list extraction to `_lib.sh`:** the 4-pathspec list now appears at 4 production sites (`require-skill-review.sh:52,65`; `marker.sh:137,142`). An extraction to a `SKILL_REVIEW_PATHSPECS` shell array would DRY this — but the byte-identical `_lib.sh` enforcement (`test_plugin_lib_sh_matches_stowed_lib_sh`) makes this safer as a focused follow-up. Will file as a separate ticket.

## Test plan

- [x] `pytest claude/.claude/` PASS (includes the 8 new tests)
- [x] `ruff check claude/.claude/` PASS
- [x] `/skill-review` clean on the staged SKILL.md diff (behavioral-equivalence audit, no N rows)
- [x] `/code-review` clean (Claude Code config domain; no specialist spawn — pathspec broadening with no privilege boundary or user-visible-behavior delta beyond doc updates)
- [ ] Reviewer: confirm the §7 item 3 executor-style carve-out language reads correctly for `check-runner` (the only current executor agent) and won't bleed into routed reviewers
- [ ] Reviewer: confirm the §1 side-by-side frontmatter section is the right structure (vs. two separate sections)

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)