### PR TITLE
respond-pr: require holistic triage before per-comment work

### DIFF
--- a/claude/.claude/skills/respond-pr/SKILL.md
+++ b/claude/.claude/skills/respond-pr/SKILL.md
@@ -15,17 +15,24 @@ Fetch all review comments on the current branch's open pull request and address 
    ```
    The `require-respond-pr.sh` PreToolUse hook bypasses while THIS session's marker exists and its stored PID is alive (PID liveness check via `kill -0`). Per-session keying prevents parallel respond-pr sessions from thrashing on cleanup or leaking bypass to unrelated sessions. If the chain fails (empty `SESSION_ID`, etc.), the `capture-session-id.sh` SessionStart hook didn't run — abort and report; do not proceed without the marker, since every gated `gh` call below will be blocked.
 
-   **Marker lifecycle:** this marker must stay active for the entire skill session — step 8 is the only step that removes it. If you run other skills as intermediate steps (e.g., `/ready-for-review` before pushing in step 7), their cleanup must not touch this marker. If the marker is accidentally removed mid-session, restore it in a standalone Bash call before any subsequent `gh` command — the hook fires before the shell executes, so you cannot create the marker and use it atomically in the same call.
+   **Marker lifecycle:** this marker must stay active for the entire skill session — step 9 is the only step that removes it. If you run other skills as intermediate steps (e.g., `/ready-for-review` before pushing in step 8), their cleanup must not touch this marker. If the marker is accidentally removed mid-session, restore it in a standalone Bash call before any subsequent `gh` command — the hook fires before the shell executes, so you cannot create the marker and use it atomically in the same call.
 1. Identify the PR number for the current branch: `gh pr view --json number -q '.number'`
 2. Fetch **all three** types of comments. Two failure modes Claude commonly hits: (a) fetching only the first type and missing the other two; (b) fetching without `--paginate` and silently truncating at 30 results per type. Both produce reviews that look complete but miss real feedback.
    - **Inline file comments:** `gh api repos/{owner}/{repo}/pulls/{number}/comments --paginate`
    - **Top-level review comments:** `gh api repos/{owner}/{repo}/pulls/{number}/reviews --paginate --jq '.[] | select(.body != "")'`
    - **Issue-level comments:** `gh api repos/{owner}/{repo}/issues/{number}/comments --paginate`
 3. **Divergence precheck.** Before applying any `FIXED` change or posting any reply, run the canonical detection recipe (see `git-feature-branch-sync/SKILL.md` § "Detecting divergence") against the PR's base branch (`gh pr view --json baseRefName --jq .baseRefName`). If the trial merge reports CONFLICT, abort the skill — print a message naming the PR number (captured in step 1) and route the user to `/git-feature-branch-sync`. Do not apply `FIXED` changes onto a stale tree; replies acknowledging fixes would refer to a commit the reviewer cannot cleanly resolve. If the trial merge is CLEAN, proceed even when behind > 0 — small drift is normal during review; the precheck only blocks on actual conflicts.
-4. **Classify, then batch.** Before drafting any reply, assign each unresolved comment to one of the five types below. All code changes across the batch go into a single commit (step 7); all replies are posted after that commit. Required fields are not optional — if a field's value is non-obvious, that is exactly when it earns its keep.
+4. **Holistic triage.** Before classifying or fixing anything, read the complete set of unresolved comments as one body and name what you find across them:
+
+   - **Shared root causes** — multiple comments tracing to one underlying issue. Fix at the root once; a serial fix-the-first-then-the-next sequence has produced regressions where the second fix stripped what the first one needed.
+   - **Contradictions** — reviewers asking for incompatible things. Pick a direction explicitly; a silent choice surfaces in the next review round.
+   - **Batched-design choices** — comments that are constraints on one design question, not independent issues (e.g., three comments that all resolve to "pick A or B"; naming conventions across functions; error-handling shape across handlers).
+
+   If none apply after a careful read, say so — but the read is required. Per-comment patching that skips this step produces overlapping fixes and diffs reviewers must re-review one thread at a time.
+5. **Classify, then batch.** Assign each unresolved comment to one of the five types below. When there are 3+ unresolved comments, render the classification as a four-column table — Comment (one-line + source link) | Theme (from step 4, or `—`) | Disposition | Plan — before starting any per-comment work; the table forces all comments to be seen at once and ties each one to the cross-cutting themes named in step 4. All code changes across the batch go into a single commit (step 8); all replies are posted after that commit. Required fields are not optional — if a field's value is non-obvious, that is exactly when it earns its keep.
 
    - **`FIXED`** — a code change was made.
-     Required fields: `disposition` (one of `fixed-as-requested` | `fixed-with-modification` | `fixed-differently`), `rationale` (REQUIRED when disposition ≠ `fixed-as-requested` — explain what was changed and why), `commit_sha` (filled in after the commit in step 7).
+     Required fields: `disposition` (one of `fixed-as-requested` | `fixed-with-modification` | `fixed-differently`), `rationale` (REQUIRED when disposition ≠ `fixed-as-requested` — explain what was changed and why), `commit_sha` (filled in after the commit in step 8).
    - **`EXPLAIN-DESIGN`** — the existing code is correct; the comment misreads intent.
      Required fields: `decision` (what the code does), `why` (the reason it does that), `why-not-alternative` (why the reviewer's apparent alternative was not taken), `where-documented` (file:line or "inline below").
    - **`OUT-OF-SCOPE`** — the comment identifies a real issue but it belongs in a separate PR.
@@ -43,12 +50,12 @@ Fetch all review comments on the current branch's open pull request and address 
    *`EXPLAIN-DESIGN`:*
    > **[Claude Code]** The early return is intentional — when the session token is absent we want a fast 401 with no DB round-trip. The alternative (falling through to a null-check deeper in the stack) would silently succeed for unauthenticated callers in contexts where the token field is optional. `where-documented: auth/middleware.ts:42`
 
-5. For each unresolved comment:
+6. For each unresolved comment:
    - Read the referenced file and line to understand the context
-   - Apply the classification from step 4
+   - Apply the classification from step 5
    - If a code change is needed, make it; note it in the reply using the `FIXED` field template
    - If it's design explanation, draft using the `EXPLAIN-DESIGN` template
-6. Post replies using the appropriate endpoint for each comment type — do **not** use `gh api .../pulls/comments/{id}` with `-F body=...`; that endpoint PATCHes the target comment in place and silently overwrites the author's text.
+7. Post replies using the appropriate endpoint for each comment type — do **not** use `gh api .../pulls/comments/{id}` with `-F body=...`; that endpoint PATCHes the target comment in place and silently overwrites the author's text.
 
    - **Inline file comments** (fetched from `pulls/{n}/comments`) — reply via the `/replies` sub-resource:
      ```
@@ -67,8 +74,8 @@ Fetch all review comments on the current branch's open pull request and address 
      gh api repos/{owner}/{repo}/issues/{number}/comments \
        -F body='**[Claude Code]** ...reply text...'
      ```
-7. Commit and push any code changes in a single commit
-8. **Remove this session's hook bypass marker:**
+8. Commit and push any code changes in a single commit
+9. **Remove this session's hook bypass marker:**
    <!-- HOOK_TEST_FIXTURE: disable-bypass — the hook-alignment test suite reads this exact fenced block to verify it removes the marker the enable step created. Do not duplicate elsewhere; the test re-reads it from here. -->
    ```
    ~/.claude/scripts/marker.sh deactivate respond-pr
@@ -91,7 +98,7 @@ gh api repos/owner/repo/pulls/4/comments/12345678/replies \
 - Be concise in replies — state what was done, not lengthy explanations
 - If you disagree with a comment, explain why clearly but defer to the reviewer's judgment
 - Do not resolve review threads — let the reviewer verify and resolve them
-- PR comments are editable after posting. If a reply **you authored** in this session has a typo or factual error, edit it in place rather than posting a correction. **Use PATCH only against comments you authored — confusing the target ID with the user's comment ID overwrites their text irrecoverably and cannot be undone.** A `user.login` check is insufficient — Claude posts under the user's own token, so PATCH against the user's own comment will succeed. The reliable check is the attribution prefix: every reply Claude posts starts with `**[Claude Code]**`, and the user's comments do not. Before any PATCH, fetch the target body and verify it starts with that prefix; abort to the `/replies` form (Step 6) on any mismatch:
+- PR comments are editable after posting. If a reply **you authored** in this session has a typo or factual error, edit it in place rather than posting a correction. **Use PATCH only against comments you authored — confusing the target ID with the user's comment ID overwrites their text irrecoverably and cannot be undone.** A `user.login` check is insufficient — Claude posts under the user's own token, so PATCH against the user's own comment will succeed. The reliable check is the attribution prefix: every reply Claude posts starts with `**[Claude Code]**`, and the user's comments do not. Before any PATCH, fetch the target body and verify it starts with that prefix; abort to the `/replies` form (Step 7) on any mismatch:
   ```
   TARGET_BODY=$(gh api repos/{owner}/{repo}/pulls/comments/{id} --jq '.body')
   case "$TARGET_BODY" in


### PR DESCRIPTION
## Summary

- Add new step 4 **Holistic triage** to `/respond-pr`: before classifying or fixing anything, read the complete unresolved-comment set as one body and name shared root causes, contradictions, and batched-design choices across them.
- Require a four-column disposition table (Comment | Theme | Disposition | Plan) in step 5 when there are 3+ unresolved comments, forcing all comments to be seen at once before per-comment work begins.
- Renumber existing steps 4–8 → 5–9 and update cross-references in marker-lifecycle, classify lead-in, FIXED-field template, per-comment apply step, and PATCH-safety guideline.

## Why

The existing skill body already named batching as a requirement ("Classify, then batch"), but agents reached the right *commit shape* (single commit) without doing the *cross-comment analysis* — so adjacent comments that should have changed the approach (or revealed the same root cause) were patched independently.

Concrete examples from recent merged PRs in this repo:

- **PR #290** (`skill-management` rename + validator) — four threads shared one root cause: a hardcoded numeric value surfacing across README, docs, marketplace.json, plugin.json, CHANGELOG. Per-comment patches stripped the documented rationale; thread #7 then reported a regression caused by thread #6's fix. A holistic read would have framed all four as one decision about what belongs in the validator script vs. surface docs.
- **PR #278** (extract delegation triad to subagent-delegation skill) — two threads were constraints on the same design question (boundary between always-loaded CLAUDE.md signal and on-demand skill body), but were addressed as independent issues.
- **PR #280** (proactive branch-divergence detection) — two threads, same root cause (detail at wrong altitude in two README sections); two near-identical "Fixed — reverted…" replies where one would suffice.

## Mechanism

Mirrors PR #294's per-finding disposition pattern for `/code-review` subagent findings, adapted to reviewer comments. The disposition table from `/code-review` becomes the per-comment table here; the new Holistic-triage step is the missing layer that makes "Classify, then batch" actionable rather than rule-only.

## Test plan

- [x] `pytest claude/.claude/` — passes (recipes extract by `HOOK_TEST_FIXTURE` markers, not step numbers, so renumbering doesn't break them)
- [x] `ruff check claude/.claude/` — passes
- [x] `/skill-review` walked: frontmatter, trigger, voice, length (111 lines, under 200), behavior test on new lines, behavioral-equivalence audit on renumbering/compressions — all clean
- [x] `/code-review` walked on staged diff — one matched Change-type row (skill edit) dispatched to `/skill-review` already; no `staff-*` co-spawn warranted (edit changes Claude's PR-reply process, not any `staff-*` lane's output)
- [ ] Smoke test on the next `/respond-pr` invocation with 3+ comments — verify the table format renders and the triage step lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)