### PR TITLE
chore(skill-management): bump to 2.1.3 to re-ship PR #297

### DIFF
--- a/plugins/skill-management/.claude-plugin/plugin.json
+++ b/plugins/skill-management/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "skill-management",
   "description": "Authoring guardrails for SKILL.md files: a commit-time structural validator (catches frontmatter that would silently truncate from the harness's skill listing or fail strict-YAML parsing) plus a behavioral-equivalence audit via /skill-review. Install at project scope in repos that author SKILL.md files.",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "author": {
     "name": "Cordova Strategy"
   },


### PR DESCRIPTION
## Summary

PR #297 (`fix(skill-management): graceful SessionStart when python3 -m venv fails`) shipped a behavior change to the `skill-management` plugin — a new `provision-validator-venv.sh` and a rewritten `hooks.json` — without bumping `plugins/skill-management/.claude-plugin/plugin.json`. PR #298 had incidentally bumped that file to `2.1.2` four minutes earlier for an unrelated description trim, so the on-disk version on `main` after #297 matched the on-disk version on `main` before #297. Downstream caches already on `2.1.2` do not refresh and keep running the old bootstrap.

This bump (`2.1.2` → `2.1.3`, patch — re-delivery of a backward-compatible bug fix) tells every cached install to refresh on its next plugin check, pulling in PR #297's script and rewritten `hooks.json`.

## Post-merge install (per `plugin-semver`)

```
claude plugin install skill-management@claude-config --scope project
```

## Follow-up

The structural gap that let PR #297 land unbumped — `/code-review`'s dispatcher does not route plugin file diffs to `plugin-semver`, no commit-time hook gate exists, and the skill's checklist reads file-at-HEAD rather than diff-against-base — is captured in a follow-up brief at `/tmp/plugin-semver-dispatcher-gap-brief.md`. Not bundled here; this PR is the one-line forward-fix.

## Test plan

- [ ] After merge, on a machine cached at `2.1.1` or `2.1.2` for `skill-management@claude-config`, run the plugin manager's next refresh and confirm `installed_plugins.json` records version `2.1.3` and `hooks/provision-validator-venv.sh` appears in the cached plugin tree.
- [ ] On that same machine, open a fresh Claude Code session and confirm SessionStart no longer emits the 7-line `ensurepip is not available...` banner — either silence (venv provisioned) or the single graceful one-line warning (when `python3-venv` is missing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)