### PR TITLE
fix(skill-management): probe yaml import in cache-hit branch (2.2.1)

### DIFF
--- a/claude/.claude/hooks/tests/test_provision_validator_venv.py
+++ b/claude/.claude/hooks/tests/test_provision_validator_venv.py
@@ -193,14 +193,36 @@ class TestPython3Absent:
         assert "python3 not found" in result.stderr
 
 
+def _stub_venv_python(data: Path, body: str) -> Path:
+    """Drop an executable stub at data/venv/bin/python with `body` as its
+    script body. Used to simulate a previously-provisioned (or
+    previously-provisioned-then-broken) venv interpreter."""
+    venv_bin = data / "venv" / "bin"
+    venv_bin.mkdir(parents=True, exist_ok=True)
+    stub = venv_bin / "python"
+    stub.write_text("#!/bin/bash\n" + body)
+    stub.chmod(0o755)
+    return stub
+
+
 class TestCacheHit:
-    """When the cached requirements.txt matches the plugin's requirements.txt,
-    the script must short-circuit — no python3 invocation, no stderr."""
+    """When the cached requirements.txt matches the plugin's requirements.txt
+    AND the cached venv's python can still `import yaml`, the script must
+    short-circuit — no python3 invocation, no stderr.
+
+    The yaml import probe matters because the cache key (requirements.txt
+    diff) is what was *requested*, not what currently *works*. A previously-
+    good venv can break without requirements.txt changing — system Python
+    upgrade evicts the interpreter target, manual `rm` against site-packages,
+    partial snapshot restore, etc. Without the probe, require-skill-review.sh
+    would elect a broken interpreter as VALIDATOR_PYTHON."""
 
     def test_cache_hit_short_circuits(self, tmp_path, plugin_dirs):
         root, data = plugin_dirs
-        # Pre-populate the cache as if a prior session already provisioned.
+        # Pre-populate the cache as if a prior session already provisioned —
+        # requirements.txt matches AND venv/bin/python can `import yaml`.
         (data / "requirements.txt").write_text((root / "requirements.txt").read_text())
+        _stub_venv_python(data, "exit 0\n")  # accepts any args, incl. -c 'import yaml'
 
         # Stub python3 to fail loudly — if the script invokes it, the test
         # will surface the failure.
@@ -212,6 +234,46 @@ class TestCacheHit:
         assert result.returncode == 0
         assert result.stderr == "", (
             f"cache hit must produce no stderr; got: {result.stderr!r}"
+        )
+
+    def test_broken_venv_falls_through_to_reprovisioning(self, tmp_path, plugin_dirs):
+        """Cache key matches but the venv is silently broken — yaml is no
+        longer importable. The script must NOT short-circuit; it must fall
+        through to the reprovisioning path so the broken venv is replaced or
+        removed. Otherwise require-skill-review.sh would elect a broken
+        interpreter as VALIDATOR_PYTHON at the next commit."""
+        root, data = plugin_dirs
+        # Pre-populate: requirements.txt matches, venv/bin/python exists,
+        # but `python -c 'import yaml'` exits non-zero.
+        (data / "requirements.txt").write_text((root / "requirements.txt").read_text())
+        _stub_venv_python(
+            data,
+            'if [ "$1" = "-c" ]; then exit 1; fi\nexit 0\n',
+        )
+
+        # Stub python3 to fail at `-m venv` so reprovisioning lands in the
+        # graceful cleanup path. Cleanup removes data/venv + the cached
+        # requirements.txt — both are observable proofs that we fell through.
+        bin_dir = tmp_path / "bin"
+        _write_stub_python(
+            bin_dir,
+            'if [ "$1" = "-m" ] && [ "$2" = "venv" ]; then exit 1; fi\nexit 0\n',
+        )
+
+        result = _run(data, root, extra_path=bin_dir)
+
+        assert result.returncode == 0
+        assert not (data / "venv").exists(), (
+            "broken venv must be removed by the reprovisioning cleanup path — "
+            "presence indicates the cache-hit short-circuit was taken anyway"
+        )
+        assert not (data / "requirements.txt").exists(), (
+            "cached requirements.txt must be removed so the next session "
+            "retries — presence indicates short-circuit, not fall-through"
+        )
+        assert "failed to provision Python venv" in result.stderr, (
+            "fall-through should have reached the graceful failure message; "
+            f"got stderr: {result.stderr!r}"
         )
 
 

--- a/plugins/skill-management/.claude-plugin/plugin.json
+++ b/plugins/skill-management/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "skill-management",
   "description": "Authoring guardrails for SKILL.md files: a commit-time structural validator (catches frontmatter that would silently truncate from the harness's skill listing or fail strict-YAML parsing) plus a behavioral-equivalence audit via /skill-review. Install at project scope in repos that author SKILL.md files.",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "author": {
     "name": "Cordova Strategy"
   },

--- a/plugins/skill-management/hooks/provision-validator-venv.sh
+++ b/plugins/skill-management/hooks/provision-validator-venv.sh
@@ -18,9 +18,17 @@
 
 set -u
 
-# Cache hit: requirements.txt matches the cached copy — venv is already
-# provisioned and current. Nothing to do.
-if diff -q "${CLAUDE_PLUGIN_ROOT}/requirements.txt" "${CLAUDE_PLUGIN_DATA}/requirements.txt" >/dev/null 2>&1; then
+# Cache hit candidate: requirements.txt matches the cached copy. Confirm the
+# venv still works before short-circuiting — a previously-good venv can break
+# without requirements.txt changing (system Python upgrade evicts the
+# interpreter target, manual `rm` against site-packages, partial snapshot
+# restore, ABI swap on distro upgrade). The yaml import probe here is
+# symmetric with the probe in the provisioning path below, so drift is caught
+# on both sides of the cache decision. On probe failure we fall through to
+# the reprovisioning path, whose existing cleanup removes the broken venv.
+if diff -q "${CLAUDE_PLUGIN_ROOT}/requirements.txt" "${CLAUDE_PLUGIN_DATA}/requirements.txt" >/dev/null 2>&1 \
+   && [ -x "${CLAUDE_PLUGIN_DATA}/venv/bin/python" ] \
+   && "${CLAUDE_PLUGIN_DATA}/venv/bin/python" -c 'import yaml' >/dev/null 2>&1; then
   exit 0
 fi
 


### PR DESCRIPTION
## Summary

The cache-hit short-circuit in `provision-validator-venv.sh` gated `exit 0`
on `diff -q requirements.txt` alone — the cache key is *what was requested*,
not *what currently works*. A previously-good venv can break without
`requirements.txt` changing (system Python upgrade evicts the interpreter
target, `rm` against `site-packages`, partial snapshot restore, `pip
uninstall` against the wrong interpreter, ABI swap on distro upgrade). In
any of those cases the short-circuit returned `exit 0` without
re-provisioning, and `require-skill-review.sh` then elected the broken
`venv/bin/python` as `VALIDATOR_PYTHON` (it gates on `-x` alone). The
structural validator failed at commit time with `ModuleNotFoundError: No
module named 'yaml'` or silently ran against a broken interpreter.

Fix: gate the cache-hit `exit 0` on the same yaml import probe the
provisioning path already uses (`venv/bin/python -c 'import yaml'`), so
drift is caught on both sides of the cache decision. On probe failure the
script falls through to the existing reprovisioning path, whose cleanup
removes the broken venv.

- `plugins/skill-management/hooks/provision-validator-venv.sh` — add
  `[ -x venv/bin/python ]` + `python -c 'import yaml'` to the cache-hit
  conditional; expand the WHY comment.
- `claude/.claude/hooks/tests/test_provision_validator_venv.py` — add
  `_stub_venv_python` helper; update the existing cache-hit test to stand
  up a working venv stub; add
  `test_broken_venv_falls_through_to_reprovisioning` covering the drift
  case.
- `plugins/skill-management/.claude-plugin/plugin.json` — bump
  `2.2.0` → `2.2.1` (patch, backward-compatible bug fix).

## Background

Follow-up to #297 (graceful SessionStart) and #301 (the 2.1.3 re-bump that
delivered #297 to caches). #297 added the import probe to the
*initial-provisioning* path but not to the *cache-hit* path; this PR closes
that gap symmetrically.

Rebased onto main after #300 landed (main bumped to 2.2.0 by the
marker.sh-chain fix); the patch ships as 2.2.1.

## Test plan

- [x] `pytest claude/.claude/` (full suite passes, including the new drift
      test in `test_provision_validator_venv.py`)
- [x] `ruff check claude/.claude/` clean
- [ ] After merge: confirm consumer plugin caches refresh to 2.2.1 and the
      new probe fires on a SessionStart whose cached venv has had its yaml
      package removed.

## Post-merge install (per plugin-semver)

```
claude plugin install skill-management@claude-config --scope project
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)