### PR TITLE
feat(transcript-analysis): add skill-pair subcommand

### DIFF
--- a/claude/.claude/scripts/tests/test_transcript_analysis.py
+++ b/claude/.claude/scripts/tests/test_transcript_analysis.py
@@ -433,6 +433,221 @@ class TestSubagentMix:
 
 
 # ---------------------------------------------------------------------------
+# skill-pair
+# ---------------------------------------------------------------------------
+
+# Fixed timestamp used for tests 1–6, 8–10: 2026-05-12T12:00:00Z → ISO 2026-W20
+_TS_FIXED = "2026-05-12T12:00:00Z"
+# Boundary timestamps for test 7 (ISO week boundary Sun → Mon)
+_TS_SUNDAY = "2026-05-17T23:59:59Z"   # ISO 2026-W20 (Sunday = last day of W20)
+_TS_MONDAY = "2026-05-18T00:00:01Z"   # ISO 2026-W21 (Monday = first day of W21)
+
+
+def _skill_pair_args(leader="plan-it", follower="plan-review", *, projects="*", exclude_projects=None, branches=None):
+    return type("A", (), {
+        "leader": leader,
+        "follower": follower,
+        "projects": projects,
+        "exclude_projects": exclude_projects,
+        "branches": branches,
+    })()
+
+
+class TestSkillPair:
+    def test_empty_jsonl_prints_no_data(self, fake_projects, capsys):
+        _write_jsonl(fake_projects / "sess.jsonl", [])
+        _mod.cmd_skill_pair(_skill_pair_args())
+        assert "No data found." in capsys.readouterr().out
+
+    def test_leader_only_session_counted_with_zero_followers(self, fake_projects, capsys):
+        _write_jsonl(fake_projects / "sess.jsonl", [
+            _asst("claude-sonnet-4-6", branch="main", ts=_TS_FIXED, content=[
+                _skill_use("s1", "plan-it"),
+            ]),
+        ])
+        _mod.cmd_skill_pair(_skill_pair_args())
+        out = capsys.readouterr().out
+        lines = [ln for ln in out.splitlines() if "2026-W20" in ln]
+        assert len(lines) == 1
+        cols = lines[0].split()
+        # cols: ['2026-W20', lead, main, side, pair%]
+        assert cols[1] == "1"   # Lead=1
+        assert cols[2] == "0"   # Main=0
+        assert cols[3] == "0"   # Side=0
+        assert "0.0%" in cols[4]
+
+    def test_leader_plus_main_follower_counted(self, fake_projects, capsys):
+        _write_jsonl(fake_projects / "sess.jsonl", [
+            _asst("claude-sonnet-4-6", branch="main", ts=_TS_FIXED, content=[
+                _skill_use("s1", "plan-it"),
+            ]),
+            _asst("claude-sonnet-4-6", branch="main", ts=_TS_FIXED, content=[
+                _skill_use("s2", "plan-review"),
+            ]),
+        ])
+        _mod.cmd_skill_pair(_skill_pair_args())
+        out = capsys.readouterr().out
+        lines = [ln for ln in out.splitlines() if "2026-W20" in ln]
+        assert len(lines) == 1
+        cols = lines[0].split()
+        assert cols[1] == "1"   # Lead=1
+        assert cols[2] == "1"   # Main=1
+        assert "100.0%" in cols[4]
+
+    def test_leader_plus_sidechain_only_follower(self, fake_projects, capsys):
+        _write_jsonl(fake_projects / "sess.jsonl", [
+            _asst("claude-sonnet-4-6", branch="main", ts=_TS_FIXED, content=[
+                _skill_use("s1", "plan-it"),
+            ]),
+            _asst("claude-sonnet-4-6", branch="main", ts=_TS_FIXED, sidechain=True, content=[
+                _skill_use("s2", "plan-review"),
+            ]),
+        ])
+        _mod.cmd_skill_pair(_skill_pair_args())
+        out = capsys.readouterr().out
+        lines = [ln for ln in out.splitlines() if "2026-W20" in ln]
+        assert len(lines) == 1
+        cols = lines[0].split()
+        assert cols[1] == "1"   # Lead=1
+        assert cols[2] == "0"   # Main=0 (no main-thread follower)
+        assert cols[3] == "1"   # Side=1
+
+    def test_both_main_and_sidechain_follower_counts_main_only(self, fake_projects, capsys):
+        """Session with both main and sidechain follower hits counts in Main, NOT Side."""
+        _write_jsonl(fake_projects / "sess.jsonl", [
+            _asst("claude-sonnet-4-6", branch="main", ts=_TS_FIXED, content=[
+                _skill_use("s1", "plan-it"),
+            ]),
+            _asst("claude-sonnet-4-6", branch="main", ts=_TS_FIXED, content=[
+                _skill_use("s2", "plan-review"),
+            ]),
+            _asst("claude-sonnet-4-6", branch="main", ts=_TS_FIXED, sidechain=True, content=[
+                _skill_use("s3", "plan-review"),
+            ]),
+        ])
+        _mod.cmd_skill_pair(_skill_pair_args())
+        out = capsys.readouterr().out
+        lines = [ln for ln in out.splitlines() if "2026-W20" in ln]
+        assert len(lines) == 1
+        cols = lines[0].split()
+        assert cols[2] == "1"   # Main=1
+        assert cols[3] == "0"   # Side=0 (sidechain-only requires no main hit)
+
+    def test_multiple_leader_hits_count_as_one_session(self, fake_projects, capsys):
+        """Three leader invocations in one session → Lead=1, not 3."""
+        _write_jsonl(fake_projects / "sess.jsonl", [
+            _asst("claude-sonnet-4-6", branch="main", ts=_TS_FIXED, content=[
+                _skill_use("s1", "plan-it"),
+                _skill_use("s2", "plan-it"),
+                _skill_use("s3", "plan-it"),
+            ]),
+        ])
+        _mod.cmd_skill_pair(_skill_pair_args())
+        out = capsys.readouterr().out
+        lines = [ln for ln in out.splitlines() if "2026-W20" in ln]
+        assert len(lines) == 1
+        assert lines[0].split()[1] == "1"   # Lead=1
+
+    def test_iso_week_boundary_sunday_vs_monday(self, fake_projects, capsys):
+        """Leader on Sun 23:59:59 UTC → W20; leader on Mon 00:00:01 UTC → W21."""
+        proj2 = fake_projects.parent / "-home-user-testrepo2"
+        proj2.mkdir(parents=True)
+        _write_jsonl(fake_projects / "sess-sun.jsonl", [
+            _asst("claude-sonnet-4-6", branch="main", ts=_TS_SUNDAY, content=[
+                _skill_use("s1", "plan-it"),
+            ]),
+        ])
+        _write_jsonl(proj2 / "sess-mon.jsonl", [
+            _asst("claude-sonnet-4-6", branch="main", ts=_TS_MONDAY, content=[
+                _skill_use("s2", "plan-it"),
+            ]),
+        ])
+        _mod.cmd_skill_pair(_skill_pair_args())
+        out = capsys.readouterr().out
+        data_lines = [ln for ln in out.splitlines() if ln.startswith("2026-W")]
+        bins = [ln.split()[0] for ln in data_lines]
+        assert "2026-W20" in bins
+        assert "2026-W21" in bins
+        assert bins != ["2026-W20"]  # both bins present as distinct rows
+
+    def test_projects_glob_excludes_unmatched_project(self, fake_projects, capsys):
+        """Only project dirs matching --projects are included."""
+        proj_b = fake_projects.parent / "-home-user-other-repo"
+        proj_b.mkdir(parents=True)
+        _write_jsonl(fake_projects / "sess.jsonl", [
+            _asst("claude-sonnet-4-6", branch="main", ts=_TS_FIXED, content=[
+                _skill_use("s1", "plan-it"),
+            ]),
+        ])
+        _write_jsonl(proj_b / "sess.jsonl", [
+            _asst("claude-sonnet-4-6", branch="main", ts=_TS_FIXED, content=[
+                _skill_use("s2", "plan-it"),
+            ]),
+        ])
+        # Only match the first project dir
+        _mod.cmd_skill_pair(_skill_pair_args(projects="-home-user-testrepo"))
+        out = capsys.readouterr().out
+        lines = [ln for ln in out.splitlines() if "2026-W20" in ln]
+        assert len(lines) == 1
+        # Only 1 leader session (the included project)
+        assert lines[0].split()[1] == "1"
+
+    def test_exclude_projects_glob_omits_matching_dir(self, fake_projects, capsys):
+        """Project dirs matching --exclude-projects are skipped even when also matching --projects=*."""
+        proj_eval = fake_projects.parent / "-tmp-claude-eval-abc123"
+        proj_normal = fake_projects.parent / "-home-user-normalrepo"
+        proj_eval.mkdir(parents=True)
+        proj_normal.mkdir(parents=True)
+        # Normal project: 1 leader session
+        _write_jsonl(proj_normal / "sess.jsonl", [
+            _asst("claude-sonnet-4-6", branch="main", ts=_TS_FIXED, content=[
+                _skill_use("s1", "plan-it"),
+            ]),
+        ])
+        # Eval project: 2 leader sessions — should be excluded
+        _write_jsonl(proj_eval / "sess.jsonl", [
+            _asst("claude-sonnet-4-6", branch="main", ts=_TS_FIXED, content=[
+                _skill_use("s2", "plan-it"),
+            ]),
+        ])
+        _write_jsonl(proj_eval / "sess2.jsonl", [
+            _asst("claude-sonnet-4-6", branch="main", ts=_TS_FIXED, content=[
+                _skill_use("s3", "plan-it"),
+            ]),
+        ])
+        # fake_projects itself has no sessions for this test; use exclude on the eval dir
+        _mod.cmd_skill_pair(_skill_pair_args(exclude_projects="-tmp-claude-eval-*"))
+        out = capsys.readouterr().out
+        lines = [ln for ln in out.splitlines() if "2026-W20" in ln]
+        assert len(lines) == 1
+        # Only 1 session from the normal project; eval sessions excluded
+        assert lines[0].split()[1] == "1"
+
+    def test_branches_filter_excludes_other_branch(self, fake_projects, capsys):
+        """With --branches=branch-a, only sessions on branch-a contribute."""
+        _write_jsonl(fake_projects / "sess.jsonl", [
+            _asst("claude-sonnet-4-6", branch="branch-a", ts=_TS_FIXED, content=[
+                _skill_use("s1", "plan-it"),
+            ]),
+            _asst("claude-sonnet-4-6", branch="branch-a", ts=_TS_FIXED, content=[
+                _skill_use("s2", "plan-review"),
+            ]),
+        ])
+        _write_jsonl(fake_projects / "sess2.jsonl", [
+            _asst("claude-sonnet-4-6", branch="branch-b", ts=_TS_FIXED, content=[
+                _skill_use("s3", "plan-it"),
+            ]),
+        ])
+        _mod.cmd_skill_pair(_skill_pair_args(branches="branch-a"))
+        out = capsys.readouterr().out
+        lines = [ln for ln in out.splitlines() if "2026-W20" in ln]
+        assert len(lines) == 1
+        cols = lines[0].split()
+        assert cols[1] == "1"   # Lead=1 (branch-a only)
+        assert cols[2] == "1"   # Main=1 (follower on branch-a)
+
+
+# ---------------------------------------------------------------------------
 # pr-link (stubbed gh)
 # ---------------------------------------------------------------------------
 

--- a/claude/.claude/scripts/transcript-analysis.py
+++ b/claude/.claude/scripts/transcript-analysis.py
@@ -4,6 +4,7 @@ No writes; pr-link is the only subcommand that touches the network (via gh).
 """
 
 import argparse
+import fnmatch
 import json
 import re
 import subprocess
@@ -422,6 +423,88 @@ def cmd_subagent_mix(args: argparse.Namespace) -> None:
         )
 
 
+def cmd_skill_pair(args: argparse.Namespace) -> None:
+    """Pairing rate between two skills, bucketed by ISO week.
+
+    Counts Skill tool_use blocks regardless of tool_result success — sessions
+    where the Skill tool errored (e.g., harnesses without Skill-tool support)
+    still count as leader-sessions. Filter such corpora via --exclude-projects.
+    """
+    leader: str = args.leader
+    follower: str = args.follower
+    projects_glob = _projects_glob(args)
+    exclude_glob: str | None = getattr(args, "exclude_projects", None)
+    branch_filter = _branch_filter(args)
+
+    # bin_str -> {leader_sessions, follower_main, follower_sidechain_only}
+    data: dict[str, dict[str, int]] = defaultdict(
+        lambda: {"leader_sessions": 0, "follower_main": 0, "follower_sidechain_only": 0}
+    )
+
+    for jsonl, records in iter_sessions(PROJECTS_DIR, projects_glob):
+        # --exclude-projects: skip project dirs whose basename matches the glob
+        if exclude_glob and fnmatch.fnmatchcase(jsonl.parent.name, exclude_glob):
+            continue
+
+        has_leader_hit = False
+        leader_first_ts: float | None = None
+        has_main_follower = False
+        has_sidechain_follower = False
+
+        for rec in records:
+            if rec.get("type") != "assistant":
+                continue
+            branch = rec.get("gitBranch") or ""
+            if branch_filter and branch not in branch_filter:
+                continue
+            is_sidechain = bool(rec.get("isSidechain"))
+            for block in ((rec.get("message") or {}).get("content") or []):
+                if not isinstance(block, dict) or block.get("type") != "tool_use" or block.get("name") != "Skill":
+                    continue
+                skill = (block.get("input") or {}).get("skill") or ""
+                if skill == leader and not is_sidechain:
+                    if not has_leader_hit:
+                        # Timestamp of first leader hit; skip session if unparseable
+                        leader_first_ts = _parse_ts(rec.get("timestamp"))
+                    has_leader_hit = True
+                elif skill == follower:
+                    if is_sidechain:
+                        has_sidechain_follower = True
+                    else:
+                        has_main_follower = True
+
+        if not has_leader_hit:
+            continue
+        # Skip session entirely if the first leader hit has no parseable timestamp
+        if leader_first_ts is None:
+            continue
+
+        iso = datetime.fromtimestamp(leader_first_ts, tz=UTC).isocalendar()
+        bin_str = f"{iso.year}-W{iso.week:02d}"
+
+        d = data[bin_str]
+        d["leader_sessions"] += 1
+        if has_main_follower:
+            d["follower_main"] += 1
+        elif has_sidechain_follower:
+            # sidechain-only: sidechain follower present AND no main-thread follower
+            d["follower_sidechain_only"] += 1
+
+    if not data:
+        print("No data found.")
+        return
+
+    print(f"{'Bin':<10} {'Lead':>5} {'Main':>5} {'Side':>5} {'Pair%':>7}")
+    print(f"{'-------':<10} {'----':>5} {'----':>5} {'----':>5} {'-----':>7}")
+    for bin_str in sorted(data):
+        d = data[bin_str]
+        lead = d["leader_sessions"]
+        main = d["follower_main"]
+        side = d["follower_sidechain_only"]
+        pair_pct = 100.0 * main / lead if lead else 0.0
+        print(f"{bin_str:<10} {lead:>5} {main:>5} {side:>5} {pair_pct:>6.1f}%")
+
+
 def cmd_pr_link(args: argparse.Namespace) -> None:
     if not getattr(args, "repo", None):
         print("--repo is required for pr-link", file=sys.stderr)
@@ -538,6 +621,23 @@ def main() -> None:
     p_pr.add_argument("--author", metavar="LOGIN", help="Filter comments to this GitHub login")
     p_pr.add_argument("--projects", default="*", metavar="GLOB")
     p_pr.set_defaults(func=cmd_pr_link)
+
+    p_skill_pair = sub.add_parser(
+        "skill-pair",
+        help=(
+            "Pairing rate between two skills, bucketed by ISO week. "
+            "Counts sessions where the leader fired and whether the follower also fired (main vs sidechain-only)."
+        ),
+    )
+    p_skill_pair.add_argument("leader", metavar="LEADER", help="Leading skill name (exact match on input.skill)")
+    p_skill_pair.add_argument("follower", metavar="FOLLOWER", help="Following skill name (exact match on input.skill)")
+    p_skill_pair.add_argument("--projects", default="*", metavar="GLOB")
+    p_skill_pair.add_argument(
+        "--exclude-projects", default=None, metavar="GLOB",
+        help="Skip project dirs whose basename matches this glob.",
+    )
+    p_skill_pair.add_argument("--branches", metavar="B1,B2,...")
+    p_skill_pair.set_defaults(func=cmd_skill_pair)
 
     parsed = parser.parse_args()
     parsed.func(parsed)


### PR DESCRIPTION
## Summary
- New `skill-pair` subcommand in `transcript-analysis.py` — reusable two-skill pairing-rate analyzer bucketed by ISO week, with 10 unit tests.

## Why
First consumer was an audit of `/plan-it` → `/plan-review` chain leakage. The audit brief reported 28% / 64% pair rates in W20 / W21; reproduction shows these are a **measurement artifact**. Eval-harness sessions (`sdk-cli` entrypoint, which does not implement the `Skill` tool) fire `/plan-it` as a `Skill` tool_use that errors immediately and falls back to inline behavior — counting as a leader-session even though the skill body never executes. Real-authoring pair rate is actually **75% → 83% → 96%** across W19–W21 (improving). Three real-authoring leaks total are a mixed bag (M3 + 2×M1) with no recurring structural cause. **Recommendation: accept the current state.** Future pairing questions across other skill pairs reuse this same subcommand.

## What ships
- `claude/.claude/scripts/transcript-analysis.py` — `cmd_skill_pair` function and `skill-pair` subparser. CLI shape: `skill-pair <leader> <follower> [--projects GLOB] [--exclude-projects GLOB] [--branches B1,B2,...]`. Output columns: `Bin | Lead | Main | Side | Pair%`.
- `claude/.claude/scripts/tests/test_transcript_analysis.py` — `class TestSkillPair` with 10 cases: empty corpus, leader-only, leader+main-follower, leader+sidechain-only-follower, both-flavors-counts-main-only, multiple-leader-hits-per-session, ISO-week boundary (Sun→Mon), `--projects` filter, `--exclude-projects` glob, `--branches` filter.

The audit's plan file at `.claude/plans/plan-it-chain-audit.md` and the findings report at `/tmp/plan-it-chain-audit-findings.md` stay local (repo `.gitignore` excludes `.claude/plans/`).

## Follow-ups (deferred, not in this PR)
- Optional `--require-skill-success` flag that would filter `Skill` tool_use blocks whose corresponding `tool_result` is `is_error: true`. Would close the eval-harness measurement gap without methodology-side exclusions. Deferred to keep this PR scope tight.

## Test plan
- [x] `pytest claude/.claude/` — 60 passed (10 new TestSkillPair cases + no regressions)
- [x] `ruff check claude/.claude/` — clean
- [x] Smoke: `transcript-analysis.py skill-pair plan-it plan-review` against the real corpus reproduces the brief's headline exactly (4/3/75%, 18/5/27.8%, 36/23/63.9%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)