### PR TITLE
fix(install): stop installing pyyaml into host Python

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.detect.outputs.changed == 'true'
-        run: pip install 'pytest==8.*' 'ruff==0.6.*' 'pyyaml==6.*'
+        run: pip install -r requirements-dev.txt
 
       - name: Run tests
         if: steps.detect.outputs.changed == 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 __pycache__/
 .pytest_cache/
+.venv/
 
 # Claude Code local state at repo root. The committed .claude/worktree-required
 # sentinel activates worktree enforcement for this repo; everything else in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to `claude-config` are documented here. Format follows [Keep
 
 ### Changed
 
+- **`install.sh` no longer modifies host Python** — pyyaml `pip install --user` block removed. `pyyaml` is contributor-only (needed by `pytest claude/.claude/`); contributors set up a repo-local `.venv` per `CONTRIBUTING.md` "Tests and lint". Pins moved into `requirements-dev.txt` so CI and contributors share one source. Fixes install-time failures on macOS systems where PEP 668 / Homebrew Python rejects `--user` writes.
 - **Plugin renamed `skill-review` → `skill-management`** — bumped to 2.0.0 (breaking — downstream installers must `claude plugin uninstall skill-review && claude plugin install skill-management@claude-config --scope project`); between uninstall and install there is a brief window with no SKILL.md gate active, do not commit SKILL.md changes during that window (#290)
 - **CI workflow renamed** — workflow display name changed from "Hook tests" to "Tests"; job id `tests` (the branch-protection check context) unchanged (#169)
 - **Handoff format inlined** — `/handoff` format moved inline into the command file; dependency on `/compact` docs removed (#176)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,10 +7,11 @@ govern any contribution (human or agent).
 ## Commands
 
 ```bash
-./install.sh                            # first-time setup (stow + plugin registration)
-pip install 'ruff==0.6.*'              # one-time linter install
-pytest claude/.claude/                  # test suite (hooks + skills)
-ruff check claude/.claude/              # lint
+./install.sh                                                 # first-time setup (stow + plugin registration)
+python3 -m venv .venv                                        # one-time contributor venv (pins in requirements-dev.txt)
+.venv/bin/pip install -r requirements-dev.txt                # pytest + ruff + pyyaml
+.venv/bin/pytest claude/.claude/                             # test suite (hooks + skills)
+.venv/bin/ruff check claude/.claude/                         # lint
 ```
 
 ## Working in this repo

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,12 +30,16 @@ This repo is public. Do not commit anything that identifies a private project, o
 
 ## Tests and lint
 
+Pins live in [`requirements-dev.txt`](./requirements-dev.txt) — the same file CI's install step reads, so versions stay in sync.
+
 ```bash
-pytest claude/.claude/   # hook and skill tests
-ruff check claude/.claude/  # lint
+python3 -m venv .venv
+.venv/bin/pip install -r requirements-dev.txt
+.venv/bin/pytest claude/.claude/    # hook and skill tests
+.venv/bin/ruff check claude/.claude/  # lint
 ```
 
-CI runs both on every PR and main push. Both must pass before the PR can be reviewed.
+`./install.sh` does not install anything into the host Python — the `.venv` above is the contributor setup. CI runs both commands on every PR and main push; both must pass before the PR can be reviewed.
 
 ## Skill evals
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ This repo exposes a marketplace via `.claude-plugin/marketplace.json`. Each plug
 - **`lovable-cloud`** — Skills for Lovable Cloud projects: Project/Workspace Knowledge fields, edge-function auth model (ES256 gateway constraint, two-tier auth), and migration-sync workflow. `claude plugin install lovable-cloud@claude-config --scope project`
 - **`skill-management`** — Authoring guardrails for SKILL.md files: a commit-time structural validator (catches frontmatter that would silently truncate from the harness's skill listing or fail strict-YAML parsing) plus a behavioral-equivalence audit via `/skill-review`. `claude plugin install skill-management@claude-config --scope project`
 
-  **Plugin dependency:** the structural validator imports `pyyaml`. On first session in a consumer repo, the plugin's `SessionStart` hook provisions a persistent venv at `${CLAUDE_PLUGIN_DATA}/venv` and installs `pyyaml` into it; the commit-time hook prefers that venv's `python` and falls back to system `python3`. Contributors to this repo still get `pyyaml` installed on the system `python3` via `./install.sh`, which the pytest path needs (it imports the validator directly without going through plugin hooks).
+  **Plugin dependency:** the structural validator imports `pyyaml`. On first session in a consumer repo, the plugin's `SessionStart` hook provisions a persistent venv at `${CLAUDE_PLUGIN_DATA}/venv` and installs `pyyaml` into it; the commit-time hook prefers that venv's `python` and falls back to system `python3`. `./install.sh` does not install anything into the host Python — contributors who run the test suite set up a repo-local `.venv` per [CONTRIBUTING.md "Tests and lint"](./CONTRIBUTING.md#tests-and-lint).
 
 - **`claude-hook-review`** — Review playbook for `.claude/hooks/*.sh` and `settings.json` hook entries: event/matcher selection, path resolution, script skeleton, fail-open/fail-closed posture, dispatch drift, and the 9-item review checklist. `claude plugin install claude-hook-review@claude-config --scope project`
 
@@ -326,13 +326,16 @@ Claude Code compresses conversation history when the context window fills up. Th
 
 ## Tests
 
-Pytest suite covering hooks (allow, deny, and ask paths) and skill description contracts:
+Pytest suite covering hooks (allow, deny, and ask paths) and skill description contracts. Pins live in [`requirements-dev.txt`](./requirements-dev.txt) (single source for CI + contributors):
 
 ```bash
-pytest claude/.claude/
+python3 -m venv .venv
+.venv/bin/pip install -r requirements-dev.txt
+.venv/bin/pytest claude/.claude/
+.venv/bin/ruff check claude/.claude/
 ```
 
-CI runs this on every PR and main push via `.github/workflows/tests.yml`.
+CI runs the same pin set on every PR and main push via `.github/workflows/tests.yml`.
 
 ## Acknowledgments
 

--- a/install.sh
+++ b/install.sh
@@ -13,23 +13,6 @@ if [ ${#missing[@]} -gt 0 ]; then
   exit 1
 fi
 
-# pyyaml is imported by the skill-management plugin's structural validator,
-# which the pre-commit hook invokes via python3 and which the test suite
-# imports directly. Without it, `pytest claude/.claude/` fails to collect.
-if ! python3 -c "import yaml" >/dev/null 2>&1; then
-  echo ""
-  echo "=== Installing pyyaml (needed by tests + skill-management plugin) ==="
-  if ! python3 -m pip install --user pyyaml; then
-    echo ""
-    echo "pyyaml install failed. Some distros mark the system Python as"
-    echo "externally-managed (PEP 668). Install pyyaml another way and re-run:"
-    echo "  python3 -m pip install --user --break-system-packages pyyaml   # if you trust system pip"
-    echo "  pipx install pyyaml                                            # isolated install"
-    echo "  python3 -m venv .venv && .venv/bin/pip install pyyaml          # repo-local venv"
-    exit 1
-  fi
-fi
-
 REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$REPO_DIR"
 mkdir -p "$HOME/.local/bin"
@@ -97,5 +80,6 @@ check_private_projects_file() {
 check_private_projects_file
 
 echo ""
-echo "Done. Optional: run the hook test suite:"
-echo "  pytest claude/.claude/"
+echo "Done. Optional: run the hook test suite (see CONTRIBUTING.md 'Tests and lint'):"
+echo "  python3 -m venv .venv && .venv/bin/pip install -r requirements-dev.txt"
+echo "  .venv/bin/pytest claude/.claude/"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+pytest==8.*
+ruff==0.6.*
+pyyaml==6.*


### PR DESCRIPTION
## Summary

- `install.sh`'s `pip install --user pyyaml` block fails on macOS where PEP 668 / Homebrew Python rejects `--user` writes. Removed entirely — pyyaml is contributor-only (the SKILL.md structural validator's runtime path is covered by `plugins/skill-management/hooks/provision-validator-venv.sh`).
- Added `requirements-dev.txt` (`pytest==8.*`, `ruff==0.6.*`, `pyyaml==6.*`) as the single pin source for CI + contributors.
- `.github/workflows/tests.yml` now `pip install -r requirements-dev.txt` (verbatim same pin set, no resolver drift).
- Documented the contributor `.venv` flow in `CONTRIBUTING.md` "Tests and lint", `README.md` Tests section, and repo-root `CLAUDE.md` Commands. Updated `README.md` §180 plugin-dependency paragraph to drop the "install.sh installs pyyaml" carve-out.
- `.gitignore`: added `.venv/`.

Non-contributor stow consumers now get a fully silent install (no host-Python modification, no probes). Contributors set up `.venv` per CONTRIBUTING.md.

## Test plan

- [x] Pre-flight: `pytest claude/.claude/` (1183 pass post-rebase) + `ruff check claude/.claude/` clean (delegated to `check-runner`).
- [ ] Re-run on macOS to confirm `./install.sh` completes without the prior pyyaml-install failure (the originating bug).
- [ ] Confirm CI's `Install dependencies` step on the Tests workflow resolves the same package versions as before the swap.
- [ ] Smoke test the `skill-management` plugin's SessionStart venv provisioning still fires once on a fresh repo with no pre-existing `${CLAUDE_PLUGIN_DATA}/venv`.

## Out of scope

- Pinning `actions/setup-python@v5` to a commit SHA (pre-existing supply-chain mutable-tag concern flagged by `/code-review` specialist; orthogonal to this PR, recommended as a follow-up).
- Adding `python3` to the `README.md` §83 required-tools list (pre-existing doc/code mismatch — install.sh has required it at line 7 since before this PR; flagged in the plan's Out of Scope section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)