### PR TITLE
fix(install): skip claude-config in extraKnownMarketplaces loop

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -35,6 +35,12 @@ if [ -f "$SETTINGS_FILE" ]; then
   fi
 
   while IFS=$'\t' read -r name source_type repo; do
+    # claude-config is registered separately above as a directory source; skip
+    # any extraKnownMarketplaces entry so a stray leftover doesn't trip the
+    # non-github warning below.
+    if [ "$name" = "claude-config" ]; then
+      continue
+    fi
     if [ "$source_type" != "github" ]; then
       echo "  ! $name: non-github source '$source_type' — skipping (only github sources are portable)"
       continue


### PR DESCRIPTION
## Summary

The `extraKnownMarketplaces` loop in `install.sh` already special-cases `claude-config` registration above (it's a directory source that needs `$REPO_DIR` substituted at runtime — PR #238). But if a `claude-config` entry ever ends up in `~/.claude/settings.json`'s `extraKnownMarketplaces` — via legacy state from a pre-#238 install, a Claude CLI version that writes user-scope marketplace adds into `settings.json`, or a manual add — the loop reads it back and trips the non-github warning:

```
! claude-config: non-github source 'directory' — skipping (only github sources are portable)
```

The warning is wrong by construction: `claude-config` cannot be a github source. Skip it in the loop and continue.

## Test plan

- [ ] On a machine where the warning was firing, pull this branch and re-run `./install.sh` — confirm the `claude-config: non-github source` line no longer appears, and that the marketplace registration still works (`claude plugin marketplace list` shows `claude-config`).
- [ ] On a fresh install where the entry is absent, confirm `./install.sh` still self-registers `claude-config` from `\$REPO_DIR` without regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)