### PR TITLE
feat(skill-management): elevate aggregate corpus budget check to plugin

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,8 +54,8 @@ jobs:
 
           # Include any directory that contains test files or whose contents are
           # read by tests. Update this list when a new test or test-input
-          # directory appears under claude/.claude/.
-          REGEX='^(claude/\.claude/(hooks|skills|scripts|tests)/|\.github/workflows/tests\.yml|pyproject\.toml)'
+          # directory appears under claude/.claude/ or plugins/skill-management/.
+          REGEX='^(claude/\.claude/(hooks|skills|scripts|tests)/|plugins/skill-management/|\.github/workflows/tests\.yml|pyproject\.toml)'
 
           MATCHED=$(echo "$CHANGED" | grep -E "$REGEX" || true)
           UNMATCHED=$(echo "$CHANGED" | grep -vE "$REGEX" || true)

--- a/claude/.claude/hooks/tests/test_require_skill_review.py
+++ b/claude/.claude/hooks/tests/test_require_skill_review.py
@@ -694,16 +694,17 @@ class TestCorpusBudgetWarning:
         assert "corpus budget warning" not in result.stderr
 
     def test_corpus_warning_does_not_fire_when_no_skill_staged(self, isolated_home, git_repo):
-        """The corpus check is skipped entirely when no SKILL.md is staged.
+        """The corpus check does not warn when no SKILL.md is staged.
 
-        The hook exits early before reaching the corpus block in that case."""
+        The hook exits early at the SKILL_DIFF check (no staged skills), so the
+        corpus block is never reached."""
         # git_repo has only file.txt staged — no SKILL.md.
         result = _run_hook_with_stderr(
             SKILL_REVIEW_HOOK,
             bash_input("git commit -m foo", session_id=DEFAULT_TEST_SESSION_ID),
             cwd=git_repo,
         )
-        # Hook must allow (early exit).
+        # Hook must allow (early exit before corpus block).
         assert not result.stdout.strip() or "deny" not in result.stdout
         assert "corpus budget warning" not in result.stderr
 

--- a/claude/.claude/hooks/tests/test_require_skill_review.py
+++ b/claude/.claude/hooks/tests/test_require_skill_review.py
@@ -1,6 +1,7 @@
 """Tests for require-skill-review.sh."""
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 
@@ -620,3 +621,118 @@ class TestRequireSkillReview:
             "plugins/skill-management/hooks/_lib.sh has drifted from claude/.claude/hooks/_lib.sh. "
             "These files must stay byte-identical — update the plugin copy when the stowed copy changes."
         )
+
+
+def _run_hook_with_stderr(hook, tool_input: dict, cwd) -> subprocess.CompletedProcess:
+    """Run a hook and return the full CompletedProcess so callers can inspect both stdout and stderr."""
+    return subprocess.run(
+        [str(hook)],
+        input=json.dumps(tool_input),
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+        check=False,
+    )
+
+
+def _stage_oversized_corpus(git_repo, num_skills: int = 6, chars_each: int = 1500) -> None:
+    """Stage multiple SKILL.md files whose combined description chars exceed the 8000-char budget."""
+    for i in range(num_skills):
+        skill_file = git_repo / "claude" / ".claude" / "skills" / f"corpus-skill-{i}" / "SKILL.md"
+        skill_file.parent.mkdir(parents=True, exist_ok=True)
+        description = "x" * chars_each
+        skill_file.write_text(
+            f"---\ndescription: {description!r}\n---\n# body\n"
+        )
+        subprocess.run(
+            ["git", "add", str(skill_file.relative_to(git_repo))],
+            cwd=git_repo,
+            check=True,
+        )
+
+
+class TestCorpusBudgetWarning:
+    """Corpus budget check emits a non-blocking stderr warning on skill-touching commits.
+
+    The corpus check fires only when at least one SKILL.md is staged. It is
+    intentionally non-blocking — the commit is allowed regardless of whether the
+    aggregate description total exceeds the Claude Code listing budget. Hard
+    enforcement lives in pytest/CI (test_total_within_listing_budget).
+    """
+
+    def test_corpus_over_budget_emits_warning_but_allows_commit(
+        self, isolated_home, git_repo
+    ):
+        """When staged skills push total descriptions over 8000 chars, a warning
+        appears on stderr but the commit decision is allow (no deny JSON on stdout)."""
+        _stage_oversized_corpus(git_repo)
+        write_skill_review_marker(isolated_home, git_repo)
+        result = _run_hook_with_stderr(
+            SKILL_REVIEW_HOOK,
+            bash_input("git commit -m foo", session_id=DEFAULT_TEST_SESSION_ID),
+            cwd=git_repo,
+        )
+        # Hook must allow (no JSON deny on stdout).
+        assert not result.stdout.strip() or (
+            "deny" not in result.stdout
+        ), f"unexpected deny: {result.stdout}"
+        # Warning must appear on stderr.
+        assert "corpus budget warning" in result.stderr, (
+            f"expected corpus budget warning on stderr; got: {result.stderr!r}"
+        )
+
+    def test_corpus_under_budget_no_warning(self, isolated_home, git_repo):
+        """A single small skill staged does not trigger the corpus budget warning."""
+        _stage_skill_change(git_repo)
+        write_skill_review_marker(isolated_home, git_repo)
+        result = _run_hook_with_stderr(
+            SKILL_REVIEW_HOOK,
+            bash_input("git commit -m foo", session_id=DEFAULT_TEST_SESSION_ID),
+            cwd=git_repo,
+        )
+        assert not result.stdout.strip() or "deny" not in result.stdout
+        assert "corpus budget warning" not in result.stderr
+
+    def test_corpus_warning_does_not_fire_when_no_skill_staged(self, isolated_home, git_repo):
+        """The corpus check is skipped entirely when no SKILL.md is staged.
+
+        The hook exits early before reaching the corpus block in that case."""
+        # git_repo has only file.txt staged — no SKILL.md.
+        result = _run_hook_with_stderr(
+            SKILL_REVIEW_HOOK,
+            bash_input("git commit -m foo", session_id=DEFAULT_TEST_SESSION_ID),
+            cwd=git_repo,
+        )
+        # Hook must allow (early exit).
+        assert not result.stdout.strip() or "deny" not in result.stdout
+        assert "corpus budget warning" not in result.stderr
+
+    def test_corpus_warning_allows_even_when_validator_python_missing(
+        self, isolated_home, git_repo, tmp_path, monkeypatch
+    ):
+        """When the validator python cannot be found, the corpus block must not deny.
+
+        A misconfigured environment must not block commits — the corpus check is
+        best-effort and non-blocking by design.
+        """
+        # Point CLAUDE_PLUGIN_DATA at a dir without a venv; system python3 will be used.
+        # Then shadow python3 with a stub that exits 0 but writes nothing — simulating
+        # a missing pyyaml in a constrained environment where the corpus check silently
+        # does nothing.
+        fake_bin = tmp_path / "fake-bin"
+        fake_bin.mkdir()
+        fake_python = fake_bin / "python3"
+        fake_python.write_text("#!/bin/bash\nexit 0\n")
+        fake_python.chmod(0o755)
+        monkeypatch.setenv("PATH", f"{fake_bin}:{os.environ['PATH']}")
+        monkeypatch.delenv("CLAUDE_PLUGIN_DATA", raising=False)
+
+        _stage_oversized_corpus(git_repo)
+        write_skill_review_marker(isolated_home, git_repo)
+        result = _run_hook_with_stderr(
+            SKILL_REVIEW_HOOK,
+            bash_input("git commit -m foo", session_id=DEFAULT_TEST_SESSION_ID),
+            cwd=git_repo,
+        )
+        # Must not deny even though corpus would exceed budget.
+        assert not result.stdout.strip() or "deny" not in result.stdout

--- a/claude/.claude/skills/tests/test_skills.py
+++ b/claude/.claude/skills/tests/test_skills.py
@@ -36,7 +36,11 @@ import pytest
 # Single source of truth for SKILL.md structural rules — the commit-gate hook
 # shells out to the same module. pyproject.toml's [tool.pytest.ini_options]
 # pythonpath puts plugins/skill-management/scripts on the import path.
-from validate_skill_structure import parse_frontmatter, validate
+from validate_skill_structure import (
+    SKILL_LISTING_BUDGET_CHARS,
+    corpus_budget_violations,
+    validate,
+)
 
 SKILLS_DIR = Path(__file__).resolve().parent.parent.parent / "skills"
 # Plugins live two levels above the .claude/ dir: <repo>/plugins/<name>/skills/<skill>/SKILL.md
@@ -359,33 +363,6 @@ class TestModelInvokableDescriptionLength:
         assert not length_violations, "\n".join(length_violations)
 
 
-# Skill-listing budget constants — extracted from the Claude Code binary
-# v2.1.145. Function TM$(H, $=M77) computes:
-#   budget = floor(context_window_tokens × bytesPerToken × fraction)
-# unless SLASH_COMMAND_TOOL_CHAR_BUDGET is set, in which case that wins.
-# Binary symbols (decompiled): Q3_=0.01 (fraction), M77=4 (bytesPerToken),
-# g3_=200000 (fallback context tokens), d3_=1536 (per-skill cap).
-#
-# Claude Code orchestrators run on Opus 4.7 or Sonnet 4.6; both have 1M-token
-# nominal context per the Anthropic model overview, but the binary applies
-# the 200000-token fallback at runtime — the per-skill trim PRs (#203, #298)
-# targeted the resulting 8000-char budget, so that is the operative bound
-# this test enforces. The test class is named for Sonnet because the same
-# 200000-token fallback applies to both Opus and Sonnet orchestrators, so
-# the bound is identical regardless of which model is dispatching. Raising
-# the bound to the nominal 1M context would require evidence that Claude
-# Code passes the model's true window through the H parameter, which
-# v2.1.145 does not.
-SKILL_LISTING_FALLBACK_CONTEXT_TOKENS = 200_000
-SKILL_LISTING_BYTES_PER_TOKEN = 4
-SKILL_LISTING_BUDGET_FRACTION = 0.01
-SKILL_LISTING_BUDGET_CHARS = int(
-    SKILL_LISTING_FALLBACK_CONTEXT_TOKENS
-    * SKILL_LISTING_BYTES_PER_TOKEN
-    * SKILL_LISTING_BUDGET_FRACTION
-)
-
-
 class TestTotalListingBudgetUnderSonnet:
     """Pin the aggregate skill-listing total under Claude Code's char budget.
 
@@ -395,44 +372,76 @@ class TestTotalListingBudgetUnderSonnet:
     Claude Code drops descriptions for the least-used skills entirely; the
     user-facing symptom is silent — Claude stops auto-loading affected
     skills until the user notices and runs ``/doctor``.
-
-    Test premise: if the total fits the Sonnet-context-window budget, it
-    fits the Opus budget by construction (both 1M nominal, both apply the
-    same 200000-token fallback at runtime). On failure, the message names
-    the five largest descriptions so the trimming target is obvious.
     """
 
     MODEL_INVOKABLE_SKILLS = _model_invokable_skills()
 
     def test_total_within_listing_budget(self):
-        per_skill_chars: dict[str, int] = {}
-        for skill_name in self.MODEL_INVOKABLE_SKILLS:
-            frontmatter = parse_frontmatter(_skill_file(skill_name))
-            description = frontmatter.get("description", "") or ""
-            when_to_use = frontmatter.get("when_to_use", "") or ""
-            per_skill_chars[skill_name] = len(description) + len(when_to_use)
+        skill_paths = [_skill_file(name) for name in self.MODEL_INVOKABLE_SKILLS]
+        violations = corpus_budget_violations(skill_paths, SKILL_LISTING_BUDGET_CHARS)
+        assert not violations, "\n".join(violations)
 
-        total = sum(per_skill_chars.values())
-        if total <= SKILL_LISTING_BUDGET_CHARS:
-            return
 
-        top_offenders = sorted(
-            per_skill_chars.items(), key=lambda item: item[1], reverse=True
-        )[:5]
-        offender_lines = "\n".join(
-            f"  {name}: {chars} chars" for name, chars in top_offenders
-        )
-        raise AssertionError(
-            f"Combined description+when_to_use across "
-            f"{len(self.MODEL_INVOKABLE_SKILLS)} model-invokable skills is "
-            f"{total} chars, exceeds Claude Code listing budget of "
-            f"{SKILL_LISTING_BUDGET_CHARS} chars "
-            f"(floor({SKILL_LISTING_FALLBACK_CONTEXT_TOKENS} tokens × "
-            f"{SKILL_LISTING_BYTES_PER_TOKEN} chars/token × "
-            f"{SKILL_LISTING_BUDGET_FRACTION}). Descriptions for "
-            f"least-used skills will be dropped from the system-prompt "
-            f"listing. Trim the largest offenders:\n{offender_lines}"
-        )
+class TestCorpusBudgetFunction:
+    """Unit tests for corpus_budget_violations() — uses tmp_path fixtures."""
+
+    def _make_skill(self, tmp_path, name: str, description: str = "", when_to_use: str = "", disable: bool = False) -> Path:
+        skill_dir = tmp_path / name
+        skill_dir.mkdir()
+        skill_file = skill_dir / "SKILL.md"
+        lines = ["---"]
+        if description:
+            lines.append(f"description: {description!r}")
+        if when_to_use:
+            lines.append(f"when_to_use: {when_to_use!r}")
+        if disable:
+            lines.append("disable-model-invocation: true")
+        lines.append("---")
+        lines.append("")
+        skill_file.write_text("\n".join(lines))
+        return skill_file
+
+    def test_under_budget_passes(self, tmp_path):
+        f = self._make_skill(tmp_path, "a", description="x" * 100)
+        assert corpus_budget_violations([f], 200) == []
+
+    def test_over_budget_fails(self, tmp_path):
+        f = self._make_skill(tmp_path, "a", description="x" * 100)
+        violations = corpus_budget_violations([f], 99)
+        assert len(violations) == 1
+        assert "100 chars" in violations[0]
+
+    def test_exact_boundary_passes(self, tmp_path):
+        f = self._make_skill(tmp_path, "a", description="x" * 100)
+        assert corpus_budget_violations([f], 100) == []
+
+    def test_one_over_boundary_fails(self, tmp_path):
+        f = self._make_skill(tmp_path, "a", description="x" * 101)
+        assert corpus_budget_violations([f], 100) != []
+
+    def test_empty_corpus_passes(self, tmp_path):
+        assert corpus_budget_violations([], 8000) == []
+
+    def test_disable_model_invocation_excluded(self, tmp_path):
+        f = self._make_skill(tmp_path, "a", description="x" * 100, disable=True)
+        # With disable=True the skill is excluded; should pass a budget of 0.
+        assert corpus_budget_violations([f], 0) == []
+
+    def test_sums_description_and_when_to_use(self, tmp_path):
+        f = self._make_skill(tmp_path, "a", description="x" * 50, when_to_use="y" * 60)
+        # Total is 110 chars. Budget of 109 should fail; 110 should pass.
+        assert corpus_budget_violations([f], 110) == []
+        assert corpus_budget_violations([f], 109) != []
+
+    def test_names_top_offenders_on_failure(self, tmp_path):
+        files = [
+            self._make_skill(tmp_path, f"skill_{i}", description="x" * (100 + i * 10))
+            for i in range(6)
+        ]
+        violations = corpus_budget_violations(files, 1)
+        assert violations
+        # Violation message should name at most 5 offenders.
+        assert violations[0].count("chars") >= 5  # each offender line ends "N chars"
 
 
 def test_trigger_cases_files_well_formed() -> None:

--- a/plugins/skill-management/.claude-plugin/plugin.json
+++ b/plugins/skill-management/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "skill-management",
   "description": "Authoring guardrails for SKILL.md files: a commit-time structural validator (catches frontmatter that would silently truncate from the harness's skill listing or fail strict-YAML parsing) plus a behavioral-equivalence audit via /skill-review. Install at project scope in repos that author SKILL.md files.",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "author": {
     "name": "Cordova Strategy"
   },

--- a/plugins/skill-management/hooks/require-skill-review.sh
+++ b/plugins/skill-management/hooks/require-skill-review.sh
@@ -77,6 +77,18 @@ while IFS= read -r STAGED_PATH; do
   [ -n "$STAGED_PATH" ] && STAGED_SKILL_PATHS+=("$STAGED_PATH")
 done <<< "$SKILL_DIFF"
 
+VALIDATOR_SCRIPT="$(dirname "$0")/../scripts/validate_skill_structure.py"
+# Prefer the plugin's persistent-venv python (provisioned by the
+# SessionStart hook against ${CLAUDE_PLUGIN_DATA}/venv) so the validator
+# finds pyyaml without the consumer running a manual pip install. Fall
+# back to system python3 — covers the contributor pytest path, which
+# imports the validator directly without going through plugin hooks, and
+# the brief window before the first SessionStart provisions the venv.
+VALIDATOR_PYTHON="python3"
+if [ -n "${CLAUDE_PLUGIN_DATA:-}" ] && [ -x "${CLAUDE_PLUGIN_DATA}/venv/bin/python" ]; then
+  VALIDATOR_PYTHON="${CLAUDE_PLUGIN_DATA}/venv/bin/python"
+fi
+
 if [ "${#STAGED_SKILL_PATHS[@]}" -gt 0 ]; then
   STAGED_BLOB_DIR=$(mktemp -d)
   trap 'rm -rf "$STAGED_BLOB_DIR"' EXIT
@@ -93,17 +105,6 @@ if [ "${#STAGED_SKILL_PATHS[@]}" -gt 0 ]; then
   done
 
   if [ "${#STAGED_BLOB_PATHS[@]}" -gt 0 ]; then
-    VALIDATOR_SCRIPT="$(dirname "$0")/../scripts/validate_skill_structure.py"
-    # Prefer the plugin's persistent-venv python (provisioned by the
-    # SessionStart hook against ${CLAUDE_PLUGIN_DATA}/venv) so the validator
-    # finds pyyaml without the consumer running a manual pip install. Fall
-    # back to system python3 — covers the contributor pytest path, which
-    # imports the validator directly without going through plugin hooks, and
-    # the brief window before the first SessionStart provisions the venv.
-    VALIDATOR_PYTHON="python3"
-    if [ -n "${CLAUDE_PLUGIN_DATA:-}" ] && [ -x "${CLAUDE_PLUGIN_DATA}/venv/bin/python" ]; then
-      VALIDATOR_PYTHON="${CLAUDE_PLUGIN_DATA}/venv/bin/python"
-    fi
     VALIDATOR_STDERR=$("$VALIDATOR_PYTHON" "$VALIDATOR_SCRIPT" "${STAGED_BLOB_PATHS[@]}" 2>&1)
     VALIDATOR_EXIT=$?
     if [ "$VALIDATOR_EXIT" -ne 0 ]; then
@@ -115,6 +116,36 @@ if [ "${#STAGED_SKILL_PATHS[@]}" -gt 0 ]; then
       printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' "$REASON_JSON"
       exit 0
     fi
+  fi
+fi
+
+# Corpus budget warning: check aggregate description+when_to_use chars across
+# all model-invokable skills in this repo against the Claude Code listing budget.
+# Non-blocking — exits 0 regardless; hard enforcement is in pytest/CI.
+# Uses the same scoped pathspecs as SKILL_DIFF above (no bare *SKILL.md glob,
+# which would sweep in vendored or fixture files).
+CORPUS_PATHS=()
+while IFS= read -r CORPUS_PATH; do
+  [ -n "$CORPUS_PATH" ] && CORPUS_PATHS+=("$CORPUS_PATH")
+done < <(git ls-files 'claude/.claude/skills/**/SKILL.md' 'plugins/*/skills/**/SKILL.md' 2>/dev/null)
+
+# Overlay staged blobs: replace corpus path with staged blob path for any
+# staged SKILL.md (so the warning reflects the post-commit state of staged files).
+if [ "${#CORPUS_PATHS[@]}" -gt 0 ]; then
+  OVERLAY_PATHS=()
+  for CORPUS_PATH in "${CORPUS_PATHS[@]}"; do
+    # Check if this path has a staged version (already materialized in STAGED_BLOB_DIR).
+    BLOB_CANDIDATE="${STAGED_BLOB_DIR:-}/$CORPUS_PATH"
+    if [ -n "${STAGED_BLOB_DIR:-}" ] && [ -f "$BLOB_CANDIDATE" ]; then
+      OVERLAY_PATHS+=("$BLOB_CANDIDATE")
+    else
+      OVERLAY_PATHS+=("$CORPUS_PATH")
+    fi
+  done
+
+  CORPUS_STDERR=$("$VALIDATOR_PYTHON" "$VALIDATOR_SCRIPT" --corpus "${OVERLAY_PATHS[@]}" 2>&1)
+  if [ -n "$CORPUS_STDERR" ]; then
+    printf 'skill-management: corpus budget warning: %s\n' "$CORPUS_STDERR" >&2
   fi
 fi
 

--- a/plugins/skill-management/hooks/require-skill-review.sh
+++ b/plugins/skill-management/hooks/require-skill-review.sh
@@ -143,7 +143,7 @@ if [ "${#CORPUS_PATHS[@]}" -gt 0 ]; then
     fi
   done
 
-  CORPUS_STDERR=$("$VALIDATOR_PYTHON" "$VALIDATOR_SCRIPT" --corpus "${OVERLAY_PATHS[@]}" 2>&1)
+  CORPUS_STDERR=$(timeout 10s "$VALIDATOR_PYTHON" "$VALIDATOR_SCRIPT" --corpus "${OVERLAY_PATHS[@]}" 2>&1 || true)
   if [ -n "$CORPUS_STDERR" ]; then
     printf 'skill-management: corpus budget warning: %s\n' "$CORPUS_STDERR" >&2
   fi

--- a/plugins/skill-management/scripts/validate_skill_structure.py
+++ b/plugins/skill-management/scripts/validate_skill_structure.py
@@ -1,18 +1,19 @@
 """Structural validator for SKILL.md files.
 
-Exposes a library interface (``validate(skill_file)``) and a CLI entry point
-(``python3 validate_skill_structure.py <paths...>``) for use by the
-``require-skill-review.sh`` hook and the ``test_skills.py`` test suite.
+Exposes a library interface (``validate(skill_file)``, ``corpus_budget_violations()``)
+and a CLI entry point (``python3 validate_skill_structure.py <paths...>``) for
+use by the ``require-skill-review.sh`` hook and the ``test_skills.py`` test suite.
 
-The two rules enforced here are the single source of truth for the
-plugin — the hook invokes this module at commit time, and the test suite
-imports it and calls ``validate()`` directly. Neither the hook nor the tests
-re-implement the rules.
+The rules enforced here are the single source of truth for the plugin — the
+hook invokes this module at commit time, and the test suite imports it and calls
+``validate()`` and ``corpus_budget_violations()`` directly. Neither the hook nor
+the tests re-implement the rules.
 """
 
 from __future__ import annotations
 
 import sys
+from collections.abc import Iterable
 from pathlib import Path
 
 import yaml
@@ -22,6 +23,32 @@ import yaml
 # listing to reduce context usage." Configurable via maxSkillDescriptionChars
 # setting; 1,536 is the default the harness applies when no override is set.
 MAX_SKILL_DESCRIPTION_CHARS = 1536
+
+# Skill-listing budget constants — extracted from the Claude Code binary
+# v2.1.145. Function TM$(H, $=M77) computes:
+#   budget = floor(context_window_tokens × bytesPerToken × fraction)
+# unless SLASH_COMMAND_TOOL_CHAR_BUDGET is set, in which case that wins.
+# Binary symbols (decompiled): Q3_=0.01 (fraction), M77=4 (bytesPerToken),
+# g3_=200000 (fallback context tokens), d3_=1536 (per-skill cap).
+#
+# Claude Code orchestrators run on Opus 4.7 or Sonnet 4.6; both have 1M-token
+# nominal context per the Anthropic model overview, but the binary applies
+# the 200000-token fallback at runtime — the per-skill trim PRs (#203, #298)
+# targeted the resulting 8000-char budget, so that is the operative bound
+# this check enforces. The test class is named for Sonnet because the same
+# 200000-token fallback applies to both Opus and Sonnet orchestrators, so
+# the bound is identical regardless of which model is dispatching. Raising
+# the bound to the nominal 1M context would require evidence that Claude
+# Code passes the model's true window through the H parameter, which
+# v2.1.145 does not.
+SKILL_LISTING_FALLBACK_CONTEXT_TOKENS = 200_000
+SKILL_LISTING_BYTES_PER_TOKEN = 4
+SKILL_LISTING_BUDGET_FRACTION = 0.01
+SKILL_LISTING_BUDGET_CHARS = int(
+    SKILL_LISTING_FALLBACK_CONTEXT_TOKENS
+    * SKILL_LISTING_BYTES_PER_TOKEN
+    * SKILL_LISTING_BUDGET_FRACTION
+)
 
 
 def parse_frontmatter(skill_file: Path) -> dict:
@@ -80,9 +107,76 @@ def validate(skill_file: Path) -> list[str]:
     return violations
 
 
+def corpus_budget_violations(skill_files: Iterable[Path], budget: int) -> list[str]:
+    """Check whether the aggregate description+when_to_use chars exceed budget.
+
+    Pure function — no filesystem discovery. Caller supplies the file list and
+    decides corpus scope (project-only, user-scope, plugin skills, etc.) so
+    user-scope and project-scope listings are never inadvertently conflated.
+
+    Skips files with disable-model-invocation: true (their descriptions are
+    suppressed from the harness listing). Skips files with unparseable
+    frontmatter rather than aborting — preserving best-effort posture for
+    use in non-blocking hook warnings.
+
+    Returns a list with at most one violation string (naming total and the
+    five largest offenders) or an empty list if the corpus is within budget.
+    """
+    per_skill_chars: dict[str, int] = {}
+    for skill_file in skill_files:
+        try:
+            frontmatter = parse_frontmatter(skill_file)
+        except (yaml.YAMLError, ValueError, OSError):
+            continue
+        if frontmatter.get("disable-model-invocation"):
+            continue
+        description = frontmatter.get("description", "") or ""
+        when_to_use = frontmatter.get("when_to_use", "") or ""
+        per_skill_chars[str(skill_file)] = len(description) + len(when_to_use)
+
+    total = sum(per_skill_chars.values())
+    if total <= budget:
+        return []
+
+    top_offenders = sorted(
+        per_skill_chars.items(), key=lambda item: item[1], reverse=True
+    )[:5]
+    offender_lines = "\n".join(
+        f"  {name}: {chars} chars" for name, chars in top_offenders
+    )
+    skill_count = len(per_skill_chars)
+    return [
+        f"Combined description+when_to_use across {skill_count} model-invokable "
+        f"skills is {total} chars, exceeds Claude Code listing budget of "
+        f"{budget} chars "
+        f"(floor({SKILL_LISTING_FALLBACK_CONTEXT_TOKENS} tokens × "
+        f"{SKILL_LISTING_BYTES_PER_TOKEN} chars/token × "
+        f"{SKILL_LISTING_BUDGET_FRACTION})). Descriptions for least-used skills "
+        f"will be dropped from the system-prompt listing. Trim the largest "
+        f"offenders:\n{offender_lines}"
+    ]
+
+
 if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("files", nargs="*")
+    parser.add_argument("--corpus", nargs="+", metavar="FILE")
+    args = parser.parse_args()
+
+    if args.corpus is not None:
+        violations = corpus_budget_violations(
+            [Path(f) for f in args.corpus], SKILL_LISTING_BUDGET_CHARS
+        )
+        if violations:
+            for v in violations:
+                print(v, file=sys.stderr)
+        sys.exit(0)  # --corpus is always best-effort; never exits non-zero
+
+    # Default: per-file structural validation (hard-deny mode).
     all_violations: list[str] = []
-    for arg in sys.argv[1:]:
+    for arg in args.files:
         all_violations.extend(validate(Path(arg)))
 
     if all_violations:

--- a/plugins/skill-management/scripts/validate_skill_structure.py
+++ b/plugins/skill-management/scripts/validate_skill_structure.py
@@ -114,10 +114,12 @@ def corpus_budget_violations(skill_files: Iterable[Path], budget: int) -> list[s
     decides corpus scope (project-only, user-scope, plugin skills, etc.) so
     user-scope and project-scope listings are never inadvertently conflated.
 
-    Skips files with disable-model-invocation: true (their descriptions are
-    suppressed from the harness listing). Skips files with unparseable
-    frontmatter rather than aborting — preserving best-effort posture for
-    use in non-blocking hook warnings.
+    Skips files with disable-model-invocation: true (exact hyphenated key;
+    only the literal string "disable-model-invocation" is recognized —
+    underscore variants are not). Skips files with unparseable frontmatter
+    rather than aborting — preserving best-effort posture for use in
+    non-blocking hook warnings. Descriptions are suppressed from the harness
+    listing for disabled skills.
 
     Returns a list with at most one violation string (naming total and the
     five largest offenders) or an empty list if the corpus is within budget.
@@ -126,7 +128,7 @@ def corpus_budget_violations(skill_files: Iterable[Path], budget: int) -> list[s
     for skill_file in skill_files:
         try:
             frontmatter = parse_frontmatter(skill_file)
-        except (yaml.YAMLError, ValueError, OSError):
+        except (yaml.YAMLError, ValueError, OSError):  # ValueError covers UnicodeDecodeError
             continue
         if frontmatter.get("disable-model-invocation"):
             continue


### PR DESCRIPTION
## Summary

- Moves the 8000-char aggregate skill-listing budget check from `claude-config`'s pytest suite into the `skill-management` plugin so downstream plugin consumers get it automatically at commit time
- Adds `corpus_budget_violations()` pure function and `--corpus` CLI mode to `validate_skill_structure.py` (single source of truth — hook and test suite both import from here)
- Adds a non-blocking corpus warning block to `require-skill-review.sh` that fires on every SKILL.md commit; warns to stderr, never denies (hard enforcement stays in pytest/CI)
- Widens `.github/workflows/tests.yml` change-detection REGEX to include `plugins/skill-management/` so CI runs on plugin file changes
- Bumps plugin to `2.3.0`

## Design decisions

- **Hard enforcement stays in pytest/CI, not as a commit deny.** A budget violation doesn't block the commit — the warning nudges the author, but denial would create an unrecoverable state if the corpus is already over budget when the plugin is first installed. Hard gate via `test_total_within_listing_budget`.
- **Two separate validator invocations in the hook.** Per-file structural validation (hard deny) and corpus check (soft warn) use separate subprocess calls so their exit codes remain separable.
- **`corpus_budget_violations()` is a pure function.** No filesystem discovery — caller supplies the file list, so project-scope and user-scope listings are never inadvertently conflated.
- **`timeout 10s` on corpus subprocess.** Bounds the hook on slow Python startup (NFS venv, throttled container) without blocking commits — the `|| true` inside the command substitution preserves the non-blocking contract on timeout.

## Test plan

- [x] `pytest claude/.claude/` — 1202 tests pass (includes `TestCorpusBudgetWarning` (4 hook tests) and `TestCorpusBudgetFunction` (8 unit tests))
- [x] `ruff check claude/.claude/` — clean
- [ ] Manual smoke: stage a SKILL.md change in a repo with the plugin installed and confirm corpus warning appears on stderr when total exceeds 8000 chars

🤖 Generated with [Claude Code](https://claude.com/claude-code)