### PR TITLE
docs: note contributor .venv is main-tree-only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,8 +25,9 @@ non-read-only git operations must run inside a linked worktree
 (`git worktree add .claude/worktrees/<branch> -b <branch>`) or an agent with
 `isolation: worktree`. See README "Worktree enforcement" for why. The
 contributor `.venv` lives at the main worktree root only — it is gitignored,
-so linked worktrees never inherit it. Run tests and lint from a worktree via
-`../../../.venv/bin/pytest` and `../../../.venv/bin/ruff`.
+so linked worktrees never inherit it. That path is exactly three levels deep,
+so run tests and lint from a worktree via `../../../.venv/bin/pytest` and
+`../../../.venv/bin/ruff`.
 
 `claude/` is stowed into `$HOME`. Changes under `claude/.claude/**` go live on
 `git pull` — no re-install needed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,10 @@ python3 -m venv .venv                                        # one-time contribu
 Worktree enforcement is active. `.claude/worktree-required` is committed, so
 non-read-only git operations must run inside a linked worktree
 (`git worktree add .claude/worktrees/<branch> -b <branch>`) or an agent with
-`isolation: worktree`. See README "Worktree enforcement" for why.
+`isolation: worktree`. See README "Worktree enforcement" for why. The
+contributor `.venv` lives at the main worktree root only — it is gitignored,
+so linked worktrees never inherit it. Run tests and lint from a worktree via
+`../../../.venv/bin/pytest` and `../../../.venv/bin/ruff`.
 
 `claude/` is stowed into `$HOME`. Changes under `claude/.claude/**` go live on
 `git pull` — no re-install needed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,8 @@ python3 -m venv .venv
 .venv/bin/ruff check claude/.claude/  # lint
 ```
 
+The `.venv` lives only in the main worktree root. From a linked worktree (`.claude/worktrees/<branch>/`), invoke `../../../.venv/bin/pytest` and `../../../.venv/bin/ruff` instead.
+
 `./install.sh` does not install anything into the host Python — the `.venv` above is the contributor setup. CI runs both commands on every PR and main push; both must pass before the PR can be reviewed.
 
 ## Skill evals

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ python3 -m venv .venv
 .venv/bin/ruff check claude/.claude/  # lint
 ```
 
-The `.venv` lives only in the main worktree root. From a linked worktree (`.claude/worktrees/<branch>/`), invoke `../../../.venv/bin/pytest` and `../../../.venv/bin/ruff` instead.
+The `.venv` lives only in the main worktree root. Linked worktrees live at `.claude/worktrees/<branch>/` — exactly three levels deep — so from inside a worktree invoke `../../../.venv/bin/pytest` and `../../../.venv/bin/ruff` instead.
 
 `./install.sh` does not install anything into the host Python — the `.venv` above is the contributor setup. CI runs both commands on every PR and main push; both must pass before the PR can be reviewed.
 

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ cd .claude/worktrees/my-feature
 # work happens here; git commit/push/etc. pass through the hook cleanly
 ```
 
-The contributor `.venv` is gitignored and lives only in the main worktree root — linked worktrees never inherit it. Run tests and lint from a worktree via `../../../.venv/bin/pytest` and `../../../.venv/bin/ruff` (see [Tests](#tests)).
+The contributor `.venv` is gitignored and lives only in the main worktree root — linked worktrees never inherit it. See [Tests](#tests) for cross-worktree invocation.
 
 Agents spawned with `isolation: worktree` create their own worktrees under `.claude/worktrees/` automatically — on a harness-generated branch name (`worktree-agent-<hash>`). That auto-naming is fine for ephemeral, non-PR work (parallel exploration, reviewer agents). For PR-bound work that needs a meaningful branch name, create the worktree yourself with `git worktree add .claude/worktrees/<slug> -b <slug>` first, then dispatch the agent into that path.
 
@@ -337,7 +337,7 @@ python3 -m venv .venv
 .venv/bin/ruff check claude/.claude/
 ```
 
-The `.venv` lives only in the main worktree root. From a linked worktree (`.claude/worktrees/<branch>/`), invoke `../../../.venv/bin/pytest` and `../../../.venv/bin/ruff` instead.
+The `.venv` lives only in the main worktree root. Linked worktrees live at `.claude/worktrees/<branch>/` — exactly three levels deep — so from inside a worktree invoke `../../../.venv/bin/pytest` and `../../../.venv/bin/ruff` instead.
 
 CI runs the same pin set on every PR and main push via `.github/workflows/tests.yml`.
 

--- a/README.md
+++ b/README.md
@@ -255,6 +255,8 @@ cd .claude/worktrees/my-feature
 # work happens here; git commit/push/etc. pass through the hook cleanly
 ```
 
+The contributor `.venv` is gitignored and lives only in the main worktree root — linked worktrees never inherit it. Run tests and lint from a worktree via `../../../.venv/bin/pytest` and `../../../.venv/bin/ruff` (see [Tests](#tests)).
+
 Agents spawned with `isolation: worktree` create their own worktrees under `.claude/worktrees/` automatically — on a harness-generated branch name (`worktree-agent-<hash>`). That auto-naming is fine for ephemeral, non-PR work (parallel exploration, reviewer agents). For PR-bound work that needs a meaningful branch name, create the worktree yourself with `git worktree add .claude/worktrees/<slug> -b <slug>` first, then dispatch the agent into that path.
 
 To opt out, delete `.claude/worktree-required`.
@@ -334,6 +336,8 @@ python3 -m venv .venv
 .venv/bin/pytest claude/.claude/
 .venv/bin/ruff check claude/.claude/
 ```
+
+The `.venv` lives only in the main worktree root. From a linked worktree (`.claude/worktrees/<branch>/`), invoke `../../../.venv/bin/pytest` and `../../../.venv/bin/ruff` instead.
 
 CI runs the same pin set on every PR and main push via `.github/workflows/tests.yml`.
 


### PR DESCRIPTION
## Summary

- Linked git worktrees never inherit the contributor `.venv` (it is gitignored at the repo root). Documents the correct invocation (`../../../.venv/bin/pytest` / `../../../.venv/bin/ruff`) in all three contributor-facing docs: `CLAUDE.md`, `README.md`, and `CONTRIBUTING.md`.
- README previously carried the venv note in two places ("Working inside a worktree" and "Tests"). Trims the first occurrence to a forward reference to keep a single canonical location.
- Adds "exactly three levels deep" at each mention so the relative prefix `../../../` is traceable to the documented worktree path (`.claude/worktrees/<branch>/`) rather than reading as a magic number.

## Test plan

- [ ] Verify `../../../.venv/bin/pytest --version` resolves correctly from `.claude/worktrees/<any-branch>/` once `pip install -r requirements-dev.txt` has been run in the main tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)