### PR TITLE
fix: surface python3-venv prerequisite for contributor venv setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,20 +30,7 @@ This repo is public. Do not commit anything that identifies a private project, o
 
 ## Tests and lint
 
-Pins live in [`requirements-dev.txt`](./requirements-dev.txt) — the same file CI's install step reads, so versions stay in sync.
-
-```bash
-python3 -m venv .venv
-.venv/bin/pip install -r requirements-dev.txt
-.venv/bin/pytest claude/.claude/    # hook and skill tests
-.venv/bin/ruff check claude/.claude/  # lint
-```
-
-**Debian/Ubuntu:** `python3 -m venv` needs the `python3-venv` apt package (or the version-specific `python3.12-venv`). Without it, venv creation exits 0 but produces no `pip`, so the second command fails with a confusing "no such file" error. If `.venv/bin/pip` is missing after the first command, run `sudo apt install python3.12-venv`, delete `.venv`, and re-run. macOS (python.org or Homebrew) bundles `ensurepip` and is unaffected.
-
-The `.venv` lives only in the main worktree root. Linked worktrees live at `.claude/worktrees/<branch>/` — exactly three levels deep — so from inside a worktree invoke `../../../.venv/bin/pytest` and `../../../.venv/bin/ruff` instead.
-
-`./install.sh` does not install anything into the host Python — the `.venv` above is the contributor setup. CI runs both commands on every PR and main push; both must pass before the PR can be reviewed.
+See [Tests](./README.md#tests) for the contributor `.venv` setup, the pinned `pytest` / `ruff` commands, and cross-worktree invocation. Run both before opening a PR — CI runs them on every PR and main push, and both must pass before the PR can be reviewed.
 
 ## Skill evals
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,8 @@ python3 -m venv .venv
 .venv/bin/ruff check claude/.claude/  # lint
 ```
 
+**Debian/Ubuntu:** `python3 -m venv` needs the `python3-venv` apt package (or the version-specific `python3.12-venv`). Without it, venv creation exits 0 but produces no `pip`, so the second command fails with a confusing "no such file" error. If `.venv/bin/pip` is missing after the first command, run `sudo apt install python3.12-venv`, delete `.venv`, and re-run. macOS (python.org or Homebrew) bundles `ensurepip` and is unaffected.
+
 The `.venv` lives only in the main worktree root. Linked worktrees live at `.claude/worktrees/<branch>/` — exactly three levels deep — so from inside a worktree invoke `../../../.venv/bin/pytest` and `../../../.venv/bin/ruff` instead.
 
 `./install.sh` does not install anything into the host Python — the `.venv` above is the contributor setup. CI runs both commands on every PR and main push; both must pass before the PR can be reviewed.

--- a/README.md
+++ b/README.md
@@ -337,6 +337,8 @@ python3 -m venv .venv
 .venv/bin/ruff check claude/.claude/
 ```
 
+**Debian/Ubuntu:** `python3 -m venv` needs the `python3-venv` apt package (or the version-specific `python3.12-venv`). Without it, venv creation exits 0 but produces no `pip`, so the second command fails. If `.venv/bin/pip` is missing after the first command, run `sudo apt install python3.12-venv`, delete `.venv`, and re-run. macOS (python.org or Homebrew) bundles `ensurepip` and is unaffected.
+
 The `.venv` lives only in the main worktree root. Linked worktrees live at `.claude/worktrees/<branch>/` — exactly three levels deep — so from inside a worktree invoke `../../../.venv/bin/pytest` and `../../../.venv/bin/ruff` instead.
 
 CI runs the same pin set on every PR and main push via `.github/workflows/tests.yml`.

--- a/install.sh
+++ b/install.sh
@@ -85,6 +85,12 @@ check_private_projects_file() {
 
 check_private_projects_file
 
+if ! python3 -c "import ensurepip" >/dev/null 2>&1; then
+  echo ""
+  echo "NOTE: this python3 lacks ensurepip, so 'python3 -m venv' produces a venv with no pip."
+  echo "      On Debian/Ubuntu, install it first: sudo apt install python3.12-venv"
+fi
+
 echo ""
 echo "Done. Optional: run the hook test suite (see CONTRIBUTING.md 'Tests and lint'):"
 echo "  python3 -m venv .venv && .venv/bin/pip install -r requirements-dev.txt"


### PR DESCRIPTION
## Problem

On Debian/Ubuntu, `python3 -m venv` exits 0 even when the `python3-venv` apt package is absent — it writes the venv skeleton and `pyvenv.cfg`, then fails silently at the ensurepip pip-bootstrap step, leaving a venv with **no `pip`**. The documented next step `.venv/bin/pip install -r requirements-dev.txt` then fails with a "no such file" error that reads as a path bug rather than a setup bug.

This is a confirmed incident: a session hit a bare main-tree `.venv` and could not run the pinned test suite. Verified on the affected machine — `python3.12-venv` is `Installed: (none)`, `/usr/lib/python3.12/ensurepip` does not exist, and `python3 -c "import ensurepip"` fails.

PR #312 diagnosed an adjacent symptom (worktree relative-path resolution) and explicitly dismissed "python3-venv not installed" as a misdiagnosis — but that *was* the root cause. #312 was docs-only, so it never populated a venv and the real blocker remained.

## What shipped

- **README.md** — the canonical home for the fix: a Debian/Ubuntu-scoped prerequisite note in the Tests section naming the symptom (`.venv/bin/pip` absent after venv creation) and the fix (`sudo apt install python3.12-venv`). macOS (python.org / Homebrew) bundles `ensurepip` and is marked unaffected.
- **CONTRIBUTING.md** — the "Tests and lint" section duplicated README's "Tests" section near-verbatim (same setup commands, same `.venv` worktree note, same CI note). Collapsed it to a one-line deferral to [README#tests](./README.md#tests) so there is a single canonical home; the contributor-process fact (both checks must pass before PR review) is kept.
- **install.sh** — probes `import ensurepip` and prints a non-fatal warning before the venv setup hint, so a broken `python3` is flagged at the point a contributor would otherwise copy-paste into a silent failure. Non-fatal because venv tooling is optional — `install.sh`'s core job (stow) does not need it.

## Notes

Approach reviewed by the staff-platform-engineer reviewer, which prescribed this docs-note + setup-probe shape and confirmed the failure mode is Debian/Ubuntu-specific.

## Test plan

- [x] `ruff check claude/.claude/` — clean (ruff 0.6.9, matches pinned `0.6.*`).
- [x] `pytest claude/.claude/` — passes; the diff is docs + a non-Python script, so the suite is unaffected.
- [ ] Reviewer: confirm the `README#tests` anchor resolves and the CONTRIBUTING deferral reads correctly on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)