### PR TITLE
Review-vs-babysitting case study + review-trace subcommand

### DIFF
--- a/claude/.claude/scripts/tests/test_transcript_analysis.py
+++ b/claude/.claude/scripts/tests/test_transcript_analysis.py
@@ -1110,6 +1110,33 @@ def _hook_deny(hook_name: str, *, stringified: bool = False) -> dict:
     }
 
 
+def _hook_deny_current(
+    message: str,
+    *,
+    tool_id: str = "toolu_cur",
+    ts: str | None = None,
+    branch: str = "main",
+) -> dict:
+    """Build a current-format hook denial.
+
+    Newer Claude Code transcripts no longer emit a hook_blocking_error
+    attachment record — a denial surfaces only as a user record whose
+    tool_result block carries is_error and the denial text.
+    """
+    rec: dict = {
+        "type": "user",
+        "gitBranch": branch,
+        "isSidechain": False,
+        "message": {"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": tool_id,
+             "content": message, "is_error": True},
+        ]},
+    }
+    if ts:
+        rec["timestamp"] = ts
+    return rec
+
+
 def _review_trace_args(
     *,
     projects: str = "*",
@@ -1326,3 +1353,92 @@ class TestReviewTrace:
         _mod.cmd_review_trace(_review_trace_args())
         out = capsys.readouterr().out
         assert out.strip() == ""
+
+    def test_current_format_denial_detected(self, fake_projects, capsys):
+        """A current-format is_error tool_result with a hook-denial signature is a denial."""
+        _write_jsonl(fake_projects / "sess.jsonl", [
+            _hook_deny_current("Commit blocked by code-review gate: run /code-review."),
+        ])
+        _mod.cmd_review_trace(_review_trace_args())
+        out = capsys.readouterr().out
+        denial_lines = [ln for ln in out.splitlines() if ln.startswith("  [") and "denial" in ln]
+        assert len(denial_lines) == 1
+        assert "code-review gate" in denial_lines[0]
+
+    def test_current_format_ordinary_error_is_not_a_denial(self, fake_projects, capsys):
+        """An is_error tool_result without a hook-denial signature is NOT a denial."""
+        _write_jsonl(fake_projects / "sess.jsonl", [
+            _hook_deny_current("npm ERR! command failed with exit code 1"),
+        ])
+        _mod.cmd_review_trace(_review_trace_args())
+        out = capsys.readouterr().out
+        assert out.strip() == ""
+
+    def test_current_format_denial_text_without_is_error_ignored(self, fake_projects, capsys):
+        """A tool_result with denial-shaped text but no is_error flag is NOT a denial."""
+        rec = _hook_deny_current("Blocked by worktree-enforcement hook: not allowed.")
+        rec["message"]["content"][0]["is_error"] = False
+        _write_jsonl(fake_projects / "sess.jsonl", [rec])
+        _mod.cmd_review_trace(_review_trace_args())
+        out = capsys.readouterr().out
+        assert out.strip() == ""
+
+    def test_legacy_and_current_shapes_deduped_by_tool_use_id(self, fake_projects, capsys):
+        """A denial recorded as both an attachment and an is_error tool_result for one
+        tool_use_id collapses to one event — and the legacy record (which carries the
+        hook name) is the one retained."""
+        attach = _hook_deny("worktree")  # toolUseID == "toolu_worktree", hookName "worktree"
+        twin = _hook_deny_current(
+            "Blocked by worktree-enforcement hook: 'git add' not allowed.",
+            tool_id="toolu_worktree",
+        )
+        _write_jsonl(fake_projects / "sess.jsonl", [attach, twin])
+        _mod.cmd_review_trace(_review_trace_args())
+        out = capsys.readouterr().out
+        denial_lines = [ln for ln in out.splitlines() if ln.startswith("  [") and "denial" in ln]
+        assert len(denial_lines) == 1
+        assert "denials=1" in out
+        # The retained event is the legacy attachment record — it carries hook=worktree;
+        # the current-format twin would have emitted hook= (empty).
+        assert "hook=worktree" in denial_lines[0]
+
+    def test_multiple_distinct_current_format_denials_each_counted(self, fake_projects, capsys):
+        """Two current-format denials with distinct tool_use_ids count as two events —
+        dedup collapses same-id pairs, not distinct denials."""
+        _write_jsonl(fake_projects / "sess.jsonl", [
+            _hook_deny_current("Commit blocked by code-review gate.", tool_id="toolu_a"),
+            _hook_deny_current("Push blocked by ready-for-review gate.", tool_id="toolu_b"),
+        ])
+        _mod.cmd_review_trace(_review_trace_args())
+        out = capsys.readouterr().out
+        denial_lines = [ln for ln in out.splitlines() if ln.startswith("  [") and "denial" in ln]
+        assert len(denial_lines) == 2
+        assert "denials=2" in out
+
+    def test_current_format_denial_with_list_content_detected(self, fake_projects, capsys):
+        """A current-format denial whose tool_result content is a list of text blocks
+        (not a bare string) is still detected."""
+        rec = _hook_deny_current("placeholder")
+        rec["message"]["content"][0]["content"] = [
+            {"type": "text", "text": "Commit blocked by code-review gate: run /code-review."},
+        ]
+        _write_jsonl(fake_projects / "sess.jsonl", [rec])
+        _mod.cmd_review_trace(_review_trace_args())
+        out = capsys.readouterr().out
+        denial_lines = [ln for ln in out.splitlines() if ln.startswith("  [") and "denial" in ln]
+        assert len(denial_lines) == 1
+        assert "code-review gate" in denial_lines[0]
+
+    def test_deny_only_matches_current_format_denial(self, fake_projects, capsys):
+        """--deny-only retains a session whose only denial is current-format."""
+        _write_jsonl(fake_projects / "cur.jsonl", [
+            _hook_deny_current("Push to a branch blocked by ready-for-review gate."),
+        ])
+        _write_jsonl(fake_projects / "none.jsonl", [
+            _asst("claude-opus-4-7", branch="feat", ts="2026-05-19T10:00:00.000Z",
+                  content=[_agent_use("a1", "staff-sdet")]),
+        ])
+        _mod.cmd_review_trace(_review_trace_args(deny_only=True))
+        out = capsys.readouterr().out
+        assert "cur.jsonl" in out
+        assert "none.jsonl" not in out

--- a/claude/.claude/scripts/tests/test_transcript_analysis.py
+++ b/claude/.claude/scripts/tests/test_transcript_analysis.py
@@ -1,4 +1,5 @@
 """Tests for transcript-analysis.py."""
+import argparse
 import importlib.util
 import json
 import subprocess
@@ -107,6 +108,17 @@ class TestHelpers:
 
     def test_parse_ts_invalid_string(self):
         assert _mod._parse_ts("not-a-date") is None
+
+    def test_iso_date_valid_returns_string(self):
+        assert _mod._iso_date("2026-05-19") == "2026-05-19"
+
+    def test_iso_date_invalid_month_raises_type_error(self):
+        with pytest.raises(argparse.ArgumentTypeError):
+            _mod._iso_date("2026-13-01")
+
+    def test_iso_date_garbage_raises_type_error(self):
+        with pytest.raises(argparse.ArgumentTypeError):
+            _mod._iso_date("garbage")
 
 
 # ---------------------------------------------------------------------------
@@ -1068,3 +1080,249 @@ class TestCommitGate:
         data_lines2 = [ln for ln in out2.splitlines() if "2026-W" in ln]
         # Still only 1 session (feat-b-only session excluded)
         assert int(data_lines2[0].split()[1]) == 1
+
+
+# ---------------------------------------------------------------------------
+# review-trace
+# ---------------------------------------------------------------------------
+
+
+def _hook_deny(hook_name: str, *, stringified: bool = False) -> dict:
+    """Build an attachment/hook_blocking_error record using the real transcript shape.
+
+    Real transcripts nest the human-readable denial text in a "blockingError" key
+    inside the blockingError dict (alongside a "command" key).
+
+    When stringified=True, the outer blockingError value is a JSON-encoded string
+    of that dict rather than the dict itself (as seen in some real transcripts).
+    """
+    human_message = f"Hook '{hook_name}' blocked the operation"
+    error_dict = {"blockingError": human_message, "command": "git commit -m x"}
+    blocking_error = json.dumps(error_dict) if stringified else error_dict
+    return {
+        "type": "attachment",
+        "attachment": {
+            "type": "hook_blocking_error",
+            "hookName": hook_name,
+            "toolUseID": f"toolu_{hook_name[:8]}",
+            "blockingError": blocking_error,
+        },
+    }
+
+
+def _review_trace_args(
+    *,
+    projects: str = "*",
+    branches: str | None = None,
+    since: str | None = None,
+    until: str | None = None,
+    deny_only: bool = False,
+    skill: str | None = None,
+) -> object:
+    return type("A", (), {
+        "projects": projects,
+        "branches": branches,
+        "since": since,
+        "until": until,
+        "deny_only": deny_only,
+        "skill": skill,
+    })()
+
+
+class TestReviewTrace:
+    def test_skill_invocation_appears_in_output(self, fake_projects, capsys):
+        """Main-thread Skill call for a review skill produces a 'skill' event in output."""
+        _write_jsonl(fake_projects / "sess.jsonl", [
+            _asst("claude-sonnet-4-6", branch="feat",
+                  ts="2026-05-19T10:00:00.000Z",
+                  content=[_skill_use("s1", "code-review")]),
+        ])
+        _mod.cmd_review_trace(_review_trace_args())
+        out = capsys.readouterr().out
+        assert "skill" in out
+        assert "code-review" in out
+
+    def test_denial_dict_blockingError_parsed(self, fake_projects, capsys):
+        """hook_blocking_error with blockingError as a dict produces a denial event."""
+        _write_jsonl(fake_projects / "sess.jsonl", [
+            _hook_deny("require-code-review", stringified=False),
+        ])
+        _mod.cmd_review_trace(_review_trace_args())
+        out = capsys.readouterr().out
+        assert "denial" in out
+        assert "require-code-review" in out
+
+    def test_denial_stringified_blockingError_parsed_identically(self, fake_projects, capsys):
+        """hook_blocking_error with blockingError as a JSON string produces identical output to dict form."""
+        _write_jsonl(fake_projects / "dict_form.jsonl", [
+            _hook_deny("require-code-review", stringified=False),
+        ])
+        _write_jsonl(fake_projects / "str_form.jsonl", [
+            _hook_deny("require-code-review", stringified=True),
+        ])
+        _mod.cmd_review_trace(_review_trace_args())
+        out = capsys.readouterr().out
+        # Event lines have leading whitespace followed by a timestamp bracket.
+        sections = out.split("### ")
+        dict_section = next((s for s in sections if "dict_form" in s), "")
+        str_section = next((s for s in sections if "str_form" in s), "")
+        # Each section should have exactly one event line tagged 'denial'.
+        dict_denial_lines = [ln for ln in dict_section.splitlines() if ln.startswith("  [") and "denial" in ln]
+        str_denial_lines = [ln for ln in str_section.splitlines() if ln.startswith("  [") and "denial" in ln]
+        assert len(dict_denial_lines) == 1
+        assert len(str_denial_lines) == 1
+        # The hook name and message content should be identical between both forms.
+        assert "require-code-review" in dict_denial_lines[0]
+        assert "require-code-review" in str_denial_lines[0]
+        # The human-readable message text must appear in both forms, not a dict repr.
+        assert "blocked the operation" in dict_denial_lines[0]
+        assert "blocked the operation" in str_denial_lines[0]
+        # Must NOT be showing a raw dict repr.
+        assert "{'blockingError'" not in dict_denial_lines[0]
+        assert "{'blockingError'" not in str_denial_lines[0]
+
+    def test_hook_non_blocking_error_produces_zero_denial_events(self, fake_projects, capsys):
+        """hook_non_blocking_error records must NOT appear as denial events."""
+        non_blocking_rec = {
+            "type": "attachment",
+            "attachment": {
+                "type": "hook_non_blocking_error",
+                "hookName": "some-hook",
+                "toolUseID": "toolu_abc",
+                "blockingError": {"message": "non-fatal"},
+            },
+        }
+        _write_jsonl(fake_projects / "sess.jsonl", [non_blocking_rec])
+        _mod.cmd_review_trace(_review_trace_args())
+        out = capsys.readouterr().out
+        # No sessions should be emitted — the non-blocking record is not a review event.
+        assert "denial" not in out
+        assert "denials=1" not in out
+
+    def test_reviewer_spawn_detected_general_purpose_excluded(self, fake_projects, capsys):
+        """staff-backend-engineer spawn appears; general-purpose spawn is excluded."""
+        _write_jsonl(fake_projects / "sess.jsonl", [
+            _asst("claude-opus-4-7", branch="feat",
+                  ts="2026-05-19T10:00:00.000Z",
+                  content=[
+                      _agent_use("a1", "staff-backend-engineer"),
+                      _agent_use("a2", "general-purpose"),
+                  ]),
+        ])
+        _mod.cmd_review_trace(_review_trace_args())
+        out = capsys.readouterr().out
+        assert "staff-backend-engineer" in out
+        assert "general-purpose" not in out
+        # Exactly one reviewer-spawn event (event lines start with "  [").
+        reviewer_lines = [ln for ln in out.splitlines() if ln.startswith("  [") and "reviewer" in ln]
+        assert len(reviewer_lines) == 1
+
+    def test_sidechain_skill_invocation_excluded(self, fake_projects, capsys):
+        """A code-review Skill call inside a sidechain record must not appear as a skill event."""
+        _write_jsonl(fake_projects / "sess.jsonl", [
+            _asst("claude-sonnet-4-6", branch="feat",
+                  ts="2026-05-19T10:00:00.000Z",
+                  sidechain=True,
+                  content=[_skill_use("s1", "code-review")]),
+        ])
+        _mod.cmd_review_trace(_review_trace_args())
+        out = capsys.readouterr().out
+        # Sidechain skill produces no events → the session block is not printed at all.
+        assert out.strip() == ""
+
+    def test_since_boundary_inclusive_record_included(self, fake_projects, capsys):
+        """A record whose timestamp matches exactly --since is included."""
+        _write_jsonl(fake_projects / "sess.jsonl", [
+            _asst("claude-sonnet-4-6", branch="feat",
+                  ts="2026-05-19T00:00:00Z",
+                  content=[_skill_use("s1", "code-review")]),
+        ])
+        _mod.cmd_review_trace(_review_trace_args(since="2026-05-19"))
+        out = capsys.readouterr().out
+        assert "skill" in out
+        assert "code-review" in out
+
+    def test_until_boundary_inclusive_record_included(self, fake_projects, capsys):
+        """A record whose timestamp matches exactly --until is included."""
+        _write_jsonl(fake_projects / "sess.jsonl", [
+            _asst("claude-sonnet-4-6", branch="feat",
+                  ts="2026-05-19T23:59:59Z",
+                  content=[_skill_use("s1", "plan-review")]),
+        ])
+        _mod.cmd_review_trace(_review_trace_args(until="2026-05-19"))
+        out = capsys.readouterr().out
+        assert "skill" in out
+        assert "plan-review" in out
+
+    def test_record_with_no_timestamp_excluded_no_crash(self, fake_projects, capsys):
+        """A record with no parseable timestamp is excluded when a date filter is active; no crash."""
+        _write_jsonl(fake_projects / "sess.jsonl", [
+            _asst("claude-sonnet-4-6", branch="feat",
+                  content=[_skill_use("s1", "code-review")]),  # no ts field
+        ])
+        # No exception must be raised; the missing-timestamp record is silently skipped.
+        _mod.cmd_review_trace(_review_trace_args(since="2026-05-01"))
+        # No crash; output may be empty (no matching events survive the date filter).
+        capsys.readouterr()  # consume; success if no exception raised above
+
+    def test_deny_only_restricts_to_denial_sessions(self, fake_projects, capsys):
+        """--deny-only: only sessions with at least one hook denial appear."""
+        # Session A: has a denial.
+        _write_jsonl(fake_projects / "with_denial.jsonl", [
+            _hook_deny("require-code-review"),
+        ])
+        # Session B: only a reviewer spawn, no denial.
+        _write_jsonl(fake_projects / "no_denial.jsonl", [
+            _asst("claude-opus-4-7", branch="feat",
+                  ts="2026-05-19T10:00:00.000Z",
+                  content=[_agent_use("a1", "staff-backend-engineer")]),
+        ])
+        _mod.cmd_review_trace(_review_trace_args(deny_only=True))
+        out = capsys.readouterr().out
+        assert "with_denial" in out
+        assert "no_denial" not in out
+
+    def test_until_subsecond_record_included(self, fake_projects, capsys):
+        """A record at T23:59:59.500Z on the --until date IS included (sub-second gap fix)."""
+        _write_jsonl(fake_projects / "sess.jsonl", [
+            _asst("claude-sonnet-4-6", branch="feat",
+                  ts="2026-05-10T23:59:59.500Z",
+                  content=[_skill_use("s1", "code-review")]),
+        ])
+        _mod.cmd_review_trace(_review_trace_args(until="2026-05-10"))
+        out = capsys.readouterr().out
+        assert "skill" in out
+        assert "code-review" in out
+
+    def test_denial_blockingError_key_used_for_display_message(self, fake_projects, capsys):
+        """Denial message displays the nested blockingError string, not a dict repr."""
+        human_message = "Hook 'require-code-review' blocked the operation"
+        error_dict = {"blockingError": human_message, "command": "git commit -m x"}
+        denial_rec = {
+            "type": "attachment",
+            "attachment": {
+                "type": "hook_blocking_error",
+                "hookName": "require-code-review",
+                "toolUseID": "toolu_abc",
+                "blockingError": error_dict,
+            },
+        }
+        _write_jsonl(fake_projects / "sess.jsonl", [denial_rec])
+        _mod.cmd_review_trace(_review_trace_args())
+        out = capsys.readouterr().out
+        denial_lines = [ln for ln in out.splitlines() if "denial" in ln and ln.startswith("  [")]
+        assert len(denial_lines) == 1
+        # Human-readable text must appear, not a raw dict repr.
+        assert "blocked the operation" in denial_lines[0]
+        assert "{'blockingError'" not in denial_lines[0]
+
+    def test_no_match_session_produces_no_output(self, fake_projects, capsys):
+        """A session with only non-review tool_use (Bash) produces no output block."""
+        _write_jsonl(fake_projects / "sess.jsonl", [
+            _asst("claude-sonnet-4-6", branch="feat",
+                  ts="2026-05-19T10:00:00.000Z",
+                  content=[_bash_use("b1", "git status")]),
+        ])
+        _mod.cmd_review_trace(_review_trace_args())
+        out = capsys.readouterr().out
+        assert out.strip() == ""

--- a/claude/.claude/scripts/tests/test_transcript_analysis.py
+++ b/claude/.claude/scripts/tests/test_transcript_analysis.py
@@ -1385,8 +1385,9 @@ class TestReviewTrace:
 
     def test_legacy_and_current_shapes_deduped_by_tool_use_id(self, fake_projects, capsys):
         """A denial recorded as both an attachment and an is_error tool_result for one
-        tool_use_id collapses to one event — and the legacy record (which carries the
-        hook name) is the one retained."""
+        tool_use_id collapses to one event. Dedup keeps whichever record appears first
+        in the transcript; here the attachment is written ahead of its twin, so the
+        retained event carries the hook name the attachment record provides."""
         attach = _hook_deny("worktree")  # toolUseID == "toolu_worktree", hookName "worktree"
         twin = _hook_deny_current(
             "Blocked by worktree-enforcement hook: 'git add' not allowed.",
@@ -1398,8 +1399,9 @@ class TestReviewTrace:
         denial_lines = [ln for ln in out.splitlines() if ln.startswith("  [") and "denial" in ln]
         assert len(denial_lines) == 1
         assert "denials=1" in out
-        # The retained event is the legacy attachment record — it carries hook=worktree;
-        # the current-format twin would have emitted hook= (empty).
+        # Dedup retains the first-seen record. The attachment is written ahead of the
+        # current-format twin above, so the retained event carries hook=worktree; had
+        # the twin come first, hook= would be empty.
         assert "hook=worktree" in denial_lines[0]
 
     def test_multiple_distinct_current_format_denials_each_counted(self, fake_projects, capsys):

--- a/claude/.claude/scripts/transcript-analysis.py
+++ b/claude/.claude/scripts/transcript-analysis.py
@@ -82,6 +82,15 @@ def _parse_ts(ts_str: str | None) -> float | None:
         return None
 
 
+def _iso_date(s: str) -> str:
+    """argparse type: validate a YYYY-MM-DD date string."""
+    try:
+        datetime.strptime(s, "%Y-%m-%d")
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"not a valid YYYY-MM-DD date: {s!r}") from None
+    return s
+
+
 def _fmt_date(epoch: float) -> str:
     return datetime.fromtimestamp(epoch, tz=UTC).strftime("%Y-%m-%d")
 
@@ -362,6 +371,184 @@ def cmd_subagents(args: argparse.Namespace) -> None:
 
 
 REVIEW_SKILLS: tuple[str, ...] = ("code-review", "plan-review", "ready-for-review")
+
+# Skills counted as review invocations in review-trace.
+REVIEW_TRACE_SKILLS: frozenset[str] = frozenset(
+    {"code-review", "plan-review", "ready-for-review", "skill-review", "agent-review", "plan-it"}
+)
+
+# Reviewer-agent subagent_type prefixes/names counted in review-trace.
+_REVIEWER_PREFIX = "staff-"
+_REVIEWER_EXACT = "ciso-reviewer"
+
+
+def _normalize_blocking_error(raw) -> dict | str:
+    """Normalize blockingError — may arrive as a dict or a JSON-stringified dict."""
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+        except (json.JSONDecodeError, ValueError):
+            return raw
+        if isinstance(parsed, dict):
+            return parsed
+        return raw
+    return raw if raw is not None else {}
+
+
+def cmd_review_trace(args: argparse.Namespace) -> None:
+    """Emit an ordered review-event timeline per session.
+
+    Three event types are detected per session:
+    - skill: main-thread Skill tool_use where input.skill is in REVIEW_TRACE_SKILLS
+    - denial: attachment record with type==hook_blocking_error
+    - reviewer: Agent/Task spawn where subagent_type starts with 'staff-' or == 'ciso-reviewer'
+    """
+    projects_glob = _projects_glob(args)
+    branch_filter = _branch_filter(args)
+    deny_only: bool = bool(getattr(args, "deny_only", False))
+    skill_filter: str | None = getattr(args, "skill", None) or None
+
+    since_str: str | None = getattr(args, "since", None) or None
+    until_str: str | None = getattr(args, "until", None) or None
+    since_ts: float | None = _parse_ts(f"{since_str}T00:00:00Z") if since_str else None
+    # Inclusive-day boundary: compute start of the *next* day and compare with strict <.
+    # Adding 86400 seconds covers the entire until-day at any sub-second precision.
+    until_epoch: float | None = None
+    if until_str:
+        day_start = _parse_ts(f"{until_str}T00:00:00Z")
+        if day_start is not None:
+            until_epoch = day_start + 86400
+
+    for jsonl, records in iter_sessions(PROJECTS_DIR, projects_glob):
+        events: list[dict] = []  # ordered, tagged with type/ts/line_no
+
+        # Determine session model family from first non-empty main-thread assistant record.
+        session_model = ""
+        for rec in records:
+            if rec.get("type") == "assistant" and not bool(rec.get("isSidechain")):
+                session_model = (rec.get("message") or {}).get("model", "")
+                if session_model:
+                    break
+        fam = _fam(session_model)
+
+        # Determine primary branch from first main-thread record that has one.
+        session_branch = ""
+        for rec in records:
+            if not bool(rec.get("isSidechain")):
+                b = rec.get("gitBranch") or ""
+                if b:
+                    session_branch = b
+                    break
+
+        if branch_filter and session_branch not in branch_filter:
+            continue
+
+        for line_no, rec in enumerate(records, start=1):
+            rec_ts_str: str | None = rec.get("timestamp")
+            rec_ts: float | None = _parse_ts(rec_ts_str)
+
+            # Apply date filter: records with no parseable timestamp are excluded when
+            # a date boundary is active.
+            if (since_ts is not None or until_epoch is not None):
+                if rec_ts is None:
+                    continue
+                if since_ts is not None and rec_ts < since_ts:
+                    continue
+                if until_epoch is not None and rec_ts >= until_epoch:
+                    continue
+
+            rec_type = rec.get("type", "")
+
+            # --- Signals 1 + 3: skill invocations and reviewer-agent spawns ---
+            # Both are main-thread assistant tool_use blocks; a single pass over
+            # content dispatches on tool name to avoid iterating the list twice.
+            if rec_type == "assistant" and not bool(rec.get("isSidechain")):
+                for block in ((rec.get("message") or {}).get("content") or []):
+                    if not isinstance(block, dict) or block.get("type") != "tool_use":
+                        continue
+                    block_name = block.get("name")
+                    if block_name == "Skill":
+                        skill_name = (block.get("input") or {}).get("skill") or ""
+                        if skill_name not in REVIEW_TRACE_SKILLS:
+                            continue
+                        if skill_filter and skill_name != skill_filter:
+                            continue
+                        events.append({
+                            "kind": "skill",
+                            "skill": skill_name,
+                            "ts": rec_ts_str,
+                            "line_no": line_no,
+                        })
+                    elif block_name in ("Agent", "Task"):
+                        stype = (block.get("input") or {}).get("subagent_type") or ""
+                        if not (stype.startswith(_REVIEWER_PREFIX) or stype == _REVIEWER_EXACT):
+                            continue
+                        events.append({
+                            "kind": "reviewer-spawn",
+                            "subagent_type": stype,
+                            "ts": rec_ts_str,
+                            "line_no": line_no,
+                        })
+
+            # --- Signal 2: hook denials (attachment records only) ---
+            if rec_type == "attachment":
+                att = rec.get("attachment") or {}
+                if att.get("type") != "hook_blocking_error":
+                    continue
+                raw_error = att.get("blockingError")
+                normalized = _normalize_blocking_error(raw_error)
+                hook_name = att.get("hookName") or ""
+                tool_use_id = att.get("toolUseID") or ""
+                if isinstance(normalized, dict):
+                    # Real transcripts nest the human-readable text in a "blockingError"
+                    # key alongside a "command" key; fall back to "message" then repr.
+                    message = (
+                        normalized.get("blockingError")
+                        or normalized.get("message")
+                        or str(normalized)
+                    )
+                else:
+                    message = str(normalized) if normalized else ""
+                events.append({
+                    "kind": "denial",
+                    "hook_name": hook_name,
+                    "tool_use_id": tool_use_id,
+                    "message": message,
+                    "ts": rec_ts_str,
+                    "line_no": line_no,
+                })
+
+        if not events:
+            continue
+
+        has_denial = any(e["kind"] == "denial" for e in events)
+        if deny_only and not has_denial:
+            continue
+
+        skill_count = sum(1 for e in events if e["kind"] == "skill")
+        denial_count = sum(1 for e in events if e["kind"] == "denial")
+        spawn_count = sum(1 for e in events if e["kind"] == "reviewer-spawn")
+
+        print(f"\n### {jsonl}")
+        print(
+            f"branch={session_branch}  model={fam}  skills={skill_count}"
+            f"  denials={denial_count}  reviewer-spawns={spawn_count}"
+        )
+        for evt in events:
+            ts_label = evt.get("ts") or "?"
+            lno = evt["line_no"]
+            kind = evt["kind"]
+            if kind == "skill":
+                print(f"  [{ts_label}] line {lno:>5}  skill        {evt['skill']}")
+            elif kind == "denial":
+                hook = evt['hook_name']
+                uid = evt['tool_use_id']
+                msg = evt['message']
+                print(f"  [{ts_label}] line {lno:>5}  denial       hook={hook}  id={uid}  msg={msg!r}")
+            elif kind == "reviewer-spawn":
+                print(f"  [{ts_label}] line {lno:>5}  reviewer     {evt['subagent_type']}")
 
 
 def cmd_subagent_mix(args: argparse.Namespace) -> None:
@@ -824,6 +1011,27 @@ def main() -> None:
     )
     p_gate.add_argument("--branches", metavar="B1,B2,...", help="Branch name filter (default: all)")
     p_gate.set_defaults(func=cmd_commit_gate)
+
+    p_review_trace = sub.add_parser(
+        "review-trace",
+        help=(
+            "Ordered review-event timeline per session: skill invocations, hook denials,"
+            " and reviewer-agent spawns."
+        ),
+    )
+    p_review_trace.add_argument("--projects", default="*", metavar="GLOB")
+    p_review_trace.add_argument("--branches", metavar="B1,B2,...")
+    p_review_trace.add_argument("--since", metavar="DATE", type=_iso_date, help="Inclusive start date (YYYY-MM-DD)")
+    p_review_trace.add_argument("--until", metavar="DATE", type=_iso_date, help="Inclusive end date (YYYY-MM-DD)")
+    p_review_trace.add_argument(
+        "--deny-only", action="store_true",
+        help="Restrict output to sessions that contain at least one hook denial.",
+    )
+    p_review_trace.add_argument(
+        "--skill", metavar="NAME",
+        help="Restrict skill-invocation matching to one skill name.",
+    )
+    p_review_trace.set_defaults(func=cmd_review_trace)
 
     parsed = parser.parse_args()
     parsed.func(parsed)

--- a/claude/.claude/scripts/transcript-analysis.py
+++ b/claude/.claude/scripts/transcript-analysis.py
@@ -381,6 +381,21 @@ REVIEW_TRACE_SKILLS: frozenset[str] = frozenset(
 _REVIEWER_PREFIX = "staff-"
 _REVIEWER_EXACT = "ciso-reviewer"
 
+# Current-format transcripts record a hook denial as an is_error tool_result
+# with no structured marker — it is distinguishable from an ordinary tool
+# error only by the deny message text. These patterns match the Claude Code
+# hook-denial idiom ("Blocked by <hook>", "blocked by <X> gate", "… invocation
+# denied"). Detection is therefore best-effort in both directions: an
+# atypically worded hook denial is missed, and an ordinary tool error whose
+# text happens to contain the idiom is a false positive. review-trace is a
+# candidate locator, not an exact counter — callers treat denial counts as
+# approximate. Legacy transcripts additionally carry an explicit
+# hook_blocking_error attachment record, matched separately and exactly.
+_HOOK_DENIAL_SIGNATURE = re.compile(
+    r"blocked by .{0,80}?\b(?:hook|gate)\b|invocation denied\b",
+    re.IGNORECASE | re.DOTALL,
+)
+
 
 def _normalize_blocking_error(raw) -> dict | str:
     """Normalize blockingError — may arrive as a dict or a JSON-stringified dict."""
@@ -402,7 +417,10 @@ def cmd_review_trace(args: argparse.Namespace) -> None:
 
     Three event types are detected per session:
     - skill: main-thread Skill tool_use where input.skill is in REVIEW_TRACE_SKILLS
-    - denial: attachment record with type==hook_blocking_error
+    - denial: a hook-blocking denial in either transcript shape — a legacy
+      `attachment` record (type==hook_blocking_error) or a current-format
+      `tool_result` block with is_error and a hook-denial message signature.
+      A denial recorded as both shapes is collapsed to one event by tool_use_id.
     - reviewer: Agent/Task spawn where subagent_type starts with 'staff-' or == 'ciso-reviewer'
     """
     projects_glob = _projects_glob(args)
@@ -423,6 +441,10 @@ def cmd_review_trace(args: argparse.Namespace) -> None:
 
     for jsonl, records in iter_sessions(PROJECTS_DIR, projects_glob):
         events: list[dict] = []  # ordered, tagged with type/ts/line_no
+        # Tracks tool_use_ids already emitted as a denial. A legacy denial
+        # appears as both an attachment record and an is_error tool_result
+        # sharing one tool_use_id; this set collapses the pair to one event.
+        seen_denial_ids: set[str] = set()
 
         # Determine session model family from first non-empty main-thread assistant record.
         session_model = ""
@@ -492,15 +514,17 @@ def cmd_review_trace(args: argparse.Namespace) -> None:
                             "line_no": line_no,
                         })
 
-            # --- Signal 2: hook denials (attachment records only) ---
+            # --- Signal 2a: hook denials, legacy shape (attachment record) ---
             if rec_type == "attachment":
                 att = rec.get("attachment") or {}
                 if att.get("type") != "hook_blocking_error":
                     continue
+                tool_use_id = att.get("toolUseID") or ""
+                if tool_use_id and tool_use_id in seen_denial_ids:
+                    continue
                 raw_error = att.get("blockingError")
                 normalized = _normalize_blocking_error(raw_error)
                 hook_name = att.get("hookName") or ""
-                tool_use_id = att.get("toolUseID") or ""
                 if isinstance(normalized, dict):
                     # Real transcripts nest the human-readable text in a "blockingError"
                     # key alongside a "command" key; fall back to "message" then repr.
@@ -511,6 +535,8 @@ def cmd_review_trace(args: argparse.Namespace) -> None:
                     )
                 else:
                     message = str(normalized) if normalized else ""
+                if tool_use_id:
+                    seen_denial_ids.add(tool_use_id)
                 events.append({
                     "kind": "denial",
                     "hook_name": hook_name,
@@ -519,6 +545,33 @@ def cmd_review_trace(args: argparse.Namespace) -> None:
                     "ts": rec_ts_str,
                     "line_no": line_no,
                 })
+
+            # --- Signal 2b: hook denials, current shape (is_error tool_result) ---
+            # Claude Code stopped emitting the hook_blocking_error attachment
+            # record; current transcripts surface a denial only as an is_error
+            # tool_result, identified by the hook-denial message signature.
+            if rec_type == "user":
+                for block in ((rec.get("message") or {}).get("content") or []):
+                    if not isinstance(block, dict) or block.get("type") != "tool_result":
+                        continue
+                    if not block.get("is_error"):
+                        continue
+                    message = _content_text(block.get("content"))
+                    if not _HOOK_DENIAL_SIGNATURE.search(message):
+                        continue
+                    tool_use_id = block.get("tool_use_id") or ""
+                    if tool_use_id and tool_use_id in seen_denial_ids:
+                        continue
+                    if tool_use_id:
+                        seen_denial_ids.add(tool_use_id)
+                    events.append({
+                        "kind": "denial",
+                        "hook_name": "",
+                        "tool_use_id": tool_use_id,
+                        "message": message,
+                        "ts": rec_ts_str,
+                        "line_no": line_no,
+                    })
 
         if not events:
             continue

--- a/claude/.claude/scripts/transcript-analysis.py
+++ b/claude/.claude/scripts/transcript-analysis.py
@@ -1081,7 +1081,7 @@ def main() -> None:
         help="Restrict output to sessions that contain at least one hook denial.",
     )
     p_review_trace.add_argument(
-        "--skill", metavar="NAME",
+        "--skill", metavar="NAME", choices=sorted(REVIEW_TRACE_SKILLS),
         help="Restrict skill-invocation matching to one skill name.",
     )
     p_review_trace.set_defaults(func=cmd_review_trace)

--- a/claude/.claude/skills/transcript-analysis/SKILL.md
+++ b/claude/.claude/skills/transcript-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: transcript-analysis
-description: Analyze Claude Code transcripts — model comparison by branch, test-failure convergence sequences, correction-signal frequency, active-vs-idle duration, subagent-vs-main turn split, or PR-to-branch mapping. For token-cost or cache-efficiency analysis use token-analyzer.py directly.
+description: Analyze Claude Code transcripts — model comparison by branch, test-failure convergence sequences, correction-signal frequency, active-vs-idle duration, subagent-vs-main turn split, PR-to-branch mapping, or per-session review-activity timelines (skill invocations, hook denials, reviewer spawns). For token-cost or cache-efficiency analysis use token-analyzer.py directly.
 disable-model-invocation: true
 ---
 
@@ -16,6 +16,7 @@ The toolkit lives at `~/.claude/scripts/transcript-analysis.py`. Run it directly
 | How much logged time was active vs idle gaps? | `duration --branches <branch>` |
 | How much work went through subagents vs the main thread? | `subagents --branches <branch>` |
 | Map branches to PRs; count per-author review comments | `pr-link --repo owner/repo --branches <branch>` |
+| Which sessions ran review skills, hit a hook denial, or spawned reviewer agents? | `review-trace` |
 
 ## Reading fail-seq output
 
@@ -35,6 +36,7 @@ Sequence: 0 0 5 0 0 0 3 0 0 0 0 0
 - Durations from `duration` are wall-clock dominated by idle gaps. Look at `Active(min)`, not `Span(min)`.
 - `pr-link` requires `gh` and network access. All other subcommands are local-only and make no writes.
 - A model-vs-model comparison is only meaningful when there are multiple all-Opus and all-Sonnet execution branches. One or two branches per model is directional, not a controlled A/B.
+- `review-trace` locates candidate sessions; it does not judge whether a review caught a *material* issue — that read is qualitative. Use `--since`/`--until` (inclusive day bounds) for before/after-a-date analysis and `--deny-only` to isolate sessions that hit an enforcement hook.
 
 ## Example usage
 
@@ -51,4 +53,10 @@ python3 ~/.claude/scripts/transcript-analysis.py fail-seq --branches feat-TICKET
 # Link branches to PRs and count one author's review comments
 python3 ~/.claude/scripts/transcript-analysis.py pr-link \
   --repo owner/repo --branches feat-TICKET-101,feat-TICKET-202 --author alice
+
+# Find sessions that hit an enforcement-hook denial
+python3 ~/.claude/scripts/transcript-analysis.py review-trace --deny-only
+
+# Review activity in a date window (e.g. before vs after a skill landed)
+python3 ~/.claude/scripts/transcript-analysis.py review-trace --since 2026-01-01 --until 2026-03-31
 ```

--- a/docs/case-studies.md
+++ b/docs/case-studies.md
@@ -5,6 +5,7 @@ Longer-form writeups of specific design decisions in this repo, with primary-sou
 ## Index
 
 - [Worktree enforcement: hook vs. CLAUDE.md prose](#worktree-enforcement-hook-vs-claudemd-prose)
+- [Review gates and the agent-babysitting problem](#review-gates-and-the-agent-babysitting-problem)
 
 ---
 
@@ -90,7 +91,7 @@ From the repo's README ("How enforcement complements instructions"):
 
 > A CLAUDE.md instruction says "you should run code-review before committing." A PreToolUse hook says "the commit is denied until code-review ran on this exact diff in this session." This distinction is the core design choice: enforce at the tool-call boundary, not at the prompt layer, because prompt-layer instructions are advisory — the model can disregard them on any change it judges simple enough not to need review.
 
-Generalized: structural enforcement runs at 100% by construction; prose runs at whatever compliance rate the agent's judgment delivers. On a public repo where commits ship to the world and history can't be retracted, the cost asymmetry favors the hook even if the compliance delta is small.
+Generalized: structural enforcement runs at 100% by construction; prose runs at whatever compliance rate the agent's judgment delivers — and that rate is not 100%. Across this repo's transcript corpus (785 sessions, 2026-04-21 to 2026-05-22), with the worktree-enforcement hook active *and* CLAUDE.md prose instructing worktree use, the hook still denied 387 main-tree git or file operations across 243 sessions. Those are 387 attempts the prose did not prevent and the hook did. On a public repo where commits ship to the world and history can't be retracted, that residual is the case for enforcement. The companion case study [Review gates and the agent-babysitting problem](#review-gates-and-the-agent-babysitting-problem) extends this measurement across every review gate in the repo.
 
 ### Why opt-in per-repo
 
@@ -124,8 +125,106 @@ The hook scripts themselves and the README / `design-decisions.md` sections quot
 - **`docs/design-decisions.md` §7** — "Worktree-required as a per-project sentinel."
 - **[PR #24](https://github.com/jcdendrite/claude-config/pull/24)** — original hook, motivation paragraph and "Design decisions" section. Claude-Code-generated body.
 - **[PR #30](https://github.com/jcdendrite/claude-config/pull/30)** — added the worktree-enforcement note to root CLAUDE.md so fresh sessions discover the constraint at load time rather than mid-task.
-- **[PR #52](https://github.com/jcdendrite/claude-config/pull/52)** — trimmed ~38 lines of CLAUDE.md prose that duplicated fully-enforced hook behavior. Source of the "structural enforcement runs at 100%, prose tops out around 70%" framing, originally stated in the redaction-hook context and generalized here.
+- **[PR #52](https://github.com/jcdendrite/claude-config/pull/52)** — trimmed ~38 lines of CLAUDE.md prose that duplicated fully-enforced hook behavior.
+- **`claude/.claude/scripts/transcript-analysis.py`** — the `review-trace` subcommand, source of the 387-denial / 243-session measurement (run `review-trace --deny-only` over the transcript corpus).
 - **[PR #59](https://github.com/jcdendrite/claude-config/pull/59)** — added the `cwd_anchor_note_if_chained` helper that suffixes the malformed-subcommand and non-allowlist deny paths with a chained-`cd` self-correction note.
 - **[PR #114](https://github.com/jcdendrite/claude-config/pull/114)** — added `require-worktree-for-file-writes.sh`.
 - **[PR #131](https://github.com/jcdendrite/claude-config/pull/131)** — added the chained-`cd` hard-deny gate (lines 146–155) that fires before the persisted-cwd check.
 - **[anthropics/claude-code#34327](https://github.com/anthropics/claude-code/issues/34327)** — external GitHub issue cited by PR #24 as documenting the cross-session race in the wild. Cited here as PR #24's reference; not independently summarized.
+
+---
+
+## Review gates and the agent-babysitting problem
+
+**The problem.** In conversations with engineers about working alongside coding agents, one complaint recurs more than any other: *babysitting*. Not "the agent can't code" — the agent codes fine — but that it cannot be left alone. It writes code that wasn't asked for, edits the wrong file, ships a plausible-looking change with a defect the author would have caught, and the only defense the engineer trusts is watching every step. The hypothesis behind this repo's review pipeline is that the babysitting cost is largely a *missing-gates* cost: the agent is unsupervised at the moments that matter, and the fix is to put structure — review skills, enforcement hooks, specialist reviewers — at those moments rather than a human's attention.
+
+**Question.** Does a workflow built from review gates and reviewer agents reduce the babysitting cost, or just relocate it?
+
+**Short answer.** It relocates it — and the relocation is the point. The transcripts show review steps catching defects the agent had already declared finished: a missing API field, a wrong dispatch target, two exploitable bypass paths in a security gate, a structural bug in the agent's own review rule. The enforcement hooks fire constantly — 946 denials across 317 of 785 sessions — and repeatedly convert an agent's "this doesn't need review" into a review that finds something. Specialist reviewers catch real defects, and they also produce confidently wrong advice the agent must be equipped to reject. None of this is zero-supervision. What changes is *what* the human supervises: not keystrokes in real time, but findings, after the gate has already stopped the bad outcome.
+
+### How this was measured
+
+The evidence is this repo's own Claude Code transcript corpus: 785 sessions and 44,645 assistant turns on `claude-config` work, 2026-04-21 to 2026-05-22, analyzed with the `review-trace` subcommand of `transcript-analysis.py` (committed in this repo — the analysis is reproducible by running it over any transcript corpus). Three honest limits on what the corpus can show:
+
+- **No pre-gate baseline.** The review pipeline was already in place before the corpus begins — the plan-review skill, the code-review gate, and the plan-review gate hook all merged at or before the corpus start. So this is not a before/after experiment. It measures the *steady state* of a mature gated workflow, not the transition into one.
+- **Denial counts are best-effort.** Claude Code changed its transcript format mid-window; current-format hook denials carry no structured marker and are matched by message-text signature. Counts are accurate to within signature precision, not exact.
+- **No model-versus-model claim.** The corpus spans both Opus and Sonnet sessions. Examples below are drawn from both; no Opus-vs-Sonnet comparison is asserted — the corpus has too few branches per model to support one.
+
+Quotes are verbatim from transcripts and were scanned for credential material before inclusion.
+
+### The numbers
+
+Of 785 sessions, 332 contain at least one review event. Within them:
+
+- **837 review-skill invocations** (`/code-review`, `/plan-review`, `/skill-review`, `/ready-for-review`, `/agent-review`, `/plan-it`) across 297 sessions.
+- **142 specialist-reviewer spawns** (`staff-*`, `ciso-reviewer`) across 62 sessions.
+- **946 hook denials** across 317 sessions — 40% of all sessions hit a gate at least once. By gate: worktree-enforcement 387, marker-shape 213, ready-for-review 88, plan-review 69, code-review 62, redaction 39, respond-pr 35, memory-write 30, skill-review 14.
+
+The denial total is the headline: 946 times, an agent attempted something a gate blocked. That is the load-bearing measurement — the gates are not decorative, they are interposed on real attempts. A second repository's private transcript corpus — 590 sessions over a comparable window — shows the same shape in aggregate (989 denials across 244 sessions, 712 review-skill invocations, 330 specialist spawns); it is not quoted here, only noted as corroboration at similar scale.
+
+What the numbers cannot show is whether any given review *caught something material*. That is a question only a transcript read answers, and the three sections below work through it from primary sources.
+
+### Review catching what the agent had already missed
+
+The recurring shape: the agent finishes, tests pass, it declares the work done — and the review finds the defect anyway.
+
+In one session the agent built a hook to re-inject context after compaction, ran it, and saw it work. `/code-review` spawned a `staff-platform-engineer` reviewer, which found the hook's JSON output omitted a required field. The agent verified the claim against primary documentation and confirmed it (session `6544551e`, record 423):
+
+> Crucial finding from the superpowers code. Two things confirmed: 1. **`hookEventName: "SessionStart"` IS required** — superpowers line 51 explicitly emits it for Claude Code (`CLAUDE_PLUGIN_ROOT` detection). My implementation is missing it.
+
+Without that field, the hook's output is silently discarded on every `/compact` and `/clear` — the feature would have shipped inert. Passing tests did not catch it because the tests exercised the script, not Claude Code's ingestion contract.
+
+In another, the agent trimmed two `SKILL.md` files under a length budget, passed tests, and declared the trim complete. `/code-review`'s specialist panel found that words dropped as apparent filler were load-bearing (session `a061ff88`, record 175):
+
+> All 8 specialists back. Two actionable concerns to fix, both in plan-review's Reviewer-roles Focus cells where I overcompressed: 1. **`staff-platform-engineer`**: dropped "runbook linkage" and "load characteristics" — those were the only routing surface for those concerns; no checklist item recovers them.
+
+The dropped tokens read as narrative prose but were the only signal routing a concern to its reviewer — deleting them silently disabled a reviewer lane.
+
+The pattern repeats across smaller catches: a `/code-review` pass found a plugin skill dispatching `general-purpose` where repo convention prescribes the `check-runner` agent (session `8a226a48`, record 184); a `/skill-review` and a follow-on `/code-review` together caught a private project's name — and a filesystem path embedding it — staged for commit into this *public* repository (session `0ce152ae`). In each case the agent had written the change and moved on; the review, not the agent, was the thing that noticed.
+
+### The gate forcing a review the agent meant to skip
+
+The case studies above are reviews the agent chose to run. The more pointed evidence is the reviews it chose *not* to run.
+
+One session is close to a controlled demonstration. The agent wrote a plan to decompose a 4,458-line test file, judged a specialist reviewer unnecessary, and tried to save the plan. The `plan-review` gate hook denied the write. Forced to run `/plan-review`, the agent recorded — in its own words — that it had "rationalized skipping a named primary owner." The forced `staff-sdet` review then returned eight findings, four substantive (session `c12ee6b1`, record 116):
+
+> SDET came back with 8 findings — 4 are substantive things I missed: **F2:** `TestDenyPrivateProjectRefs` has an autouse `_isolate_home_for_blocklist` fixture … Real correctness risk if the autouse drops or coexists wrong. **F3:** My grep missed multiple module-level fixtures … Plan needs an explicit per-fixture ownership rule.
+
+The agent's own judgment was that the review was unnecessary. The gate disagreed, and the gate was right. A similar sequence: a push to a branch with an open PR was denied by the `ready-for-review` gate; the review it forced spawned a `staff-backend-engineer` that found an unquoted right-hand side in a bash `[[ ]]` test — capable of glob-expanding and targeting the wrong branch for `git branch -D` — and rated it MUST-FIX (session `de453486`, record 157). The denial did not catch the bug; it caused the review that did.
+
+This is the mechanism that most directly displaces babysitting. The human's job in a prose-only workflow is to notice when the agent is about to skip a step it shouldn't. The gate does that noticing.
+
+### Specialist judgment, in both directions
+
+Specialist reviewers are not an unalloyed good, and the honest version of this case study has to say so. They are themselves agents; they are sometimes wrong; and a workflow that adopts every reviewer finding is its own failure mode.
+
+The clearest instance: `/code-review` spawned a `ciso-reviewer` and a `staff-sdet` in parallel on a marker-expiry hook. Both flagged the same guard clause — with *opposite* advice. The agent did its own analysis rather than splitting the difference (session `1b1eebec`, record 381):
+
+> Both agents flagged the `-ge 0` guard independently, but with conflicting recommendations. CISO says "remove it — it's dead logic." SDET says "add a test for it." … Without `-ge 0`, the expression `-600 -lt 5400` is **true** — bypass would be granted. So the guard is **load-bearing**, not dead. CISO's analysis miscalculated the sign. Removing it would be a bug.
+
+The security reviewer's advice, taken literally, would have introduced the security regression it existed to prevent. The agent kept the guard, added the test the SDET asked for, and recorded why it rejected the CISO finding. Judgment cut the other way too: in a CI-change review, a `staff-platform-engineer` raised a mutable-action-tag supply-chain risk *and* queried a widened path regex; the agent adopted the supply-chain finding and explicitly declined the regex query as intentional — "that's the whole point of the PR" (session `f8781720`, record 233).
+
+And the reviewers do catch what no single pass would. A one-line addition to a review-routing table triggered a recursive seven-specialist panel, which found that the new rule — "spawn every persona listed in the table being edited" — let a reviewer be silently exempted by *deleting* their table row, because a deletion removes the persona from the list the rule reads (session `9850cf69`, record 95). That is a structural bug in a review rule, found by reviews.
+
+The disposition discipline matters here as much as the spawning. A reviewer finding is an input to a decision, not the decision. The repo later made this explicit — `/code-review` requires an explicit keep/fix/reject disposition for every reviewer finding — precisely so that "a specialist said so" cannot substitute for the judgment the transcripts above show the agent exercising.
+
+### What this says about babysitting
+
+The babysitting hypothesis was that the cost comes from the agent being unsupervised at the moments that matter. The corpus supports a sharper version: the agent is not unskilled at those moments, it is *overconfident* — it finishes, tests pass, and it declares done while a real defect remains. Review gates do not make the agent more careful. They interpose a second look at exactly the point where the agent's own confidence is highest and least reliable, and 946 denials across the corpus show how often that point is reached.
+
+This does not eliminate supervision. A human still reads the findings, still arbitrates when a specialist is wrong, still owns the disposition. But the supervision moves off the critical path: it happens against a diff a gate has already frozen, not against a stream of keystrokes that has to be watched live. That is the relocation in the short answer — and for the engineers describing the babysitting cost, reading a review finding after the fact is a categorically cheaper posture than watching to prevent one.
+
+### Attribution notes
+
+The quoted text is the Claude agent's, drawn from sessions the repo owner was supervising — first-person narration ("things I missed," "my implementation is missing it") refers to the agent in that session, not to the repo owner. The repo owner's role is directing the work and approving what merges.
+
+Transcript sessions are local Claude Code logs, not public artifacts; they are cited by session-id stem and record number so the owner can re-locate each quote, and the `review-trace` tool makes the aggregate counts reproducible by method. The `transcript-analysis.py` tool, the hooks, and the skills referenced are committed code — primary sources without attribution ambiguity.
+
+### Sources
+
+- **`claude/.claude/scripts/transcript-analysis.py`** — the `review-trace` subcommand: per-session timeline of review-skill invocations, hook denials, and specialist-reviewer spawns. All aggregate counts in this case study come from `review-trace` over the transcript corpus.
+- **Transcript corpus** — 785 `claude-config` sessions, 2026-04-21 to 2026-05-22, in the repo owner's local Claude Code history. Quoted sessions, by id stem and record number: `6544551e`:423, `a061ff88`:175, `8a226a48`:184, `0ce152ae` (redaction catch), `c12ee6b1`:116, `de453486`:157, `1b1eebec`:381, `f8781720`:233, `9850cf69`:95.
+- **`claude/.claude/skills/code-review/SKILL.md`** — the `/code-review` skill, including the specialist-reviewer routing and the explicit per-finding disposition requirement.
+- **`claude/.claude/skills/plan-review/SKILL.md`** — the `/plan-review` skill.
+- **`claude/.claude/hooks/require-plan-review.sh`, `require-code-review.sh`, `require-ready-for-review.sh`** — the enforcement-gate hooks whose denials are counted above.
+- **[Worktree enforcement: hook vs. CLAUDE.md prose](#worktree-enforcement-hook-vs-claudemd-prose)** — companion case study; its 387-denial worktree-enforcement measurement is one row of the denial breakdown here.

--- a/docs/case-studies.md
+++ b/docs/case-studies.md
@@ -126,7 +126,7 @@ The hook scripts themselves and the README / `design-decisions.md` sections quot
 - **[PR #24](https://github.com/jcdendrite/claude-config/pull/24)** — original hook, motivation paragraph and "Design decisions" section. Claude-Code-generated body.
 - **[PR #30](https://github.com/jcdendrite/claude-config/pull/30)** — added the worktree-enforcement note to root CLAUDE.md so fresh sessions discover the constraint at load time rather than mid-task.
 - **[PR #52](https://github.com/jcdendrite/claude-config/pull/52)** — trimmed ~38 lines of CLAUDE.md prose that duplicated fully-enforced hook behavior.
-- **`claude/.claude/scripts/transcript-analysis.py`** — the `review-trace` subcommand, source of the 387-denial / 243-session measurement (run `review-trace --deny-only` over the transcript corpus).
+- **`claude/.claude/scripts/transcript-analysis.py`** — the `review-trace` subcommand, source of the 387-denial / 243-session measurement (via `review-trace --deny-only`; a point-in-time snapshot, per the companion case study's *How this was measured*).
 - **[PR #59](https://github.com/jcdendrite/claude-config/pull/59)** — added the `cwd_anchor_note_if_chained` helper that suffixes the malformed-subcommand and non-allowlist deny paths with a chained-`cd` self-correction note.
 - **[PR #114](https://github.com/jcdendrite/claude-config/pull/114)** — added `require-worktree-for-file-writes.sh`.
 - **[PR #131](https://github.com/jcdendrite/claude-config/pull/131)** — added the chained-`cd` hard-deny gate (lines 146–155) that fires before the persisted-cwd check.
@@ -144,8 +144,9 @@ The hook scripts themselves and the README / `design-decisions.md` sections quot
 
 ### How this was measured
 
-The evidence is this repo's own Claude Code transcript corpus: 785 sessions and 44,645 assistant turns on `claude-config` work, 2026-04-21 to 2026-05-22, analyzed with the `review-trace` subcommand of `transcript-analysis.py` (committed in this repo — the analysis is reproducible by running it over any transcript corpus). Three honest limits on what the corpus can show:
+The evidence is this repo's own Claude Code transcript corpus: 785 sessions and 44,645 assistant turns on `claude-config` work, 2026-04-21 to 2026-05-22, analyzed with the `review-trace` subcommand of `transcript-analysis.py` (committed in this repo). Four honest limits on what the corpus can show:
 
+- **The counts are a point-in-time snapshot.** A local Claude Code transcript store is mutable — sessions accrue continuously, and a worktree's transcript directory is removed when that worktree is cleaned up after a merge. The figures here were measured during this case study's authoring; the `review-trace` *method* reproduces, but a later run over the same machine reports different totals.
 - **No pre-gate baseline.** The review pipeline was already in place before the corpus begins — the plan-review skill, the code-review gate, and the plan-review gate hook all merged at or before the corpus start. So this is not a before/after experiment. It measures the *steady state* of a mature gated workflow, not the transition into one.
 - **Denial counts are best-effort.** Claude Code changed its transcript format mid-window; current-format hook denials carry no structured marker and are matched by message-text signature. Counts are accurate to within signature precision, not exact.
 - **No model-versus-model claim.** The corpus spans both Opus and Sonnet sessions. Examples below are drawn from both; no Opus-vs-Sonnet comparison is asserted — the corpus has too few branches per model to support one.
@@ -158,7 +159,7 @@ Of 785 sessions, 332 contain at least one review event. Within them:
 
 - **837 review-skill invocations** (`/code-review`, `/plan-review`, `/skill-review`, `/ready-for-review`, `/agent-review`, `/plan-it`) across 297 sessions.
 - **142 specialist-reviewer spawns** (`staff-*`, `ciso-reviewer`) across 62 sessions.
-- **946 hook denials** across 317 sessions — 40% of all sessions hit a gate at least once. By gate: worktree-enforcement 387, marker-shape 213, ready-for-review 88, plan-review 69, code-review 62, redaction 39, respond-pr 35, memory-write 30, skill-review 14.
+- **946 hook denials** across 317 sessions — 40% of all sessions hit a gate at least once. By gate, attributed best-effort from each denial's message text: worktree-enforcement 387, marker-shape 213, ready-for-review 88, plan-review 69, code-review 62, redaction 39, respond-pr 35, memory-write 30, skill-review 14 — these nine sum to 937; the remaining 9 are denials whose message did not map cleanly to a single gate.
 
 The denial total is the headline: 946 times, an agent attempted something a gate blocked. That is the load-bearing measurement — the gates are not decorative, they are interposed on real attempts. A second repository's private transcript corpus — 590 sessions over a comparable window — shows the same shape in aggregate (989 denials across 244 sessions, 712 review-skill invocations, 330 specialist spawns); it is not quoted here, only noted as corroboration at similar scale.
 
@@ -218,7 +219,7 @@ This does not eliminate supervision. A human still reads the findings, still arb
 
 The quoted text is the Claude agent's, drawn from sessions the repo owner was supervising — first-person narration ("things I missed," "my implementation is missing it") refers to the agent in that session, not to the repo owner. The repo owner's role is directing the work and approving what merges.
 
-Transcript sessions are local Claude Code logs, not public artifacts; they are cited by session-id stem and record number so the owner can re-locate each quote, and the `review-trace` tool makes the aggregate counts reproducible by method. The `transcript-analysis.py` tool, the hooks, and the skills referenced are committed code — primary sources without attribution ambiguity.
+Transcript sessions are local Claude Code logs, not public artifacts; they are cited by session-id stem and record number so the owner can re-locate each quote, and the `review-trace` tool makes the aggregate-count *method* reproducible (the counts themselves are a point-in-time snapshot — see *How this was measured*). The `transcript-analysis.py` tool, the hooks, and the skills referenced are committed code — primary sources without attribution ambiguity.
 
 ### Sources
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -32,11 +32,12 @@ Full descriptions for utility scripts in `claude/.claude/scripts/` (stowed to `~
   token-analyzer --since 7d  # include token activity from the last N days (e.g. 2d, 7d)
   ```
 
-- **`transcript-analysis.py`** — analysis toolkit for Claude Code transcripts (`~/.claude/projects/*/*.jsonl`). Six subcommands: `buckets` (assistant turns by branch × model family), `fail-seq` (ordered test-failure-count sequence per branch — convergence vs thrashing), `struggle` (correction/frustration phrase frequency split by model), `duration` (active vs idle-gap time per branch), `subagents` (`isSidechain` vs main-thread turn split), `pr-link` (map branches to GitHub PRs and count per-author comments). All subcommands are local-only reads except `pr-link`, which calls `gh`. Invoked directly from the shell (no `~/.local/bin/` wrapper); the `/transcript-analysis` skill documents which subcommand answers which question.
+- **`transcript-analysis.py`** — analysis toolkit for Claude Code transcripts (`~/.claude/projects/*/*.jsonl`). Ten subcommands: `buckets` (assistant turns by branch × model family), `fail-seq` (ordered test-failure-count sequence per branch — convergence vs thrashing), `struggle` (correction/frustration phrase frequency split by model), `duration` (active vs idle-gap time per branch), `subagents` (`isSidechain` vs main-thread turn split), `subagent-mix` (per-branch subagent/Task spawn types and review-skill spawn counts), `skill-pair` (leader→follower skill-invocation pairing rate, binned by ISO week), `commit-gate` (review-skill vs git-commit ordering per ISO week, with `--no-verify` detection), `pr-link` (map branches to GitHub PRs and count per-author comments), `review-trace` (per-session timeline of review-skill invocations, hook denials, and reviewer-agent spawns). All subcommands are local-only reads except `pr-link`, which calls `gh`. Invoked directly from the shell (no `~/.local/bin/` wrapper); the `/transcript-analysis` skill documents which subcommand answers which question.
 
   ```bash
   python3 ~/.claude/scripts/transcript-analysis.py buckets
   python3 ~/.claude/scripts/transcript-analysis.py fail-seq --branches <branch>
+  python3 ~/.claude/scripts/transcript-analysis.py review-trace --deny-only
   python3 ~/.claude/scripts/transcript-analysis.py pr-link --repo owner/repo --branches <branch>
   ```
 


### PR DESCRIPTION
## Summary

Adds a primary-source case study showing review/guideline steps catch agent mistakes that would otherwise ship, plus the `review-trace` tooling that mines the evidence.

**What shipped, by surface:**

- **`claude/.claude/scripts/transcript-analysis.py`** — new `review-trace` subcommand: per-session timeline of review-skill invocations, hook denials, and reviewer-agent spawns. Detects hook denials in both transcript shapes (legacy `attachment` record and current-format `is_error` tool_result). `--skill` is validated against the known skill set.
- **`docs/case-studies.md`** — new "Review gates and the agent-babysitting problem" case study; the existing worktree-enforcement case study revised with measured denial counts.
- **`claude/.claude/skills/transcript-analysis/SKILL.md`, `docs/scripts.md`** — document the new subcommand (`docs/scripts.md` also corrects a stale subcommand count).
- **Tests** — `TestReviewTrace` covers both denial shapes, dedup by `tool_use_id`, date filters, and reviewer-spawn detection.

## Reviewer note — case-study figures are a snapshot

The case study's aggregate counts are a point-in-time snapshot of a mutable local transcript corpus: sessions accrue continuously, and a worktree's transcript directory is removed when that worktree is cleaned up after merge. Re-running `review-trace` today yields different totals — the doc states this explicitly. The by-gate denial breakdown is best-effort message-text attribution and is annotated as such (it sums to 937 of the 946 total, with 9 unattributable).

## Test plan

- [x] `ruff check claude/.claude/` — passes (host ruff 0.6.9, matches the pinned `ruff==0.6.*`).
- [ ] `pytest claude/.claude/` — pinned suite deferred to CI: the local contributor `.venv` is missing `pip`/`pytest` (incomplete one-time setup), so the pinned `pytest==8.*` run could not execute locally. CI runs it on every PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)