### PR TITLE
docs: add credential-blocker row to test-conventions §9

### DIFF
--- a/claude/.claude/skills/test-conventions/SKILL.md
+++ b/claude/.claude/skills/test-conventions/SKILL.md
@@ -197,4 +197,4 @@ Avoid these when writing new tests:
 | Over-mocking (test encodes implementation, not behavior) | Mock only direct dependencies; let integration tests cover wiring |
 | Mocking third-party internals (library's private API) | Use the library's test utilities or mock at your own abstraction boundary |
 | Testing the test double (asserting stub's own return value) | Assert on values the code computed or transformed |
-| Stub or vacuous assertion when blocked by credentials/env/external state | Surface the blocker; test what you *can*; use skip/todo for the rest. |
+| Stub or vacuous assertion when blocked by credentials/env/external state | Mock or fake the credential boundary; don't commit a permanently-passing assertion. |

--- a/claude/.claude/skills/test-conventions/SKILL.md
+++ b/claude/.claude/skills/test-conventions/SKILL.md
@@ -197,4 +197,4 @@ Avoid these when writing new tests:
 | Over-mocking (test encodes implementation, not behavior) | Mock only direct dependencies; let integration tests cover wiring |
 | Mocking third-party internals (library's private API) | Use the library's test utilities or mock at your own abstraction boundary |
 | Testing the test double (asserting stub's own return value) | Assert on values the code computed or transformed |
-| Stub or vacuous assertion when blocked by credentials/env/external state | Surface the blocker explicitly (PR description, comment on the test, or chat message) and test what you *can* — input validation, error shaping, request payload construction, response decoding. Use the framework's skip/todo marker for the parts that genuinely need the blocked dependency; never commit an always-passing assertion as a placeholder. |
+| Stub or vacuous assertion when blocked by credentials/env/external state | Surface the blocker; test what you *can*; use skip/todo for the rest. |

--- a/claude/.claude/skills/test-conventions/SKILL.md
+++ b/claude/.claude/skills/test-conventions/SKILL.md
@@ -189,7 +189,6 @@ If an assertion checks a value that was set up directly in the test double rathe
 ## 9. Common authoring mistakes
 
 Avoid these when writing new tests:
-
 | Mistake | Fix |
 |---|---|
 | Assertion-free tests (code runs but nothing is asserted) | Every test must assert on a specific expected outcome |
@@ -198,3 +197,4 @@ Avoid these when writing new tests:
 | Over-mocking (test encodes implementation, not behavior) | Mock only direct dependencies; let integration tests cover wiring |
 | Mocking third-party internals (library's private API) | Use the library's test utilities or mock at your own abstraction boundary |
 | Testing the test double (asserting stub's own return value) | Assert on values the code computed or transformed |
+| Stub or vacuous assertion when blocked by credentials/env/external state | Surface the blocker explicitly (PR description, comment on the test, or chat message) and test what you *can* — input validation, error shaping, request payload construction, response decoding. Use the framework's skip/todo marker for the parts that genuinely need the blocked dependency; never commit an always-passing assertion as a placeholder. |


### PR DESCRIPTION
## Summary

- Adds a new row to the §9 "Common authoring mistakes" table in `test-conventions/SKILL.md` covering the credential/env-blocker scenario
- When a test can't exercise the happy path (needs live credentials, external state), the existing "Assertion-free tests" row only said "assert on something" — it didn't say what to do when the needed dependency is unreachable
- New row: mock or fake the credential boundary; don't commit a permanently-passing assertion

## Context

Surfaced during a post-mortem on a PR where a test was committed with a vacuous `assertEquals(true, true)` because the agent couldn't exercise the happy path without a live token. Root cause was at the dispatcher level (separate investigation), but this write-time guidance prevents the placeholder from being written in the first place.

"Credential boundary" — the seam where real creds would be presented — is the right abstraction: applies to API keys, DB URLs, cloud IAM, not just OAuth exchanges. "Permanently-passing" is sharper than "untestable" — the assertion runs fine, it just never falsifies because the real code path doesn't execute. Consistent with §3 ("choose the right test double") and §8 ("abstraction boundary") already in the skill.

## Test plan

- [ ] Manual: next time Claude writes tests for a task that needs live credentials for the happy path, confirm it mocks/fakes the credential boundary rather than writing a placeholder
- [ ] Skill-review checklist passed (marker written)

🤖 Generated with [Claude Code](https://claude.com/claude-code)