### PR TITLE
fix: close skip-rationale gap in /code-review and /plan-review dispatcher

### DIFF
--- a/claude/.claude/skills/code-review/SKILL.md
+++ b/claude/.claude/skills/code-review/SKILL.md
@@ -219,6 +219,13 @@ The Change type column keys on what the change *does* for an operator or consume
 | Changes runtime config (env vars, secrets, feature flags) | `staff-platform-engineer` + `ciso-reviewer` — verify config is consistent across environments, check for leaked secrets |
 | Reshapes reviewer ownership (substantive edits to plan-review/code-review skill routing tables, or scope language in `agents/*.md`) | Spawn every persona named in the pre- or post-edit table — each evaluates whether their row (or its removal) is accurate, scoped, and not bleeding into another lane. The pre/post union ensures a row deletion still spawns the affected persona. For an `agents/*.md` edit, spawn the edited persona plus their Item-ownership co-owners. Skip whitespace / typo / copy-edit-only diffs. |
 
+**Invalid skip rationales.** These look like the DEFER criteria below but apply to a different decision — the spawn-dispatch step, not the finding-disposition step. Do not use them to skip a matched row:
+
+- **"Prior reviewer covered this."** — Prior spawns covered prior diffs; the current `/code-review` runs against the current staged diff. If prior findings are still relevant, pass them to the new spawn as prior context — do not substitute for the spawn.
+- **"Self-review sufficient."** — The orchestrator's self-review supplements specialist depth — it does not replace it.
+- **"Verified inline."** — Inline orchestrator verification is the generalist read the spawn exists to escalate from, not a substitute for specialist scrutiny.
+- **"New helper, not a modification."** — `Modifies shared utilities` covers additions to and extensions of the shared module that introduce new caller dependencies — not only edits to existing utility files.
+
 Report every matched row's verdict via the **Spawn decisions:** line in the *Output format* section above. Empty rationale is the under-spawn failure mode the format closes — write the read, don't omit it.
 
 When you do spawn a specialist, be specific. "Spawn `ciso-reviewer`" is useless; "Spawn `ciso-reviewer` and ask it to verify the checkout flow in CheckoutPage.tsx still enforces ownership after the new validation" is actionable.

--- a/claude/.claude/skills/plan-review/ROUTING.md
+++ b/claude/.claude/skills/plan-review/ROUTING.md
@@ -17,6 +17,13 @@ The criteria below stay — but are reframed as *reasons a matched row is non-ne
 - **Convergence-as-design-tell** from a prior round (see Reconciliation).
 - **Explicit user request.**
 
+**Invalid skip rationales.** These look like finding-disposition DEFER criteria but are not valid reasons to skip spawning a matched reviewer at the spawn-dispatch step. Do not use them to skip a matched reviewer:
+
+- **"Prior reviewer covered this."** — Prior review rounds covered prior plan versions; the current `/plan-review` runs against the current plan. If prior findings are still relevant, pass them to the new spawn as prior context — do not substitute for the spawn.
+- **"Self-review sufficient."** — The orchestrator's self-review supplements specialist depth — it does not replace it.
+- **"Verified inline."** — Inline orchestrator verification is the generalist read the spawn exists to escalate from, not a substitute for specialist scrutiny.
+- **"New helper, not a modification."** — A plan introducing a new shared utility that creates new caller dependencies falls within the `Modifies shared utilities` criterion — not only plans that modify existing utilities.
+
 Always spawn `ciso-reviewer` when the plan touches auth/authz, secrets, tokens, data exposure, sensitive-data logging, third-party data sharing, or infra permissions — high-stakes-boundary case is non-optional, **unless** the Step 4 user-surface declaration puts the change outside `ciso-reviewer`'s threat model (e.g., a dev-only flow with no production reachability, or an internal-only path where engineers themselves are the only callers and the change crosses no privilege boundary they shouldn't cross). When skipping on those grounds, name the surface in the review output — never silently skip. The ciso-reviewer rule is one instance of the general default-fire pattern above, not the exception. Always spawn `staff-product-engineer` when the plan changes any end-user-visible surface: user interface, transactional or lifecycle email, push notification, SMS, in-app notification, billing artifact, exported file, webhook payload to a customer integration, OAuth consent screen, embedded widget or iframe surface, or end-user-visible log/audit entry. The trigger fires on the *channel*, not on the file-path domain. Indirect channel effects count: a data or logic change that determines which channel fires or what it contains (a new user-status enum value that triggers a different lifecycle email, a field added to a user record that an existing template reads) changes user-facing behavior even when the plan touches no channel template file.
 
 Spawn per question (not per file-path domain) — "plan touches backend" isn't enough; the question needs a specific shape.


### PR DESCRIPTION
## Summary

- Adds **Invalid skip rationales** closed-list subsection to `code-review/SKILL.md` (Ripple-effect triage section, after the Change-type table) and mirrors it in `plan-review/ROUTING.md` (Reviewer-roles section, after the criteria bullet list).
- Closes the recurring failure mode where orchestrators enumerate Change-type rows correctly but skip all matched rows with off-criteria rationales — bypassing the entire specialist tier silently.
- Modeled on the proven **Invalid DEFER rationales** pattern from PR #294; four named-invalid rationales: "Prior reviewer covered this," "Self-review sufficient," "Verified inline," "New helper, not a modification."

## Root cause

Across a 17-session sample, ~55% of enumerated-but-skipped sessions used off-criteria skip rationales. The dominant illegitimate skip is `"prior reviewer covered this"` — a Finding Disposition criterion (`Contract pinned at another layer`) misapplied to the spawn-dispatch decision. The other three were observed at lower frequency. PR #295 fixed the enumeration step (rows are now listed); this PR closes the downstream skip-rationale gap.

## Design rationale

**Why not a triage-dispatcher subagent?** Compounding-defensive-layers tell: a delegated subagent still enumerates correctly but skips loosely unless the prose-level standard is fixed. The subagent layer wouldn't help without fixing the foundation.

**Why not a static dispatcher script?** The Change-type table keys on change *intent*, not file paths — a script can't infer intent. It would also leave the skip-rationale gap untouched.

**Strict vs. permissive for "prior reviewer covered this":** A permissive alternative (allow skip if a `findings_path` hash covers the current diff) was considered and rejected — hash-of-diff verification is unenforceable in prose; orchestrators would recite the path without checking.

## Counterfactual replay — PR that surfaced this issue

The 4 skip rationales from the triggering PR mapped against the new closed list:

| Row | Skip rationale used | Hits invalid entry? |
|-----|---------------------|---------------------|
| Adds/modifies security controls | "prior staff-backend-engineer reviews covered this in full" | ✓ "Prior reviewer covered this." |
| Modifies shared utilities | "run-google-sync.ts is a new shared helper, not modification" | ✓ "New helper, not a modification." |
| Changes API response shape | "shape is identical to prior implementation" | — factual claim; remains acceptable |
| Third-party API integration | "prior staff-backend-engineer review traced calendarList fetch" | ✓ "Prior reviewer covered this." |

## Test plan

- [x] `.venv/bin/pytest claude/.claude/` — PASS
- [x] `.venv/bin/ruff check claude/.claude/` — PASS
- [x] `/skill-review` against staged diff — clean (marker written)
- [x] `/code-review` — no issues found (marker written)
- [ ] **Post-merge:** re-run `python3 ~/.claude/scripts/transcript-analysis.py subagent-mix` against next 5–10 `/code-review` sessions; confirm specialist spawn rate rises on PRs matching high-stakes rows (auth, shared utilities, API response shape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)