### PR TITLE
fix(plan-review): extend B12 to flag unverified hoisting assumptions on dep removal

### DIFF
--- a/claude/.claude/skills/plan-review/SKILL.md
+++ b/claude/.claude/skills/plan-review/SKILL.md
@@ -115,7 +115,7 @@ B10. **Test realism** — Are the planned test assertions realistic? Will existi
 
 B11. **Rollback strategy** — For destructive or hard-to-reverse changes (data migrations, API format changes, dependency removals), is there a rollback plan, or is the change structured to be safely reversible by default?
 
-B12. **Dependency risk** — Does the plan add, upgrade, or remove dependencies? If so, does it account for transitive conflicts, license implications, and the maintenance health of new dependencies?
+B12. **Dependency risk** — Does the plan add, upgrade, or remove dependencies? If so, does it account for transitive conflicts, license implications, and the maintenance health of new dependencies? When a plan removes a direct dependency and asserts the package remains available via transitive resolution, require verification that the project's package manager isolation model actually makes it visible to build tools — not all package managers hoist transitives to root-level resolution paths.
 
 ### Clarity
 


### PR DESCRIPTION
## Summary

- Appends one sentence to checklist item B12 in `claude/.claude/skills/plan-review/SKILL.md`
- When a plan removes a direct dependency and asserts the package remains available via transitive resolution, plan-review now requires the plan to verify that the project's package manager isolation model actually makes the package visible to build tools
- Wording is paradigm-agnostic — no pnpm / npm / yarn / PnP tokens per the global skill platform-agnostic rule

Closes #311.

## Rationale

B12 as written covered transitive conflicts, license implications, and maintenance health, but not the hoisting-assumption class. Strict-isolation package managers (pnpm, Yarn PnP) do not hoist transitives to root-level resolution paths the way classic npm does. A plan asserting "X is still available because Y pulls it in" is making an unverified assumption that B12 previously had no hook to catch.

The fix is one sentence at the end of B12 — no new checklist item, no ROUTING.md changes (routing target for B12 is unchanged: `staff-backend-engineer` for runtime deps, `staff-platform-engineer` for CI/build deps).

## Test plan

- [x] `/skill-review` run on the diff — clean
- [x] `/code-review` run on the diff — clean
- [x] `ruff check claude/.claude/` — all checks passed
- [x] `pytest claude/.claude/` — 1225/1225 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)