### PR TITLE
feat: add test-code guardrails to /test-conventions and /code-review

### DIFF
--- a/claude/.claude/skills/code-review/SKILL.md
+++ b/claude/.claude/skills/code-review/SKILL.md
@@ -209,6 +209,7 @@ The Change type column keys on what the change *does* for an operator or consume
 | Re-points a read to a different data source while both stay populated | `staff-data-engineer` + `staff-backend-engineer` + `ciso-reviewer` (when the read feeds an access-control decision) — verify every write path to the prior source also writes to the new one |
 | Changes API response shape | `staff-product-engineer` + `staff-backend-engineer` — verify all consumers handle new shape |
 | Adds/modifies security controls | `staff-sdet` + `ciso-reviewer` — verify test pyramid, coverage, and threat model |
+| Adds or modifies test code | `staff-sdet` — verify test-pyramid placement, behavioral-vs-structural fidelity, fixture realism, and mock design |
 | Changes auth model (JWT, roles, permissions) | `ciso-reviewer` + `staff-backend-engineer` — trace all auth paths including token refresh, session expiry, and error fallbacks |
 | Modifies shared utilities (helpers, hooks, contexts) | `staff-backend-engineer` + `staff-frontend-engineer` — verify all call sites and check for behavioral assumptions |
 | Changes data model (columns, types, defaults, migrations) | Route by change type: new nullable column, index, or view → `staff-backend-engineer` only; new table → `staff-backend-engineer` + `staff-analytics-engineer`; rename, drop, type change, NOT NULL constraint added, partition key, or RLS policy → `staff-backend-engineer` + `staff-data-engineer` + `staff-analytics-engineer`. Add `staff-product-engineer` if user-visible. |

--- a/claude/.claude/skills/test-conventions/SKILL.md
+++ b/claude/.claude/skills/test-conventions/SKILL.md
@@ -142,7 +142,6 @@ For tests that guard against a specific past bug, include a comment or docstring
 - Run when either side changes; no need for a live instance of the other service
 
 **E2E tests:**
-- Complete user flows across the full stack
 - Run pre-merge or on a schedule, not on every commit
 - Use test/sandbox accounts and environments
 
@@ -197,4 +196,5 @@ Avoid these when writing new tests:
 | Over-mocking (test encodes implementation, not behavior) | Mock only direct dependencies; let integration tests cover wiring |
 | Mocking third-party internals (library's private API) | Use the library's test utilities or mock at your own abstraction boundary |
 | Testing the test double (asserting stub's own return value) | Assert on values the code computed or transformed |
+| Source-scanning the file under test (reading it as a string and asserting substrings) instead of executing it | Reading source proves the literal text exists, not that it runs, is reachable, or behaves correctly; the assertion passes on dead code and fails on cosmetic renames. Use a behavioral test: execute the function/hook/component with mocked dependencies and assert observable behavior. Source-scans are a tripwire for *wiring presence only*, never a substitute for a behavioral assertion. |
 | Stub or vacuous assertion when blocked by credentials/env/external state | Mock or fake the credential boundary; don't commit a permanently-passing assertion. |


### PR DESCRIPTION
## Summary

- **test-conventions §9**: adds a source-scanning anti-pattern row — flags tests that read a source file as a string and assert on substrings instead of executing the code under test.
- **code-review Change-type table**: adds a routing row that fires `staff-sdet` on any diff that adds or modifies test code, closing the gap where test-only PRs bypassed specialist review.

## Details

The source-scanning row explains why the pattern is defective (assertion passes on dead code, fails on cosmetic renames) and states the fix (behavioral test with mocked dependencies).

The code-review row directs `staff-sdet` to verify test-pyramid placement, behavioral-vs-structural fidelity, fixture realism, and mock design.

`test-conventions/SKILL.md` is now exactly 200 lines (trimmed a redundant bullet from the §7 E2E list that duplicated the §1 table row and §1 prose).

## Test plan

- [ ] `wc -l claude/.claude/skills/test-conventions/SKILL.md` → 200
- [ ] CI passes (pytest + ruff)
- [ ] Trigger `/test-conventions` on a session that is authoring a source-scanning test — confirm the new §9 row surfaces
- [ ] Trigger `/code-review` on a diff that only modifies test files — confirm `staff-sdet` is dispatched

🤖 Generated with [Claude Code](https://claude.com/claude-code)