### PR TITLE
docs: ground-choices, scope-discipline, DEFER-persist rules

### DIFF
--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -11,16 +11,39 @@
 - **Audit structural siblings before scoping a fix narrowly.** When a fix lands in one arm of a multi-arm structure (case statement, switch, parallel subcommands, sibling functions sharing a shape), check the other arms for the same bug shape before finalizing scope. If the fix is identical, apply to every affected site; abstract when two or more share it. Scope is set by the bug, not by where the symptom surfaced.
 - **Prove your change caused a failing check before treating it as in-scope.** When a check fails, reproduce it on the pre-change baseline — a throwaway worktree at the merge-base (`git worktree add <tmp> $(git merge-base HEAD origin/main)`) — before assuming the failure is yours. Failing there too means pre-existing drift, not this task's work: sync the branch if the base already fixed it, but never hand-reimplement a merged fix or edit an unrelated file. Passing at the baseline but failing on your branch means your change caused it — in scope even if you never touched the failing file, since a change breaks dependents through their imports.
 - **Extract functions when you need to explain what a fragment does.** When writing a function, if any internal fragment requires effort to understand *what* (not *how*) it's doing, extract it and name the new function after that "what." The signal is comprehension effort, not line count — a large function that expresses one nameable thing without inner confusion is fine.
+- **Ground every choice.** Five categories of decision require a primary-source citation before implementation, not after:
+  - **Numeric literals in network/timeout/retry contexts** — cite the vendor or protocol documentation that specifies the value. A timeout of `10000` is a silent assumption; a timeout cited to "Stripe's webhook signature window (300s, per the Stripe docs)" is grounded.
+  - **Lint suppressions** (`deno-lint-ignore`, `eslint-disable`, `// @ts-ignore`) — add a one-line comment naming the alternative that was considered and why it does not apply. No rationale = no suppression.
+  - **Discriminator literals where a canonical symbol exists** — never embed a raw value (string or integer) that represents an enum, status, or code defined elsewhere. Reach for the language or framework's standard constant first (`http.StatusNotFound` over `404`, `errno.ENOENT` over `2`); if the discriminator is project-defined and the project ships a registry, enum, or named-type module, use that. Literals diverge silently from the canonical set; named symbols don't.
+  - **New third-party dependencies** (npm packages, GitHub Actions, libraries) — research the package's vulnerability history, maintenance health, and pinning strategy before adding; record the source-of-choice rationale in the PR description. Popularity is not provenance.
+  - **Hand-rolled logic in non-trivial domains** (HTTP, auth, date/time, cryptography, calendar sync) — search the standard library and first-party SDK before implementing. If hand-rolling is warranted, justify the absence of a standard alternative in the commit message.
 
 ## Working Style
 
 - Walk through your proposed approach and explain tradeoffs before writing code. When presenting options, evaluate them — state which you'd recommend and why, rather than listing choices without a judgment.
 - Be precise. Do not overstate severity, conflate distinct issues, or hand-wave. State the realistic impact and verify claims against actual code — not against what the code or a sensible design should do.
-- Always prefer minimal, targeted changes. Do not refactor entire files or expand scope beyond what was asked. If you see an opportunity for a broader improvement, mention it separately — do not bundle it in.
+- Always prefer minimal, targeted changes. Do not refactor entire files or expand scope beyond what was asked. If you see an opportunity for a broader improvement, mention it separately — do not bundle it in. See also *Scope discipline* below for file-boundary and preserved-content rules.
 - **Compounding defensive layers are a wrong-foundation tell.** When a design accumulates stacked defenses on a single mechanism — each new layer closing a gap that the prior layer's existence created — or starts citing its own prior findings, step back and ask whether a foundational change would dissolve them. Do not keep adding hardening. The right primitive usually has a simple shape; compounding complexity is a signal to question the foundation, not to defend it more carefully.
 - Before assuming anything about the environment, stack, or project conventions, check first. Read the actual config files rather than guessing defaults.
 - Use descriptive variable and function names. No generic names.
 - **Default-consider delegation.** Before running a Bash command, starting a broad search, initiating a check suite, or beginning a Read-heavy probe, ask whether the *objective* (not the individual command) belongs in a subagent. The parent's context is re-read every turn, so verbose tool output left in it is paid for repeatedly. See the `subagent-delegation` skill for the two-test gate, which subagent fits which case, and what stays inline.
+- **Scope discipline.** Three axes govern which edits belong in a change. The *minimal, targeted changes* rule above is a fourth axis (change-size); see also `code-review/SKILL.md`'s ADDRESS default for the in-diff case (Axis 2).
+
+  **Axis 1 — File boundary.** Do not edit a file unless the ticket scopes it OR the edit is required to make the ticket's change correct (e.g., a caller's signature must change because the ticket changed the callee). Files noticed while passing through but not in scope go into one of three buckets:
+  1. **Revert** — the default, especially for copy, comments, or cosmetic edits on user-facing surfaces.
+  2. **Keep, with a one-line rationale in an "Incidental edits" section of the PR description** — for small, non-cosmetic fixes with visible value where the PR remains coherent.
+  3. **File a separate ticket** — when the observation is real but non-trivial or distracting.
+
+  **Axis 2 — In-file Fowler.** Inside a file the ticket scopes, opportunistic refactoring of *code* is encouraged (Boy Scout rule). This preserves the ADDRESS default in `code-review/SKILL.md`, which is grounded in Fowler's *Opportunistic Refactoring*.
+
+  **Axis 3 — Preserved-content exception (within in-file Fowler).** Even inside a scoped file, the following content categories are read-only unless the ticket specifically asks to update them. Fowler's Boy Scout rule applies to code (broken windows, dead code, unclear names); it does not license editing preserved-record prose:
+  1. Historical incident records, postmortems, and dated runbook entries.
+  2. Changelog entries documenting past events.
+  3. Migration file content.
+  4. Anchor comments documented to be stable (e.g., HTML-comment fixtures the test harness re-reads).
+  5. Commit-log-style narration inside docs ("In PR #N we…", "Prior to 2026-Q1 the system…").
+
+  Decision test: **Does this text record something that happened, or describe how the code currently behaves?** Records are read-only. Descriptions are fair game for in-file Fowler cleanup.
 - When a session crosses ~60% context usage (per statusline `.context_window.used_percentage`) AND the current task is incomplete, suggest the user run `/handoff` — it's user-invoked; don't run it yourself.
 
 ## Code Review

--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -12,38 +12,39 @@
 - **Prove your change caused a failing check before treating it as in-scope.** When a check fails, reproduce it on the pre-change baseline — a throwaway worktree at the merge-base (`git worktree add <tmp> $(git merge-base HEAD origin/main)`) — before assuming the failure is yours. Failing there too means pre-existing drift, not this task's work: sync the branch if the base already fixed it, but never hand-reimplement a merged fix or edit an unrelated file. Passing at the baseline but failing on your branch means your change caused it — in scope even if you never touched the failing file, since a change breaks dependents through their imports.
 - **Extract functions when you need to explain what a fragment does.** When writing a function, if any internal fragment requires effort to understand *what* (not *how*) it's doing, extract it and name the new function after that "what." The signal is comprehension effort, not line count — a large function that expresses one nameable thing without inner confusion is fine.
 - **Ground every choice.** Five categories of decision require a primary-source citation before implementation, not after:
-  - **Numeric literals in network/timeout/retry contexts** — cite the vendor or protocol documentation that specifies the value. A timeout of `10000` is a silent assumption; a timeout cited to "Stripe's webhook signature window (300s, per the Stripe docs)" is grounded.
-  - **Lint suppressions** (`deno-lint-ignore`, `eslint-disable`, `// @ts-ignore`) — add a one-line comment naming the alternative that was considered and why it does not apply. No rationale = no suppression.
-  - **Discriminator literals where a canonical symbol exists** — never embed a raw value (string or integer) that represents an enum, status, or code defined elsewhere. Reach for the language or framework's standard constant first (`http.StatusNotFound` over `404`, `errno.ENOENT` over `2`); if the discriminator is project-defined and the project ships a registry, enum, or named-type module, use that. Literals diverge silently from the canonical set; named symbols don't.
-  - **New third-party dependencies** (npm packages, GitHub Actions, libraries) — research the package's vulnerability history, maintenance health, and pinning strategy before adding; record the source-of-choice rationale in the PR description. Popularity is not provenance.
-  - **Hand-rolled logic in non-trivial domains** (HTTP, auth, date/time, cryptography, calendar sync) — search the standard library and first-party SDK before implementing. If hand-rolling is warranted, justify the absence of a standard alternative in the commit message.
+  - **Numeric literals in network/timeout/retry contexts** — cite the vendor or protocol documentation that specifies the value. A timeout of `10000` is a silent assumption; a value traceable to vendor docs or a protocol specification is grounded.
+  - **Inline lint/type-check suppressions** — add a one-line comment naming the alternative considered and why it does not apply. No rationale = no suppression.
+  - **Discriminator literals where a canonical symbol exists** — never embed a raw value (string or integer) that represents an enum, status, or code defined elsewhere. Reach for the language or framework's named constant first; if the discriminator is project-defined and the project ships a registry or named-type module, use that. Literals diverge silently from the canonical set; named symbols don't.
+  - **New third-party dependencies** — research the package's vulnerability history, maintenance health, and pinning strategy before adding; record the source-of-choice rationale in the PR description. Popularity is not provenance.
+  - **Hand-rolled logic in non-trivial domains** (cryptography, auth, date/time, network protocol parsing) — search the standard library and first-party SDK before implementing. If hand-rolling is warranted, justify the absence of a standard alternative in the commit message.
 
 ## Working Style
 
 - Walk through your proposed approach and explain tradeoffs before writing code. When presenting options, evaluate them — state which you'd recommend and why, rather than listing choices without a judgment.
 - Be precise. Do not overstate severity, conflate distinct issues, or hand-wave. State the realistic impact and verify claims against actual code — not against what the code or a sensible design should do.
-- Always prefer minimal, targeted changes. Do not refactor entire files or expand scope beyond what was asked. If you see an opportunity for a broader improvement, mention it separately — do not bundle it in. See also *Scope discipline* below for file-boundary and preserved-content rules.
 - **Compounding defensive layers are a wrong-foundation tell.** When a design accumulates stacked defenses on a single mechanism — each new layer closing a gap that the prior layer's existence created — or starts citing its own prior findings, step back and ask whether a foundational change would dissolve them. Do not keep adding hardening. The right primitive usually has a simple shape; compounding complexity is a signal to question the foundation, not to defend it more carefully.
 - Before assuming anything about the environment, stack, or project conventions, check first. Read the actual config files rather than guessing defaults.
 - Use descriptive variable and function names. No generic names.
 - **Default-consider delegation.** Before running a Bash command, starting a broad search, initiating a check suite, or beginning a Read-heavy probe, ask whether the *objective* (not the individual command) belongs in a subagent. The parent's context is re-read every turn, so verbose tool output left in it is paid for repeatedly. See the `subagent-delegation` skill for the two-test gate, which subagent fits which case, and what stays inline.
-- **Scope discipline.** Three axes govern which edits belong in a change. The *minimal, targeted changes* rule above is a fourth axis (change-size); see also `code-review/SKILL.md`'s ADDRESS default for the in-diff case (Axis 2).
+- **Scope discipline.** Four axes govern which edits belong in a change.
 
   **Axis 1 — File boundary.** Do not edit a file unless the ticket scopes it OR the edit is required to make the ticket's change correct (e.g., a caller's signature must change because the ticket changed the callee). Files noticed while passing through but not in scope go into one of three buckets:
   1. **Revert** — the default, especially for copy, comments, or cosmetic edits on user-facing surfaces.
   2. **Keep, with a one-line rationale in an "Incidental edits" section of the PR description** — for small, non-cosmetic fixes with visible value where the PR remains coherent.
-  3. **File a separate ticket** — when the observation is real but non-trivial or distracting.
+  3. **Raise to the reviewer** — when the observation is real but non-trivial or distracting; surface it to the PR reviewer or human orchestrator.
 
-  **Axis 2 — In-file Fowler.** Inside a file the ticket scopes, opportunistic refactoring of *code* is encouraged (Boy Scout rule). This preserves the ADDRESS default in `code-review/SKILL.md`, which is grounded in Fowler's *Opportunistic Refactoring*.
+  **Axis 2 — In-file scope.** Inside a file the ticket scopes, opportunistic refactoring of *code* is encouraged.
 
-  **Axis 3 — Preserved-content exception (within in-file Fowler).** Even inside a scoped file, the following content categories are read-only unless the ticket specifically asks to update them. Fowler's Boy Scout rule applies to code (broken windows, dead code, unclear names); it does not license editing preserved-record prose:
+  **Axis 3 — Preserved-content exception.** Even inside a scoped file, the following content categories are read-only unless the ticket specifically asks to update them. The in-file refactoring license (Axis 2) applies to code (broken windows, dead code, unclear names); it does not license editing preserved-record prose:
   1. Historical incident records, postmortems, and dated runbook entries.
   2. Changelog entries documenting past events.
   3. Migration file content.
   4. Anchor comments documented to be stable (e.g., HTML-comment fixtures the test harness re-reads).
   5. Commit-log-style narration inside docs ("In PR #N we…", "Prior to 2026-Q1 the system…").
 
-  Decision test: **Does this text record something that happened, or describe how the code currently behaves?** Records are read-only. Descriptions are fair game for in-file Fowler cleanup.
+  Decision test: **Does this text record something that happened, or describe how the code currently behaves?** Records are read-only. Descriptions are fair game for in-file scope cleanup.
+
+  **Axis 4 — Change size.** Prefer minimal, targeted changes. Do not refactor entire files or expand scope beyond what was asked. If you see an opportunity for a broader improvement, mention it separately — do not bundle it in.
 - When a session crosses ~60% context usage (per statusline `.context_window.used_percentage`) AND the current task is incomplete, suggest the user run `/handoff` — it's user-invoked; don't run it yourself.
 
 ## Code Review

--- a/claude/.claude/skills/code-review/SKILL.md
+++ b/claude/.claude/skills/code-review/SKILL.md
@@ -269,6 +269,23 @@ Format: inline `ADDRESS:` / `DEFER (<criterion>):` tags when there are ≤2 find
 
 If you find yourself tagging 3+ findings DEFER in a single review, re-read the criteria — the default is ADDRESS, and a heavy DEFER list is usually a sign the criteria are being stretched.
 
+## DEFER persistence
+
+When the disposition step produces ≥1 DEFER finding, persist the DEFER rows (and only the DEFER rows) to the PR description as a `## Deferred review findings` section. ADDRESS findings are not persisted — they are visible in the diff the reviewer is reading.
+
+Row format: `Finding | Source | DEFER criterion | Rationale` (four columns, same shape as the disposition table filtered to non-ADDRESS rows).
+
+**If a PR is already open** (`gh pr view --json number,body` succeeds): update the PR description idempotently with `gh pr edit --body`. Delimit the section with HTML comment markers so it can be mechanically replaced on re-runs:
+
+Opening delimiter: `<!-- code-review:deferred:start -->`
+Closing delimiter: `<!-- code-review:deferred:end -->`
+
+Append the delimited block if absent; replace the existing delimited block if present (idempotent across repeated `/code-review` runs as fix commits collapse DEFERs into ADDRESSes or introduce new ones). Preserve all PR description content outside the delimiters.
+
+**If no PR is open yet** (pre-`/ready-for-review` path): return the rendered `## Deferred review findings` block as part of the orchestrator output. The `/ready-for-review` step 5 splices it into the PR body at PR-creation time.
+
+**If zero DEFERs**: do not add the section. If a prior run wrote the delimited block and the latest run produces zero DEFERs, remove the delimited block from the PR description.
+
 ## Item ownership
 
 Routes each checklist item to the reviewer subagent(s) that file findings on it. Bold shorthands match titles above; numbers are the dispatcher's primary key. **Primary owner** files findings; **co-owners** are spawned where the item touches their turf. When in doubt, this table wins over inline mentions.

--- a/claude/.claude/skills/code-review/SKILL.md
+++ b/claude/.claude/skills/code-review/SKILL.md
@@ -282,7 +282,7 @@ Closing delimiter: `<!-- code-review:deferred:end -->`
 
 Append the delimited block if absent; replace the existing delimited block if present (idempotent across repeated `/code-review` runs as fix commits collapse DEFERs into ADDRESSes or introduce new ones). Preserve all PR description content outside the delimiters.
 
-**If no PR is open yet** (pre-`/ready-for-review` path): return the rendered `## Deferred review findings` block as part of the orchestrator output. The `/ready-for-review` step 5 splices it into the PR body at PR-creation time.
+**If no PR is open yet** (pre-`/ready-for-review` path): return the rendered `## Deferred review findings` block as part of the orchestrator output, wrapped in the same HTML comment delimiters (`<!-- code-review:deferred:start -->` / `<!-- code-review:deferred:end -->`). The `/ready-for-review` step 5 splices it into the PR body at PR-creation time; the delimiters let a subsequent `/code-review` run locate and replace the block idempotently.
 
 **If zero DEFERs**: do not add the section. If a prior run wrote the delimited block and the latest run produces zero DEFERs, remove the delimited block from the PR description.
 

--- a/claude/.claude/skills/ready-for-review/SKILL.md
+++ b/claude/.claude/skills/ready-for-review/SKILL.md
@@ -129,16 +129,16 @@ they would otherwise trigger command substitution.
 ## 5. Create PR if missing (skip if PR already exists)
 
 Skip if PR found in step 1. Halt if no remote tracking — "Branch is not pushed. Push with `git push -u origin <branch>` then re-run." TICKET-ID: split branch on `/`; if first segment matches `^[A-Za-z]+-[0-9]+$`, use as title prefix; else omit. Title: `<TICKET-ID>: <slug-hyphens-as-spaces>` ≤70 chars.
-Body (omit `$ARGUMENTS` if empty; use single-quoted `<<'EOF'` heredoc; capture PR number for step 6):
+Body (omit `$ARGUMENTS` if empty; use single-quoted `<<'EOF'` heredoc; capture PR number for step 6). If `/code-review` returned a `## Deferred review findings` block at review time (≥1 DEFER, no open PR), assign it to `DEFERRED_FINDINGS` and it will be spliced in above; otherwise set `DEFERRED_FINDINGS` to empty string:
 ```
 ## Summary
 $(git log $(git merge-base origin/$(gh pr view --json baseRefName --jq .baseRefName 2>/dev/null || echo main) HEAD)..HEAD --format="- %s")
 $ARGUMENTS
 ## Test plan
 - [ ] (fill in manual verification steps)
+$DEFERRED_FINDINGS
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ```
-
 ## 6. Final hygiene recheck (halt on fail)
 
 Steps 3 and 4 may have produced new commits or body edits. Reconfirm:


### PR DESCRIPTION
## Summary

- **Ground every choice** (`CLAUDE.md`): five decision categories now require a primary-source citation before implementation — timeout/retry literals, lint/type-check suppressions, discriminator literals, new third-party deps, hand-rolled domain logic. Examples generalized (no tool-specific tokens or language-specific constants).
- **Scope discipline** (`CLAUDE.md`): four-axis rule for which edits belong in a change — file boundary (Axis 1), in-file opportunistic refactoring (Axis 2), preserved-content exception for historical records (Axis 3), change size (Axis 4). Absorbed the prior "minimal, targeted changes" bullet as Axis 4; removed the redundant cross-ref. Bucket 3 of Axis 1 changed from "File a separate ticket" to "Raise to the reviewer / human orchestrator" (project-agnostic).
- **DEFER persistence** (`code-review/SKILL.md` + `ready-for-review/SKILL.md`): code-review now persists DEFER-tagged findings (only) to the PR description as an HTML-comment-delimited section; ready-for-review step 5 splices the block into new PRs at creation time.

## Test plan
- [x] Run `../../../.venv/bin/pytest claude/.claude/` from the worktree — verifies hook-alignment tests (HOOK_TEST_FIXTURE blocks in both SKILL.md files must still match hook scripts)
- [x] Verify `../../../.venv/bin/ruff check claude/.claude/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)