### PR TITLE
GH-315: add intent-based nudge to subagent-delegation skill

### DIFF
--- a/claude/.claude/skills/subagent-delegation/SKILL.md
+++ b/claude/.claude/skills/subagent-delegation/SKILL.md
@@ -137,11 +137,9 @@ than running it inline:
 
 Discovery output inhales into the parent context exactly like a check
 suite does, and an auto-mode parent on Opus pays that in the most
-expensive tokens — for output it only needed an *answer* from. A lookup
-stays inline when you already know the target — one `grep` for a
-specific symbol, one `Read` of a path you have already identified.
-Dispatch any read whose purpose is to explore, map, or locate — even a
-single command. The ~3-query threshold is a trailing indicator; by the
+expensive tokens — for output it only needed an *answer* from. Dispatch
+any read whose purpose is to explore, map, or locate — even a single
+command. The ~3-query threshold is a trailing indicator; by the
 time a third command fires, multiple turns of exploratory output have
 already landed in context.
 

--- a/claude/.claude/skills/subagent-delegation/SKILL.md
+++ b/claude/.claude/skills/subagent-delegation/SKILL.md
@@ -3,8 +3,9 @@ name: subagent-delegation
 description: >
   When to dispatch to a subagent vs inline. TRIGGER when: full
   check suite or full-project verification; broad codebase search;
-  2nd/3rd Bash command toward same question; delegating
-  implementation; reporting check-runner test counts.
+  first exploratory read (target unknown); 2nd/3rd Bash command
+  toward same question; delegating implementation; reporting
+  check-runner test counts.
   DO NOT TRIGGER when: single targeted lookup; comprehension read
   feeding your own writing/review/design; Edit/Write sequences;
   output requiring line-by-line reasoning.
@@ -40,8 +41,10 @@ dispatch the question instead of continuing inline.
 
 **Stays inline — do not over-delegate:**
 
-- A single targeted lookup; one `grep` for a known symbol; one `Read`
-  of a known path.
+- A lookup where you already know the target — one `grep` for a
+  specific known symbol, one `Read` of a specific known path. If you
+  do not yet know what you are looking for, that is exploratory —
+  dispatch it even if you only planned one command.
 - A comprehension read whose content feeds your own writing, review, or
   design.
 - `Edit`/`Write` sequences (judgment-dense, not scratch).
@@ -134,10 +137,13 @@ than running it inline:
 
 Discovery output inhales into the parent context exactly like a check
 suite does, and an auto-mode parent on Opus pays that in the most
-expensive tokens — for output it only needed an *answer* from. A single
-targeted lookup — one `grep` for a known symbol, one `Read` of a known
-path — stays inline; dispatch when the search is broad or spans more
-than ~3 queries.
+expensive tokens — for output it only needed an *answer* from. A lookup
+stays inline when you already know the target — one `grep` for a
+specific symbol, one `Read` of a path you have already identified.
+Dispatch any read whose purpose is to explore, map, or locate — even a
+single command. The ~3-query threshold is a trailing indicator; by the
+time a third command fires, multiple turns of exploratory output have
+already landed in context.
 
 This does not apply to *comprehension* reads: when you need a file's
 content in your own reasoning — to write or modify it, review it, or


### PR DESCRIPTION
## Summary

- Replaces threshold-based stay-inline language with an intent-based rule in `subagent-delegation/SKILL.md`
- Fires before the first exploratory read (target unknown), not after the 2nd/3rd command
- Adds "first exploratory read (target unknown)" to the frontmatter TRIGGER list

## Context

GH-315 phase 3. The `audit-routing-shape` histogram (35-day Opus transcript window) showed 86% of code-read turns end without an inline edit or dispatch (D3-neither). ~97% of code-read streaks are length-1 — the existing "2nd/3rd Bash command" threshold catches almost nothing.

## What changed

Four targeted edits to `subagent-delegation/SKILL.md`:

1. **Frontmatter** — added `first exploratory read (target unknown);` to the TRIGGER list
2. **Step 1 "Stays inline" bullet** — replaced "A single targeted lookup" with explicit intent language: if you already know the target, the lookup stays inline; if you are exploring to find it, dispatch even for a single command
3. **Step 2 codebase-discovery paragraph** — same intent-based rule replacing "dispatch when the search is broad or spans more than ~3 queries"; the ~3-query threshold is retained as a trailing-indicator note
4. **Step 2 deduplication** — removed the verbatim inline-carve-out sentence from the discovery paragraph (it restated Step 1 exactly); Step 1 is the canonical source for that rule

## Test plan

- [x] `/skill-review` clean — behavioral-equivalence audit passed, no N rows
- [x] `/code-review` clean — no findings
- [ ] Manual spot-check: verify the three borderline scenarios (inline-eligible, dispatch-required, ambiguous-now-clear) give clear answers with the new prose

🤖 Generated with [Claude Code](https://claude.com/claude-code)