### PR TITLE
GH-333: add adversarial trigger-cases for subagent-delegation skill

### DIFF
--- a/claude/.claude/skills/subagent-delegation/evals/trigger-cases.json
+++ b/claude/.claude/skills/subagent-delegation/evals/trigger-cases.json
@@ -1,0 +1,41 @@
+{
+  "skill_name": "subagent-delegation",
+  "method": "description-fidelity",
+  "cases": [
+    {
+      "id": "comprehension-read-feeding-edit",
+      "query": "Add a docstring to the `parse_config` function in `src/utils.py`.",
+      "should_trigger": false
+    },
+    {
+      "id": "targeted-lookup-known-path",
+      "query": "Show me the implementation of `render_widget` in `src/ui/widgets.py`.",
+      "should_trigger": false
+    },
+    {
+      "id": "targeted-grep-known-symbol",
+      "query": "Where is `render_widget` called in this codebase?",
+      "should_trigger": false
+    },
+    {
+      "id": "edit-sequence",
+      "query": "Bump the version field in `package.json` from 1.0.0 to 1.1.0.",
+      "should_trigger": false
+    },
+    {
+      "id": "exploratory-search-unknown-target",
+      "query": "Find every place we render widgets across the codebase.",
+      "should_trigger": true
+    },
+    {
+      "id": "exploratory-one-command",
+      "query": "What's in the `utils/` directory?",
+      "should_trigger": true
+    },
+    {
+      "id": "full-check-suite",
+      "query": "Run the full test suite and tell me what's failing.",
+      "should_trigger": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `claude/.claude/skills/subagent-delegation/evals/trigger-cases.json` with 7 `description-fidelity` cases for the existing `evals/run_skill_evals.py` harness

## Context

PR #332 added intent-based carve-outs to `subagent-delegation` ("comprehension read feeding your own writing/review/design", "lookup where you already know the target"). The PR reviewer asked to validate that prose against real non-delegation turn shapes from transcript analysis. This PR wires up the measurement.

**Method:** `description-fidelity` (correct for an advisory skill — `runtime` false-zeros advisory skills per `evals/README.md`). Same choice as `test-conventions` and `test-evaluation`.

## Case design

Four adversarial DO-NOT-TRIGGER cases (the load-bearing measurement):

| id | query | carve-out exercised |
|----|-------|---------------------|
| `comprehension-read-feeding-edit` | "Add a docstring to the `parse_config` function in `src/utils.py`." | comprehension read feeding writing/review/design |
| `targeted-lookup-known-path` | "Show me the implementation of `render_widget` in `src/ui/widgets.py`." | lookup where you already know the target |
| `targeted-grep-known-symbol` | "Where is `render_widget` called in this codebase?" | same carve-out, grep flavor |
| `edit-sequence` | "Bump the version field in `package.json` from 1.0.0 to 1.1.0." | Edit/Write sequences stay inline |

Three confirming TRIGGER cases (anchors so a collapsed skill also fails):

| id | query | trigger condition |
|----|-------|------------------|
| `exploratory-search-unknown-target` | "Find every place we render widgets across the codebase." | first exploratory read, target unknown |
| `exploratory-one-command` | "What's in the `utils/` directory?" | exploratory, even single command |
| `full-check-suite` | "Run the full test suite and tell me what's failing." | full check suite |

Cases 3 and 5 use the same `render_widget` family and codebase-grep shape, varying **only** on whether the target is named — isolating target-namedness as the discriminating axis.

**Uncovered TRIGGER condition:** "2nd/3rd Bash command toward same question" — the operational trigger. Worth a follow-up case after this baseline lands and K=30 rates are observed.

## Test plan

- [ ] Run baseline eval locally and paste per-case triggered N/K rates as a comment on this PR:
  ```bash
  python evals/run_skill_evals.py --skill subagent-delegation --samples 30 --verbose
  ```
  Expected: all 7 cases PASS. Any DO-NOT-TRIGGER case triggering ≥50% of samples, or TRIGGER case firing <50%, signals a prose discrimination problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)