### PR TITLE
docs(migration-sync): add ordering-artifact failure guidance to step 5

### DIFF
--- a/plugins/lovable-cloud/skills/lovable-cloud-migration-sync/SKILL.md
+++ b/plugins/lovable-cloud/skills/lovable-cloud-migration-sync/SKILL.md
@@ -111,6 +111,23 @@ reset and harmless — Lovable duplicates run later in timestamp order
 than the originals did, so the reset replays the originals' creation
 against the duplicates' drops.
 
+**Ordering-artifact failures: delete first, then reset.** If `supabase db reset`
+fails with an "already exists" error for an object the Lovable duplicate creates —
+because the original ran first in timestamp order and the duplicate's `CREATE`
+fires without a preceding `DROP` — this is a local ordering artifact, not a logic
+error in the Lovable duplicate. On Lovable Cloud (where only the duplicate runs)
+this works correctly.
+
+The fix: delete the original (step 6 below) first, then re-run `supabase db reset`
+with only the Lovable duplicate present. Do **not** modify the Lovable duplicate
+to add `DROP IF EXISTS` guards as a workaround — the duplicate must match exactly
+what Lovable Cloud executed. Editing it creates repo/production divergence even
+when the edit is a harmless no-op DROP.
+
+The "do not proceed on FAIL" rule applies to logic errors in the duplicate (wrong
+predicates, missing DDL, weakened security checks), not to ordering artifacts that
+disappear once the original is deleted.
+
 Once the reset completes, dispatch your project's verify entry point
 (e.g. `npm run verify`, `pytest`, `make verify` — whatever its
 verification command is) via the `Agent` tool with


### PR DESCRIPTION
## Summary

- Adds a paragraph to step 5 of the `lovable-cloud-migration-sync` skill explaining what to do when `supabase db reset` fails with an "already exists" error during migration sync verification.
- Names the root cause (local timestamp-ordering artifact where the original runs before the duplicate, not a logic error in the duplicate).
- Specifies the correct fix: delete the original first, then re-run the reset with only the Lovable duplicate present.
- Explicitly prohibits modifying the Lovable duplicate to add `DROP IF EXISTS` guards — the duplicate must exactly match what Lovable Cloud executed; editing it creates repo/production divergence even for a harmless no-op DROP.
- Scopes the existing "do not proceed on FAIL" rule: it applies to logic errors in the duplicate, not to ordering artifacts that disappear once the original is deleted.

## Test plan

- [ ] Skill review checklist applied (all 12 items clean).
- [ ] 1311 existing tests pass (`pytest claude/.claude/`).
- [ ] No private project identifiers, tracker IDs, or structural fingerprints in the added prose.
- [ ] Step numbering, acceptable-differences list, and all other existing content unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)