### PR TITLE
fix(lovable-cloud): bump plugin to 2.3.0 — missed version bump from PR 335

### DIFF
--- a/plugins/lovable-cloud/.claude-plugin/plugin.json
+++ b/plugins/lovable-cloud/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lovable-cloud",
   "description": "Skills for Lovable Cloud projects — Project/Workspace Knowledge fields, edge-function auth model, and migration-sync workflow.",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "author": {
     "name": "Cordova Strategy"
   },


### PR DESCRIPTION
## Summary

- Bumps `plugins/lovable-cloud/.claude-plugin/plugin.json` from `2.2.1` → `2.3.0`
- Backfills the missed version bump from PR #335, which added new procedural guidance to `lovable-cloud-migration-sync` but was authored by an agent anchored in a consuming repo (so `plugin-semver` never fired)

## Why minor

PR #335 added two things to `lovable-cloud-migration-sync`:
1. A new capability: handling ordering-artifact failures where `supabase db reset` reports "already exists" because the original migration ran before the Lovable duplicate in timestamp order
2. A hard prohibition: do not add `DROP IF EXISTS` guards to the Lovable duplicate (creates repo/production divergence)

Per `plugin-semver`: "a new capability in an existing skill" = minor bump.

## Post-merge install command

```
claude plugin install lovable-cloud@claude-config --scope project
```