### PR TITLE
GH-315: add check-claude-md-length.sh to enforce 200-line CLAUDE.md/AGENTS.md limit

### DIFF
--- a/claude/.claude/hooks/check-claude-md-length.sh
+++ b/claude/.claude/hooks/check-claude-md-length.sh
@@ -1,17 +1,21 @@
 #!/bin/bash
-# Gate: block git commit when a staged SKILL.md grows past its per-skill ceiling.
+set -uo pipefail
+# Gate: block git commit when a staged CLAUDE.md or AGENTS.md grows past its limit.
 #
 # Policy: deny when the staged file is over its limit AND longer than the
 # previously committed version. This allows reducing an already-over-limit
 # file commit by commit without blocking the work, while still catching new
 # bloat.
 #
-# Default limit is 200 lines. Structural-dispatcher skills (code-review,
-# plan-review) carry item-ownership / routing tables that legitimately run
-# longer and are capped at Anthropic's documented 500-line ceiling instead.
-# Plugin-scoped skills (plugins/*/skills/) currently have no override path
-# and all fall to the 200-line default — extend limit_for() if a plugin
-# skill earns the same exception.
+# Fail posture: fail-open — tool absence (jq missing, not in a git repo) and
+# parse errors allow the commit through. This gate enforces a style rule, not
+# a security boundary.
+#
+# Default limit is 200 lines, matching the Anthropic-documented threshold for
+# CLAUDE.md/AGENTS.md files (Claude Code — memory: "Longer files consume more
+# context and reduce adherence"). No per-file overrides exist today; the case
+# structure is kept so future exceptions can slot in without touching the
+# surrounding logic.
 #
 # The "if" field in settings.json is unreliable — the internal grep is the
 # actual gate. See require-code-review.sh for the same pattern and rationale.
@@ -27,11 +31,9 @@ fi
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 [ -z "$REPO_ROOT" ] && exit 0
 
-# Per-skill limit override. Listed paths are repo-root-relative.
+# Per-file limit override. Listed paths are repo-root-relative.
 limit_for() {
   case "$1" in
-    claude/.claude/skills/code-review/SKILL.md|claude/.claude/skills/plan-review/SKILL.md)
-      echo 500 ;;
     *)
       echo 200 ;;
   esac
@@ -47,13 +49,13 @@ while IFS= read -r f; do
     MESSAGES="${MESSAGES}  $f: $new lines (was $old, limit $limit)\n"
     FAIL=1
   fi
-# Path prefixes are repo-root-relative for this repo's layout.
-# Covers both stowed skills (claude/.claude/skills/) and project-scoped plugins (plugins/*/skills/).
-# In other repos this grep matches nothing and the hook exits 0 silently.
-done < <(git diff --cached --name-only | grep -E '(claude/.claude/skills/|plugins/[^/]+/skills/).+/SKILL\.md')
+# Matches CLAUDE.md and AGENTS.md at the repo root, inside any .claude/ directory,
+# or at any depth inside a .claude/ directory. Does NOT match files in arbitrary
+# subdirectories (e.g. foo/CLAUDE.md) — only root-level and .claude/-scoped files.
+done < <(git diff --cached --name-only 2>/dev/null | grep -E '^(CLAUDE\.md|AGENTS\.md|(.*/)?\.claude/(CLAUDE|AGENTS)\.md)$')
 
 if [ "$FAIL" -eq 1 ]; then
-  REASON=$(printf 'Skill length gate: one or more SKILL.md files grew past their per-skill limit. Reduce to the limit or fewer lines before committing:\n%b' "$MESSAGES")
+  REASON=$(printf 'CLAUDE.md/AGENTS.md length gate: one or more files grew past the 200-line limit. Reduce to the limit or fewer lines before committing:\n%b' "$MESSAGES")
   REASON_JSON=$(printf '%s' "$REASON" | jq -Rs .)
   printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' "$REASON_JSON"
 fi

--- a/claude/.claude/hooks/tests/test_check_claude_md_length.py
+++ b/claude/.claude/hooks/tests/test_check_claude_md_length.py
@@ -1,0 +1,589 @@
+"""Tests for check-claude-md-length.sh."""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from helpers import (
+    HOOKS_DIR,
+    bash_input,
+    edit_input,
+    run_hook,
+    run_hook_reason,
+)
+
+CHECK_CLAUDE_MD_LENGTH_HOOK = HOOKS_DIR / "check-claude-md-length.sh"
+CLAUDE_MD_PATH = "claude/.claude/CLAUDE.md"
+
+SETTINGS_PATH = Path(__file__).resolve().parents[4] / "claude/.claude/settings.json"
+
+
+def make_lines(n: int, prefix: str = "line") -> str:
+    """Return content with exactly n newline-terminated lines."""
+    return "\n".join(f"{prefix} {i + 1}" for i in range(n)) + "\n"
+
+
+def make_repo_with_file(tmp_path: Path, target_path: str, head_lines: int) -> Path:
+    """Git repo with `target_path` committed at `head_lines` lines."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "test"], cwd=repo, check=True)
+    target = repo / target_path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(make_lines(head_lines))
+    subprocess.run(["git", "add", target_path], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=repo, check=True)
+    return repo
+
+
+class TestCheckClaudeMdLength:
+    # --- Logic matrix (CLAUDE_MD_PATH fixture) ---
+
+    def test_non_commit_command_allows(self, isolated_home, tmp_path):
+        """Non-git-commit Bash command is allowed regardless of staged content."""
+        repo = make_repo_with_file(tmp_path, CLAUDE_MD_PATH, 190)
+        (repo / CLAUDE_MD_PATH).write_text(make_lines(201))
+        subprocess.run(["git", "add", CLAUDE_MD_PATH], cwd=repo, check=True)
+        assert (
+            run_hook(CHECK_CLAUDE_MD_LENGTH_HOOK, bash_input("git status"), cwd=repo)
+            == "allow"
+        )
+
+    def test_non_bash_tool_allows(self, isolated_home, tmp_path):
+        """Non-Bash tool inputs are passed through unconditionally."""
+        repo = make_repo_with_file(tmp_path, CLAUDE_MD_PATH, 190)
+        assert (
+            run_hook(CHECK_CLAUDE_MD_LENGTH_HOOK, edit_input("/tmp/foo.txt"), cwd=repo)
+            == "allow"
+        )
+
+    def test_outside_git_repo_allows(self, isolated_home, tmp_path):
+        """Hook exits 0 silently when CWD is not inside a git repo."""
+        non_repo = tmp_path / "not-a-repo"
+        non_repo.mkdir()
+        assert (
+            run_hook(
+                CHECK_CLAUDE_MD_LENGTH_HOOK,
+                bash_input("git commit -m foo"),
+                cwd=non_repo,
+            )
+            == "allow"
+        )
+
+    def test_no_staged_matching_file_allows(self, isolated_home, tmp_path):
+        """A staged non-CLAUDE.md/AGENTS.md file does not trigger the gate."""
+        repo = make_repo_with_file(tmp_path, CLAUDE_MD_PATH, 190)
+        (repo / "other.txt").write_text("something\n")
+        subprocess.run(["git", "add", "other.txt"], cwd=repo, check=True)
+        assert (
+            run_hook(
+                CHECK_CLAUDE_MD_LENGTH_HOOK,
+                bash_input("git commit -m foo"),
+                cwd=repo,
+            )
+            == "allow"
+        )
+
+    def test_claude_md_at_exactly_200_allows(self, isolated_home, tmp_path):
+        """200 lines is at the limit — the gate is `> 200`, so 200 passes."""
+        repo = make_repo_with_file(tmp_path, CLAUDE_MD_PATH, 190)
+        (repo / CLAUDE_MD_PATH).write_text(make_lines(200))
+        subprocess.run(["git", "add", CLAUDE_MD_PATH], cwd=repo, check=True)
+        assert (
+            run_hook(
+                CHECK_CLAUDE_MD_LENGTH_HOOK,
+                bash_input("git commit -m foo"),
+                cwd=repo,
+            )
+            == "allow"
+        )
+
+    def test_claude_md_growing_to_201_denies(self, isolated_home, tmp_path):
+        """HEAD at 190, staged at 201: new > 200 and new > old → deny."""
+        repo = make_repo_with_file(tmp_path, CLAUDE_MD_PATH, 190)
+        (repo / CLAUDE_MD_PATH).write_text(make_lines(201))
+        subprocess.run(["git", "add", CLAUDE_MD_PATH], cwd=repo, check=True)
+        assert (
+            run_hook(
+                CHECK_CLAUDE_MD_LENGTH_HOOK,
+                bash_input("git commit -m foo"),
+                cwd=repo,
+            )
+            == "deny"
+        )
+
+    def test_new_claude_md_over_limit_denies(self, isolated_home, tmp_path):
+        """New file with no HEAD version staged at 201 lines — old defaults to 0 → deny."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.name", "test"], cwd=repo, check=True)
+        (repo / "README.md").write_text("hello\n")
+        subprocess.run(["git", "add", "README.md"], cwd=repo, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=repo, check=True)
+        target = repo / CLAUDE_MD_PATH
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(make_lines(201))
+        subprocess.run(["git", "add", CLAUDE_MD_PATH], cwd=repo, check=True)
+        assert (
+            run_hook(
+                CHECK_CLAUDE_MD_LENGTH_HOOK,
+                bash_input("git commit -m foo"),
+                cwd=repo,
+            )
+            == "deny"
+        )
+
+    def test_already_over_limit_growing_denies(self, isolated_home, tmp_path):
+        """HEAD at 210, staged at 215: growing while over limit → deny."""
+        repo = make_repo_with_file(tmp_path, CLAUDE_MD_PATH, 210)
+        (repo / CLAUDE_MD_PATH).write_text(make_lines(215))
+        subprocess.run(["git", "add", CLAUDE_MD_PATH], cwd=repo, check=True)
+        assert (
+            run_hook(
+                CHECK_CLAUDE_MD_LENGTH_HOOK,
+                bash_input("git commit -m foo"),
+                cwd=repo,
+            )
+            == "deny"
+        )
+
+    def test_already_over_limit_reducing_allows(self, isolated_home, tmp_path):
+        """HEAD at 210, staged at 205: reducing while over limit → allow."""
+        repo = make_repo_with_file(tmp_path, CLAUDE_MD_PATH, 210)
+        (repo / CLAUDE_MD_PATH).write_text(make_lines(205))
+        subprocess.run(["git", "add", CLAUDE_MD_PATH], cwd=repo, check=True)
+        assert (
+            run_hook(
+                CHECK_CLAUDE_MD_LENGTH_HOOK,
+                bash_input("git commit -m foo"),
+                cwd=repo,
+            )
+            == "allow"
+        )
+
+    def test_already_over_limit_same_size_allows(self, isolated_home, tmp_path):
+        """HEAD at 210, staged at 210 (different content, same count): not growing → allow."""
+        repo = make_repo_with_file(tmp_path, CLAUDE_MD_PATH, 210)
+        (repo / CLAUDE_MD_PATH).write_text(make_lines(210, prefix="row"))
+        subprocess.run(["git", "add", CLAUDE_MD_PATH], cwd=repo, check=True)
+        assert (
+            run_hook(
+                CHECK_CLAUDE_MD_LENGTH_HOOK,
+                bash_input("git commit -m foo"),
+                cwd=repo,
+            )
+            == "allow"
+        )
+
+    def test_staged_deletion_of_claude_md_allows(self, isolated_home, tmp_path):
+        """git rm-staged CLAUDE.md: git show ":$f" produces empty output → new=0, 0 > 200 is false → allow."""
+        repo = make_repo_with_file(tmp_path, CLAUDE_MD_PATH, 190)
+        subprocess.run(["git", "rm", "-q", CLAUDE_MD_PATH], cwd=repo, check=True)
+        assert (
+            run_hook(
+                CHECK_CLAUDE_MD_LENGTH_HOOK,
+                bash_input("git commit -m foo"),
+                cwd=repo,
+            )
+            == "allow"
+        )
+
+    def test_deny_message_includes_filename_and_counts(self, isolated_home, tmp_path):
+        """Deny reason must name the file, new line count, old line count, and limit."""
+        repo = make_repo_with_file(tmp_path, CLAUDE_MD_PATH, 190)
+        (repo / CLAUDE_MD_PATH).write_text(make_lines(201))
+        subprocess.run(["git", "add", CLAUDE_MD_PATH], cwd=repo, check=True)
+        reason = run_hook_reason(
+            CHECK_CLAUDE_MD_LENGTH_HOOK,
+            bash_input("git commit -m foo"),
+            cwd=repo,
+        )
+        assert reason is not None
+        assert CLAUDE_MD_PATH in reason
+        assert "201" in reason
+        assert "190" in reason
+        assert "200" in reason
+
+    def test_cwd_not_repo_root_does_not_cause_false_negative(
+        self, isolated_home, tmp_path
+    ):
+        """Hook run from a repo subdirectory must still catch over-limit CLAUDE.md.
+
+        Regression test: `git diff --cached --name-only` emits repo-root-relative
+        paths. An earlier version had `[ -f "$f" ] || continue` which resolved
+        those paths against CWD — if CWD was a subdirectory the check failed
+        and the file was silently skipped (false negative, bloated file slips
+        through). The guard was removed; `git show ":$f"` reads from the index
+        directly and doesn't depend on CWD.
+        """
+        repo = make_repo_with_file(tmp_path, CLAUDE_MD_PATH, 190)
+        (repo / CLAUDE_MD_PATH).write_text(make_lines(201))
+        subprocess.run(["git", "add", CLAUDE_MD_PATH], cwd=repo, check=True)
+        subdir = repo / "claude"
+        assert (
+            run_hook(
+                CHECK_CLAUDE_MD_LENGTH_HOOK,
+                bash_input("git commit -m foo"),
+                cwd=subdir,
+            )
+            == "deny"
+        )
+
+    # --- Path-shape positive cases (must → deny) ---
+
+    def test_root_claude_md_denies(self, isolated_home, tmp_path):
+        """CLAUDE.md at the repo root matches the filter → deny."""
+        repo = make_repo_with_file(tmp_path, "CLAUDE.md", 190)
+        (repo / "CLAUDE.md").write_text(make_lines(201))
+        subprocess.run(["git", "add", "CLAUDE.md"], cwd=repo, check=True)
+        assert (
+            run_hook(
+                CHECK_CLAUDE_MD_LENGTH_HOOK,
+                bash_input("git commit -m foo"),
+                cwd=repo,
+            )
+            == "deny"
+        )
+
+    def test_root_agents_md_denies(self, isolated_home, tmp_path):
+        """AGENTS.md at the repo root matches the filter → deny."""
+        repo = make_repo_with_file(tmp_path, "AGENTS.md", 190)
+        (repo / "AGENTS.md").write_text(make_lines(201))
+        subprocess.run(["git", "add", "AGENTS.md"], cwd=repo, check=True)
+        assert (
+            run_hook(
+                CHECK_CLAUDE_MD_LENGTH_HOOK,
+                bash_input("git commit -m foo"),
+                cwd=repo,
+            )
+            == "deny"
+        )
+
+    def test_dot_claude_claude_md_denies(self, isolated_home, tmp_path):
+        """.claude/CLAUDE.md matches the filter → deny."""
+        repo = make_repo_with_file(tmp_path, ".claude/CLAUDE.md", 190)
+        (repo / ".claude" / "CLAUDE.md").write_text(make_lines(201))
+        subprocess.run(["git", "add", ".claude/CLAUDE.md"], cwd=repo, check=True)
+        assert (
+            run_hook(
+                CHECK_CLAUDE_MD_LENGTH_HOOK,
+                bash_input("git commit -m foo"),
+                cwd=repo,
+            )
+            == "deny"
+        )
+
+    def test_stowed_source_path_denies(self, isolated_home, tmp_path):
+        """claude/.claude/CLAUDE.md (stowed-source path) matches the filter → deny."""
+        repo = make_repo_with_file(tmp_path, CLAUDE_MD_PATH, 190)
+        (repo / CLAUDE_MD_PATH).write_text(make_lines(201))
+        subprocess.run(["git", "add", CLAUDE_MD_PATH], cwd=repo, check=True)
+        assert (
+            run_hook(
+                CHECK_CLAUDE_MD_LENGTH_HOOK,
+                bash_input("git commit -m foo"),
+                cwd=repo,
+            )
+            == "deny"
+        )
+
+    def test_stowed_source_agents_md_denies(self, isolated_home, tmp_path):
+        """claude/.claude/AGENTS.md (stowed-source path) matches the filter → deny."""
+        repo = make_repo_with_file(tmp_path, "claude/.claude/AGENTS.md", 190)
+        (repo / "claude" / ".claude" / "AGENTS.md").write_text(make_lines(201))
+        subprocess.run(["git", "add", "claude/.claude/AGENTS.md"], cwd=repo, check=True)
+        assert (
+            run_hook(
+                CHECK_CLAUDE_MD_LENGTH_HOOK,
+                bash_input("git commit -m foo"),
+                cwd=repo,
+            )
+            == "deny"
+        )
+
+    def test_dot_claude_agents_md_denies(self, isolated_home, tmp_path):
+        """.claude/AGENTS.md matches the filter → deny."""
+        repo = make_repo_with_file(tmp_path, ".claude/AGENTS.md", 190)
+        (repo / ".claude" / "AGENTS.md").write_text(make_lines(201))
+        subprocess.run(["git", "add", ".claude/AGENTS.md"], cwd=repo, check=True)
+        assert (
+            run_hook(
+                CHECK_CLAUDE_MD_LENGTH_HOOK,
+                bash_input("git commit -m foo"),
+                cwd=repo,
+            )
+            == "deny"
+        )
+
+    # --- AGENTS.md transition triad ---
+
+    def test_agents_md_at_exactly_200_allows(self, isolated_home, tmp_path):
+        """AGENTS.md at 200 lines is at the limit — the gate is `> 200`, so 200 passes."""
+        repo = make_repo_with_file(tmp_path, "AGENTS.md", 190)
+        (repo / "AGENTS.md").write_text(make_lines(200))
+        subprocess.run(["git", "add", "AGENTS.md"], cwd=repo, check=True)
+        assert (
+            run_hook(
+                CHECK_CLAUDE_MD_LENGTH_HOOK,
+                bash_input("git commit -m foo"),
+                cwd=repo,
+            )
+            == "allow"
+        )
+
+    def test_agents_md_growing_to_201_denies(self, isolated_home, tmp_path):
+        """AGENTS.md HEAD at 190, staged at 201: new > 200 and new > old → deny."""
+        repo = make_repo_with_file(tmp_path, "AGENTS.md", 190)
+        (repo / "AGENTS.md").write_text(make_lines(201))
+        subprocess.run(["git", "add", "AGENTS.md"], cwd=repo, check=True)
+        assert (
+            run_hook(
+                CHECK_CLAUDE_MD_LENGTH_HOOK,
+                bash_input("git commit -m foo"),
+                cwd=repo,
+            )
+            == "deny"
+        )
+
+    def test_new_agents_md_over_limit_denies(self, isolated_home, tmp_path):
+        """New AGENTS.md staged at 201 lines — old defaults to 0 → deny."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.name", "test"], cwd=repo, check=True)
+        (repo / "README.md").write_text("hello\n")
+        subprocess.run(["git", "add", "README.md"], cwd=repo, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=repo, check=True)
+        (repo / "AGENTS.md").write_text(make_lines(201))
+        subprocess.run(["git", "add", "AGENTS.md"], cwd=repo, check=True)
+        assert (
+            run_hook(
+                CHECK_CLAUDE_MD_LENGTH_HOOK,
+                bash_input("git commit -m foo"),
+                cwd=repo,
+            )
+            == "deny"
+        )
+
+    def test_first_commit_claude_md_over_limit_denies(self, isolated_home, tmp_path):
+        """First-ever commit to a repo (no HEAD): CLAUDE.md staged at 201 lines → deny.
+
+        Regression test: git show "HEAD:$f" fails when no commits exist; awk
+        'END{print NR}' on empty output returns 0 for old, so deny fires correctly
+        when new > 200 regardless of HEAD state.
+        """
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.name", "test"], cwd=repo, check=True)
+        target = repo / CLAUDE_MD_PATH
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(make_lines(201))
+        subprocess.run(["git", "add", CLAUDE_MD_PATH], cwd=repo, check=True)
+        assert (
+            run_hook(
+                CHECK_CLAUDE_MD_LENGTH_HOOK,
+                bash_input("git commit -m init"),
+                cwd=repo,
+            )
+            == "deny"
+        )
+
+    # --- Negative-path cases (must → allow because regex does not match) ---
+
+    def test_claude_md_bak_allows(self, isolated_home, tmp_path):
+        """CLAUDE.md.bak does not match the filter → allow."""
+        repo = make_repo_with_file(tmp_path, "CLAUDE.md.bak", 190)
+        (repo / "CLAUDE.md.bak").write_text(make_lines(201))
+        subprocess.run(["git", "add", "CLAUDE.md.bak"], cwd=repo, check=True)
+        staged = subprocess.check_output(["git", "diff", "--cached", "--name-only"], cwd=repo).decode()
+        assert "CLAUDE.md.bak" in staged, "file was not actually staged"
+        assert (
+            run_hook(
+                CHECK_CLAUDE_MD_LENGTH_HOOK,
+                bash_input("git commit -m foo"),
+                cwd=repo,
+            )
+            == "allow"
+        )
+
+    def test_not_claude_md_allows(self, isolated_home, tmp_path):
+        """not-CLAUDE.md does not match the filter → allow."""
+        repo = make_repo_with_file(tmp_path, "not-CLAUDE.md", 190)
+        (repo / "not-CLAUDE.md").write_text(make_lines(201))
+        subprocess.run(["git", "add", "not-CLAUDE.md"], cwd=repo, check=True)
+        staged = subprocess.check_output(["git", "diff", "--cached", "--name-only"], cwd=repo).decode()
+        assert "not-CLAUDE.md" in staged, "file was not actually staged"
+        assert (
+            run_hook(
+                CHECK_CLAUDE_MD_LENGTH_HOOK,
+                bash_input("git commit -m foo"),
+                cwd=repo,
+            )
+            == "allow"
+        )
+
+    def test_foo_slash_claude_md_allows(self, isolated_home, tmp_path):
+        """foo/CLAUDE.md (CLAUDE.md outside root and outside .claude/) does not match → allow."""
+        repo = make_repo_with_file(tmp_path, "foo/CLAUDE.md", 190)
+        (repo / "foo" / "CLAUDE.md").write_text(make_lines(201))
+        subprocess.run(["git", "add", "foo/CLAUDE.md"], cwd=repo, check=True)
+        staged = subprocess.check_output(["git", "diff", "--cached", "--name-only"], cwd=repo).decode()
+        assert "foo/CLAUDE.md" in staged, "file was not actually staged"
+        assert (
+            run_hook(
+                CHECK_CLAUDE_MD_LENGTH_HOOK,
+                bash_input("git commit -m foo"),
+                cwd=repo,
+            )
+            == "allow"
+        )
+
+    def test_docs_agents_claude_md_allows(self, isolated_home, tmp_path):
+        """docs/agents/CLAUDE.md does not match the filter → allow."""
+        repo = make_repo_with_file(tmp_path, "docs/agents/CLAUDE.md", 190)
+        (repo / "docs" / "agents" / "CLAUDE.md").write_text(make_lines(201))
+        subprocess.run(["git", "add", "docs/agents/CLAUDE.md"], cwd=repo, check=True)
+        staged = subprocess.check_output(["git", "diff", "--cached", "--name-only"], cwd=repo).decode()
+        assert "docs/agents/CLAUDE.md" in staged, "file was not actually staged"
+        assert (
+            run_hook(
+                CHECK_CLAUDE_MD_LENGTH_HOOK,
+                bash_input("git commit -m foo"),
+                cwd=repo,
+            )
+            == "allow"
+        )
+
+    def test_subfolder_agents_md_allows(self, isolated_home, tmp_path):
+        """subfolder/AGENTS.md does not match the filter → allow."""
+        repo = make_repo_with_file(tmp_path, "subfolder/AGENTS.md", 190)
+        (repo / "subfolder" / "AGENTS.md").write_text(make_lines(201))
+        subprocess.run(["git", "add", "subfolder/AGENTS.md"], cwd=repo, check=True)
+        staged = subprocess.check_output(["git", "diff", "--cached", "--name-only"], cwd=repo).decode()
+        assert "subfolder/AGENTS.md" in staged, "file was not actually staged"
+        assert (
+            run_hook(
+                CHECK_CLAUDE_MD_LENGTH_HOOK,
+                bash_input("git commit -m foo"),
+                cwd=repo,
+            )
+            == "allow"
+        )
+
+    def test_lowercase_claude_md_allows(self, isolated_home, tmp_path):
+        """claude.md (lowercase) does not match the case-sensitive filter → allow."""
+        repo = make_repo_with_file(tmp_path, "claude.md", 190)
+        (repo / "claude.md").write_text(make_lines(201))
+        subprocess.run(["git", "add", "claude.md"], cwd=repo, check=True)
+        staged = subprocess.check_output(["git", "diff", "--cached", "--name-only"], cwd=repo).decode()
+        assert "claude.md" in staged, "file was not actually staged"
+        assert (
+            run_hook(
+                CHECK_CLAUDE_MD_LENGTH_HOOK,
+                bash_input("git commit -m foo"),
+                cwd=repo,
+            )
+            == "allow"
+        )
+
+    # --- Multi-file staged commit ---
+
+    def test_multi_file_both_over_limit_denies_and_names_both(
+        self, isolated_home, tmp_path
+    ):
+        """Both CLAUDE.md and AGENTS.md staged over limit → deny; both filenames in message."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.name", "test"], cwd=repo, check=True)
+        (repo / "CLAUDE.md").write_text(make_lines(190))
+        (repo / "AGENTS.md").write_text(make_lines(190))
+        subprocess.run(["git", "add", "CLAUDE.md", "AGENTS.md"], cwd=repo, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=repo, check=True)
+        (repo / "CLAUDE.md").write_text(make_lines(201))
+        (repo / "AGENTS.md").write_text(make_lines(201))
+        subprocess.run(["git", "add", "CLAUDE.md", "AGENTS.md"], cwd=repo, check=True)
+        result = subprocess.run(
+            [str(CHECK_CLAUDE_MD_LENGTH_HOOK)],
+            input=json.dumps(bash_input("git commit -m foo")),
+            capture_output=True,
+            text=True,
+            cwd=repo,
+            check=False,
+        )
+        payload = json.loads(result.stdout)
+        assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
+        reason = payload["hookSpecificOutput"].get("permissionDecisionReason", "")
+        assert "CLAUDE.md" in reason
+        assert "AGENTS.md" in reason
+        assert "201" in reason
+
+    def test_commit_amend_denies(self, isolated_home, tmp_path):
+        """git commit --amend is still a commit command and must be caught."""
+        repo = make_repo_with_file(tmp_path, CLAUDE_MD_PATH, 190)
+        (repo / CLAUDE_MD_PATH).write_text(make_lines(201))
+        subprocess.run(["git", "add", CLAUDE_MD_PATH], cwd=repo, check=True)
+        assert (
+            run_hook(
+                CHECK_CLAUDE_MD_LENGTH_HOOK,
+                bash_input("git commit --amend --no-edit"),
+                cwd=repo,
+            )
+            == "deny"
+        )
+
+    def test_chained_git_add_commit_denies(self, isolated_home, tmp_path):
+        """Chained `git add ... && git commit` is caught by the internal regex.
+
+        Note: the `if: "Bash(git commit *)"` predicate in settings.json does NOT
+        match chained commands (the glob requires the command to start with
+        "git commit"). This test invokes the hook binary directly, bypassing the
+        harness gate. The internal grep is the actual gate for this command shape —
+        consistent with the hook header's note that the `if` field is unreliable.
+        """
+        repo = make_repo_with_file(tmp_path, CLAUDE_MD_PATH, 190)
+        (repo / CLAUDE_MD_PATH).write_text(make_lines(201))
+        subprocess.run(["git", "add", CLAUDE_MD_PATH], cwd=repo, check=True)
+        assert (
+            run_hook(
+                CHECK_CLAUDE_MD_LENGTH_HOOK,
+                bash_input("git add . && git commit -m foo"),
+                cwd=repo,
+            )
+            == "deny"
+        )
+
+    # --- Settings.json wiring ---
+
+    def test_settings_json_contains_hook_entry(self):
+        """settings.json must wire check-claude-md-length.sh to a Bash PreToolUse group.
+
+        PreToolUse is a list of {matcher, hooks} objects. The hook must be in a
+        group whose matcher includes "Bash" — a PostToolUse entry or a non-Bash
+        matcher would register the command string but disable the gate.
+        """
+        settings = json.loads(SETTINGS_PATH.read_text())
+        matcher_groups = settings.get("hooks", {}).get("PreToolUse", [])
+        matches = [
+            (group.get("matcher", ""), entry)
+            for group in matcher_groups
+            if isinstance(group, dict)
+            for entry in group.get("hooks", [])
+            if isinstance(entry, dict)
+            and entry.get("command") == "~/.claude/hooks/check-claude-md-length.sh"
+        ]
+        assert matches, "No hook entry found for check-claude-md-length.sh in PreToolUse"
+        matcher, _ = matches[0]
+        assert "Bash" in matcher, (
+            f"check-claude-md-length.sh must be in a Bash matcher group; found: {matcher!r}"
+        )

--- a/claude/.claude/hooks/tests/test_check_claude_md_length.py
+++ b/claude/.claude/hooks/tests/test_check_claude_md_length.py
@@ -5,7 +5,6 @@ import json
 import subprocess
 from pathlib import Path
 
-import pytest
 from helpers import (
     HOOKS_DIR,
     bash_input,

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -187,6 +187,12 @@
           },
           {
             "type": "command",
+            "command": "~/.claude/hooks/check-claude-md-length.sh",
+            "if": "Bash(git commit *)",
+            "statusMessage": "Checking CLAUDE.md/AGENTS.md length..."
+          },
+          {
+            "type": "command",
             "command": "~/.claude/hooks/require-ready-for-review.sh",
             "if": "Bash(git push *)",
             "statusMessage": "Checking ready-for-review gate..."

--- a/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
+++ b/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
@@ -89,7 +89,7 @@ attention decays in the middle ("lost in the middle"). Apply the
 **behavior test** below per line; place critical rules near start or end. CLAUDE.md is **advisory** while
 hooks are **deterministic** ([Claude Code Best Practices](https://code.claude.com/docs/en/best-practices):
 hooks "guarantee the action happens") — prefer a hook or structural
-test when a rule can be encoded as one.
+test when a rule can be encoded as one. The 200-line cap is hook-enforced at commit time by `check-claude-md-length.sh` for CLAUDE.md and AGENTS.md.
 
 ### The behavior test
 


### PR DESCRIPTION
## Summary

- Adds `check-claude-md-length.sh`: a `PreToolUse` hook that blocks `git commit` when a staged `CLAUDE.md` or `AGENTS.md` grows past Anthropic's documented 200-line adherence threshold and the staged count exceeds the previously committed count. Already-over-limit files can shrink without being blocked.
- Mirrors `check-skill-length.sh` in structure, path filter (`^(CLAUDE.md|AGENTS.md|(.*/)?\.claude/(CLAUDE|AGENTS)\.md)$`), and policy — denies only when growing past the limit, never on reducing.
- Fixes `check-skill-length.sh` (structural sibling): adds `timeout 5` to both `git show` calls to bound index-lock-contention wait time.
- Wires the new hook in `settings.json` alongside `check-skill-length.sh`.
- Updates `ai-instruction-and-memory-files/SKILL.md` §2 with a one-line note that the 200-line cap is now hook-enforced.

## Test plan

- [ ] 33-test suite in `test_check_claude_md_length.py` covering: logic matrix, path-shape positive/negative cases, AGENTS.md triad, chained-command and `--amend` regression cases, first-commit (no HEAD) regression, stowed-source `claude/.claude/AGENTS.md` path, and wiring verification (event type + Bash matcher)
- [ ] All 960 hook tests pass with no regressions
- [ ] Manual smoke: stage a 201-line `CLAUDE.md` → expect deny naming file, count, and limit
- [ ] Manual smoke: stage a 199-line `CLAUDE.md` → expect commit to proceed
- [ ] Manual smoke: stage a 201-line `foo/CLAUDE.md` (outside `.claude/`) → expect commit to proceed (regex must not match)

## Incidental edits

`check-skill-length.sh` lines 43–44: added `timeout 5` to `git show ":$f"` and `git show "HEAD:$f"` calls. Identical fix applied to `check-claude-md-length.sh`; structural sibling audit per CLAUDE.md.

<!-- code-review:deferred:start -->
## Deferred review findings

| Finding | Source | DEFER criterion | Rationale |
|---------|--------|-----------------|-----------|
| `test_first_commit_claude_md_over_limit_denies` only tests `claude/.claude/CLAUDE.md`; root `CLAUDE.md` first-commit path is untested | staff-sdet | Orthogonal scope | `awk` on empty-input behavior is path-independent; this test was written to pin the awk regression, not to exhaustively cover all paths in the no-HEAD case |
<!-- code-review:deferred:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)