### PR TITLE
feat(ai-instruction-skill): add compression-diff audit to behavior-test subsection

### DIFF
--- a/claude/.claude/skills/ai-instruction-and-memory-files/REFERENCES.md
+++ b/claude/.claude/skills/ai-instruction-and-memory-files/REFERENCES.md
@@ -10,6 +10,15 @@ citing a claim.
 - [Claude Code — How Claude remembers your project](https://code.claude.com/docs/en/memory)
   — the "under 200 lines per CLAUDE.md file" size threshold, CLAUDE.md-loaded-not-AGENTS.md,
   the `@AGENTS.md` import pattern, the auto-memory role split, the MEMORY.md 200-line/25KB load limit.
+
+  > "Use CLAUDE.md files when you want to guide Claude's behavior.
+  > Auto memory lets Claude learn from your corrections without manual
+  > effort."
+
+  > "The first 200 lines of `MEMORY.md`, or the first 25KB, whichever comes
+  > first, are loaded at the start of every conversation... Topic files
+  > like `debugging.md` or `patterns.md` are not loaded at startup. Claude
+  > reads them on demand..."
 - [Claude Code — Best Practices](https://code.claude.com/docs/en/best-practices)
   — CLAUDE.md is advisory while hooks are deterministic; the over-specified-CLAUDE.md failure mode.
 - [claude-code CHANGELOG.md](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md)

--- a/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
+++ b/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
@@ -150,11 +150,7 @@ working tree — never a place for team rules. From
 | Loaded into      | Every session                                     | Every session (first 200 lines or 25KB of `MEMORY.md`)           |
 | Use for          | Coding standards, workflows, project architecture | Build commands, debugging insights, preferences Claude discovers |
 
-See REFERENCES.md — "Claude Code — How Claude remembers your project" for the source quote on CLAUDE.md vs auto-memory roles.
-
 ### `MEMORY.md` is an index, not a memory
-
-See REFERENCES.md — "Claude Code — How Claude remembers your project" for the MEMORY.md 200-line/25KB load-limit source quote.
 
 Index discipline:
 

--- a/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
+++ b/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
@@ -74,10 +74,6 @@ instructions are additive, not overridden. In monorepos this means
 root-level CLAUDE.md, team-directory CLAUDE.md, and project-level
 CLAUDE.md all load together.
 
-For Lovable's UI knowledge fields (Project Knowledge, Workspace
-Knowledge), the `.lovable/*.md` repo-mirror workflow, and review
-criteria for `.lovable/**` changes, see the `lovable-cloud-knowledge` skill.
-
 ## 2. Length targets
 
 Official threshold: **under 200 lines per CLAUDE.md file** ([Claude Code
@@ -98,6 +94,14 @@ input. If removing the line wouldn't change any behavior, cut it.
 Specific incident references, editorial meta-commentary, and narrative
 case studies almost always fail this test; rationale that arms Claude
 for an unenumerated edge case almost always passes.
+
+**Compression-diff audit.** For any diff that removes or shortens lines, fill this table before declaring the review complete:
+
+| Removed/shortened text | Surviving line | Behavior-preserving? |
+|---|---|---|
+| (quote) | (cite) | Y — (quote surviving line) / N — (what is lost) |
+
+Any N is a finding; restore the dropped instruction. Y requires citing the specific surviving line — "the meaning is the same" is not sufficient. Typical CLAUDE.md/AGENTS.md/memory drops: symptom triggers, explicit action instructions, escape-hatch exceptions, verification commands.
 
 ### Don't embed PR or ticket refs in always-loaded files
 
@@ -146,16 +150,11 @@ working tree — never a place for team rules. From
 | Loaded into      | Every session                                     | Every session (first 200 lines or 25KB of `MEMORY.md`)           |
 | Use for          | Coding standards, workflows, project architecture | Build commands, debugging insights, preferences Claude discovers |
 
-> "Use CLAUDE.md files when you want to guide Claude's behavior.
-> Auto memory lets Claude learn from your corrections without manual
-> effort."
+See REFERENCES.md — "Claude Code — How Claude remembers your project" for the source quote on CLAUDE.md vs auto-memory roles.
 
 ### `MEMORY.md` is an index, not a memory
 
-> "The first 200 lines of `MEMORY.md`, or the first 25KB, whichever comes
-> first, are loaded at the start of every conversation... Topic files
-> like `debugging.md` or `patterns.md` are not loaded at startup. Claude
-> reads them on demand..."
+See REFERENCES.md — "Claude Code — How Claude remembers your project" for the MEMORY.md 200-line/25KB load-limit source quote.
 
 Index discipline:
 


### PR DESCRIPTION
## Summary

- Adds a behavioral-equivalence audit table to the §2 "The behavior test" subsection of `ai-instruction-and-memory-files/SKILL.md`, mirroring `skill-review` §7 item 11 but concretized for CLAUDE.md/AGENTS.md/memory compression diffs
- The audit forces the reviewer to enumerate each removed/shortened line and cite the surviving line carrying the same instruction before declaring the review clean
- To stay within the 200-line ceiling: removed the Lovable body cross-ref (wrong altitude for a stow-distributed skill; DO NOT TRIGGER + skill-listing routing covers the gap); moved two Anthropic block quotes from the SKILL.md body into REFERENCES.md (substance encoded in the adjacent comparison table and index-discipline bullets — the inline quotes were supporting evidence, not behavioral instructions)

## Motivation

In an AGENTS.md compression review, two behavior-changing items were dropped ("X came back after I removed it" symptom trigger; "Tell the user this is the fix" explicit action instruction) and only caught by a follow-up engineer review comment. The behavior-test *principle* was already in §2; this adds the post-hoc *audit procedure* that makes the principle actionable on a compression diff.

## Test plan

- [ ] `wc -l` on SKILL.md returns 195 (≤200 ceiling; hook clears)
- [ ] 1386 tests pass (pytest run confirmed pre-commit)
- [ ] `/skill-review` ran clean (behavioral-equivalence table: 3 removed items, all Y with surviving-line citations)
- [ ] `/code-review` ran clean (no findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)