### PR TITLE
feat(hooks): fail-closed alignment + jq timeout across all guard hooks

### DIFF
--- a/claude/.claude/hooks/_lib.sh
+++ b/claude/.claude/hooks/_lib.sh
@@ -54,6 +54,10 @@ _lib_parse_tool_input_or_deny() {
   # error when .tool_input is non-object (e.g. "Cannot index string with string
   # 'command'"), returning non-zero.
   local jq_out
+  # WARNING: the format string below contains a literal 0x1f (ASCII Unit Separator)
+  # byte between the two interpolated fields - invisible in editors and diff views.
+  # Do not remove it. test_lib.py::test_valid_bash_payload_returns_ok will fail
+  # immediately if the delimiter is absent, catching accidental deletion.
   jq_out=$(printf '%s\n' "$INPUT" | _lib_jq -r '"\(.tool_name // "")\(.tool_input.command // "")"' 2>/dev/null)
   local jq_exit=$?
   if [ "$jq_exit" -ne 0 ]; then

--- a/claude/.claude/hooks/_lib.sh
+++ b/claude/.claude/hooks/_lib.sh
@@ -4,6 +4,75 @@
 # byte-identical output on both the read side (hooks) and the write side
 # (marker.sh). Source it; do not invoke it directly.
 
+# Backstop against a hung jq (~5s, not a per-fire latency budget).
+# Cites guard-settings-session-keys.sh's git_capped 5s precedent.
+# Fallback to bare jq when timeout(1) is absent (BSD/macOS default).
+# install.sh warns about missing timeout at onboarding time.
+# Security implication: on BSD/macOS without coreutils, a stalled or
+# replaced jq binary can hold a gate hook open indefinitely. The harness's
+# own hook timeout (if any) then governs — not this wrapper.
+_lib_jq() {
+  if command -v timeout >/dev/null 2>&1; then
+    timeout 5 jq "$@"
+  else
+    jq "$@"
+  fi
+}
+
+# Reads stdin into INPUT (global), extracts TOOL_NAME and COMMAND (globals)
+# via a single _lib_jq call using ASCII Unit Separator (0x1f) as delimiter.
+# The single call surfaces a structural-type error when .tool_input is non-object
+# (jq non-zero exit).
+#
+# Three deny paths protect against silent-allow:
+#   (a) jq non-zero exit (parse failure, timeout exit=124, missing jq binary)
+#   (b) empty INPUT (stdin EOF, closed pipe, harness misbehavior)
+#   (c) empty TOOL_NAME (valid JSON but PreToolUse contract not honored, e.g. "{}")
+# Per Anthropic PreToolUse contract, every legitimate event has a non-empty
+# .tool_name; absence indicates the call did not originate from a real tool
+# invocation. Without (b)/(c), downstream gates that early-exit on
+# `[ "$TOOL_NAME" = "Bash" ]` silently allow on zero-byte or "{}" inputs.
+#
+# Contract: if this function returns, parse succeeded AND TOOL_NAME is set.
+# On failure, calls emit_deny (caller-defined) with the supplied message and
+# exits 0 — caller never checks $?. Never call this with `|| true` or in
+# a pipeline. CALLER MUST define emit_deny before sourcing _lib.sh so this
+# helper can resolve it; the canonical pattern (define-emit_deny-then-source)
+# is enforced by test_hook_alignment.py.
+_lib_parse_tool_input_or_deny() {
+  local deny_msg="${1:-Blocked: could not parse tool-input JSON.}"
+  INPUT=$(cat)  # command substitution strips trailing newlines — safe for JSON payloads
+  if [ -z "$INPUT" ]; then
+    emit_deny "$deny_msg"
+    exit 0
+  fi
+  # Single jq call extracts both fields delimited by ASCII Unit Separator (0x1f)
+  # rather than newlines, preventing a tool_name value containing an embedded
+  # newline from corrupting COMMAND via head/tail line splitting. Unit Separator
+  # cannot appear in a valid Claude Code tool name or shell command.
+  # The .tool_input.command extraction additionally surfaces a structural-type
+  # error when .tool_input is non-object (e.g. "Cannot index string with string
+  # 'command'"), returning non-zero.
+  local jq_out
+  jq_out=$(printf '%s\n' "$INPUT" | _lib_jq -r '"\(.tool_name // "")\(.tool_input.command // "")"' 2>/dev/null)
+  local jq_exit=$?
+  if [ "$jq_exit" -ne 0 ]; then
+    emit_deny "$deny_msg"
+    exit 0
+  fi
+  TOOL_NAME="${jq_out%%$'\x1f'*}"
+  COMMAND="${jq_out#*$'\x1f'}"
+  # Embedded newline in TOOL_NAME means the payload violated the PreToolUse
+  # contract; deny rather than allow with a corrupted TOOL_NAME value.
+  if [ -z "$TOOL_NAME" ]; then
+    emit_deny "$deny_msg"
+    exit 0
+  fi
+  case "$TOOL_NAME" in
+    *$'\n'*) emit_deny "$deny_msg"; exit 0 ;;
+  esac
+}
+
 # Compute the marker repo-hash for an absolute repo-toplevel path.
 # Input must have no trailing newline -- printf '%s' omits one, so the SHA
 # covers exactly the bytes of $1.

--- a/claude/.claude/hooks/ask-review-permissions.sh
+++ b/claude/.claude/hooks/ask-review-permissions.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# hook-class: informational
 # Gate: ask before editing .claude/settings*.json.
 #
 # Why: settings.json edits that touch permissions.allow are security-sensitive

--- a/claude/.claude/hooks/block-gh-pr-merge.sh
+++ b/claude/.claude/hooks/block-gh-pr-merge.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# hook-class: gate
 # Gate: block every shape of `gh pr merge` issued by the AI agent.
 # Enforces the repo-root CLAUDE.md rule "AI agents: don't merge your own PRs":
 # CI passing is necessary but not sufficient — the engineer merges directly.
@@ -26,29 +27,27 @@ set -uo pipefail
 
 command -v jq >/dev/null 2>&1 || exit 0
 
-INPUT=$(cat)
-TOOL_NAME=$(printf '%s\n' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
-JQ_EXIT=$?
-
 emit_deny() {
   local reason="$1"
   local reason_json
   reason_json=$(printf '%s' "$reason" | jq -Rs .)
-  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' \
-    "$reason_json"
+  local payload
+  payload=$(printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}' "$reason_json")
+  printf '%s\n' "$payload"
 }
 
-if [ "$JQ_EXIT" -ne 0 ]; then
-  emit_deny "Blocked: could not parse tool-input JSON for gh-pr-merge gate."
+if ! . "$(dirname "$0")/_lib.sh" 2>/dev/null; then
+  emit_deny "Blocked by gh-pr-merge gate: could not source _lib.sh."
   exit 0
 fi
+
+_lib_parse_tool_input_or_deny "Blocked: could not parse tool-input JSON for gh-pr-merge gate."
 
 # Defense-in-depth: only act on Bash calls (settings.json already matches Bash).
 if [ "$TOOL_NAME" != "Bash" ]; then
   exit 0
 fi
 
-COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command | if type == "string" then . else empty end' 2>/dev/null)
 [ -z "$COMMAND" ] && exit 0
 
 # Word-boundary match: (^|[[:space:]]) before `gh`; non-word char or EOL after `merge`.

--- a/claude/.claude/hooks/capture-session-id.sh
+++ b/claude/.claude/hooks/capture-session-id.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# hook-class: informational
 # SessionStart hook: bootstrap a session_id ↔ claude-PID mapping at session
 # start so downstream skills running as Bash tool calls can learn their
 # own session_id.

--- a/claude/.claude/hooks/check-branch-divergence.sh
+++ b/claude/.claude/hooks/check-branch-divergence.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# hook-class: informational
 # SessionStart hook: surface feature-branch divergence from origin/<default>
 # to the resuming Claude session. Advisory-only; never blocks, never acts.
 #

--- a/claude/.claude/hooks/check-claude-md-length.sh
+++ b/claude/.claude/hooks/check-claude-md-length.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -uo pipefail
+# hook-class: gate
 # Gate: block git commit when a staged CLAUDE.md or AGENTS.md grows past its limit.
 #
 # Policy: deny when the staged file is over its limit AND longer than the
@@ -7,9 +7,10 @@ set -uo pipefail
 # file commit by commit without blocking the work, while still catching new
 # bloat.
 #
-# Fail posture: fail-open — tool absence (jq missing, not in a git repo) and
-# parse errors allow the commit through. This gate enforces a style rule, not
-# a security boundary.
+# Fail posture: fail-closed — parse errors deny the commit. This gate
+# enforces a style rule, not a security boundary, but consistent fail-closed
+# posture across all gate hooks prevents a whole class of silent-allow
+# regressions.
 #
 # Default limit is 200 lines, matching the Anthropic-documented threshold for
 # CLAUDE.md/AGENTS.md files (Claude Code — memory: "Longer files consume more
@@ -20,8 +21,28 @@ set -uo pipefail
 # The "if" field in settings.json is unreliable — the internal grep is the
 # actual gate. See require-code-review.sh for the same pattern and rationale.
 
-INPUT=$(cat)
-COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command // empty')
+set -uo pipefail
+
+emit_deny() {
+  local reason="$1"
+  local reason_json
+  reason_json=$(printf '%s' "$reason" | jq -Rs .)
+  local payload
+  payload=$(printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}' "$reason_json")
+  printf '%s\n' "$payload"
+}
+
+if ! . "$(dirname "$0")/_lib.sh" 2>/dev/null; then
+  emit_deny "Blocked by CLAUDE.md length gate: could not source _lib.sh."
+  exit 0
+fi
+
+_lib_parse_tool_input_or_deny "Blocked by CLAUDE.md length gate: could not parse tool-input JSON."
+
+# Only gate Bash tool calls.
+if [ "$TOOL_NAME" != "Bash" ]; then
+  exit 0
+fi
 
 # Only gate git commit commands.
 if ! printf '%s\n' "$COMMAND" | grep -qE '(^|&&?|;|\|\|?)\s*git\s+commit(\s|$)'; then
@@ -56,6 +77,5 @@ done < <(git diff --cached --name-only 2>/dev/null | grep -E '^(CLAUDE\.md|AGENT
 
 if [ "$FAIL" -eq 1 ]; then
   REASON=$(printf 'CLAUDE.md/AGENTS.md length gate: one or more files grew past the 200-line limit. Reduce to the limit or fewer lines before committing:\n%b' "$MESSAGES")
-  REASON_JSON=$(printf '%s' "$REASON" | jq -Rs .)
-  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' "$REASON_JSON"
+  emit_deny "$REASON"
 fi

--- a/claude/.claude/hooks/check-runner-bash-guard.sh
+++ b/claude/.claude/hooks/check-runner-bash-guard.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# hook-class: gate
 # PreToolUse(Bash) guard for the check-runner subagent.
 # Scope: wired via settings.json PreToolUse(Bash). The `.agent_type`
 # field in the hook payload scopes enforcement to calls originating
@@ -32,21 +33,21 @@ emit_deny() {
   local reason_json
   reason_json=$(printf '%s' "$reason" | jq -Rs .)
   printf 'check-runner-bash-guard: DENY: %s\n' "$reason" >&2
-  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}' \
-    "$reason_json"
+  local payload
+  payload=$(printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}' "$reason_json")
+  printf '%s\n' "$payload"
 }
 
-INPUT=$(cat)
+if ! . "$(dirname "$0")/_lib.sh" 2>/dev/null; then
+  emit_deny "check-runner-bash-guard: could not source _lib.sh — refusing to evaluate under degraded state."
+  exit 0
+fi
+
+_lib_parse_tool_input_or_deny "check-runner-bash-guard: could not parse hook payload JSON — refusing to evaluate under malformed input."
 
 # Defense in depth: only act on Bash tool calls regardless of how the
 # hook is wired in settings.json. A misconfigured matcher must not
 # cause the hook to read fields off the wrong payload shape.
-TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
-JQ_TOOL_EXIT=$?
-if [ "$JQ_TOOL_EXIT" -ne 0 ]; then
-  emit_deny "check-runner-bash-guard: could not parse hook payload JSON — refusing to evaluate under malformed input."
-  exit 0
-fi
 if [ "$TOOL_NAME" != "Bash" ]; then
   exit 0
 fi
@@ -58,18 +59,6 @@ fi
 # other subagents.
 AGENT_TYPE=$(printf '%s' "$INPUT" | jq -r '.agent_type // empty' 2>/dev/null)
 if [ "$AGENT_TYPE" != "check-runner" ]; then
-  exit 0
-fi
-
-if ! . "$(dirname "$0")/_lib.sh" 2>/dev/null; then
-  emit_deny "check-runner-bash-guard: could not source _lib.sh — refusing to evaluate under degraded state."
-  exit 0
-fi
-
-COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
-JQ_CMD_EXIT=$?
-if [ "$JQ_CMD_EXIT" -ne 0 ]; then
-  emit_deny "check-runner-bash-guard: could not parse tool-input JSON — refusing to evaluate under malformed input."
   exit 0
 fi
 

--- a/claude/.claude/hooks/check-skill-length.sh
+++ b/claude/.claude/hooks/check-skill-length.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# hook-class: gate
 # Gate: block git commit when a staged SKILL.md grows past its per-skill ceiling.
 #
 # Policy: deny when the staged file is over its limit AND longer than the
@@ -16,8 +17,28 @@
 # The "if" field in settings.json is unreliable — the internal grep is the
 # actual gate. See require-code-review.sh for the same pattern and rationale.
 
-INPUT=$(cat)
-COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command // empty')
+set -uo pipefail
+
+emit_deny() {
+  local reason="$1"
+  local reason_json
+  reason_json=$(printf '%s' "$reason" | jq -Rs .)
+  local payload
+  payload=$(printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}' "$reason_json")
+  printf '%s\n' "$payload"
+}
+
+if ! . "$(dirname "$0")/_lib.sh" 2>/dev/null; then
+  emit_deny "Blocked by skill length gate: could not source _lib.sh."
+  exit 0
+fi
+
+_lib_parse_tool_input_or_deny "Blocked by skill length gate: could not parse tool-input JSON."
+
+# Only gate Bash tool calls.
+if [ "$TOOL_NAME" != "Bash" ]; then
+  exit 0
+fi
 
 # Only gate git commit commands.
 if ! printf '%s\n' "$COMMAND" | grep -qE '(^|&&?|;|\|\|?)\s*git\s+commit(\s|$)'; then
@@ -54,6 +75,5 @@ done < <(git diff --cached --name-only | grep -E '(claude/.claude/skills/|plugin
 
 if [ "$FAIL" -eq 1 ]; then
   REASON=$(printf 'Skill length gate: one or more SKILL.md files grew past their per-skill limit. Reduce to the limit or fewer lines before committing:\n%b' "$MESSAGES")
-  REASON_JSON=$(printf '%s' "$REASON" | jq -Rs .)
-  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' "$REASON_JSON"
+  emit_deny "$REASON"
 fi

--- a/claude/.claude/hooks/cleanup-handoff-nudge-marker.sh
+++ b/claude/.claude/hooks/cleanup-handoff-nudge-marker.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# hook-class: informational
 # SessionEnd hook: remove the per-session handoff-nudge marker files written
 # by nudge-handoff-near-context-cap.sh when the session ends.
 #

--- a/claude/.claude/hooks/cleanup-session-id.sh
+++ b/claude/.claude/hooks/cleanup-session-id.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# hook-class: informational
 # SessionEnd hook: delete the session_id ↔ claude-PID lookup file that
 # capture-session-id.sh wrote for this session. It is the destructor
 # capture-session-id.sh never had — without it, ~/.claude/sessions/ gains

--- a/claude/.claude/hooks/deny-data-file-reads.sh
+++ b/claude/.claude/hooks/deny-data-file-reads.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# hook-class: gate
 # Gate: deny Claude's Read tool on data-shaped files before their content
 # enters the conversation context. A data dump (CSV export, database
 # backup, statistical dataset) read into context is PII/PHI exposure.
@@ -52,18 +53,17 @@ emit_deny() {
   local reason="$1"
   local reason_json
   reason_json=$(printf '%s' "$reason" | jq -Rs .)
-  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' \
-    "$reason_json"
+  local payload
+  payload=$(printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}' "$reason_json")
+  printf '%s\n' "$payload"
 }
 
-INPUT=$(cat)
-TOOL_NAME=$(printf '%s\n' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
-JQ_EXIT=$?
-
-if [ "$JQ_EXIT" -ne 0 ]; then
-  emit_deny "Blocked by data-file read gate: could not parse tool-input JSON. Refusing to evaluate the Read under malformed input."
+if ! . "$(dirname "$0")/_lib.sh" 2>/dev/null; then
+  emit_deny "Blocked by data-file read gate: could not source _lib.sh."
   exit 0
 fi
+
+_lib_parse_tool_input_or_deny "Blocked by data-file read gate: could not parse tool-input JSON. Refusing to evaluate the Read under malformed input."
 
 # Defense-in-depth: only act on Read calls. Edit/Write/MultiEdit also carry
 # a file_path field; settings.json matches Read, this re-checks it.

--- a/claude/.claude/hooks/deny-env-reads.sh
+++ b/claude/.claude/hooks/deny-env-reads.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# hook-class: gate
 # Gate: deny Claude's Read tool on .env* files that commonly hold secrets.
 # Allows the three conventional non-secret template suffixes:
 #   .env.example  .env.template  .env.sample
@@ -27,22 +28,21 @@
 
 set -uo pipefail
 
-INPUT=$(cat)
-TOOL_NAME=$(printf '%s\n' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
-JQ_EXIT=$?
-
 emit_deny() {
   local reason="$1"
   local reason_json
   reason_json=$(printf '%s' "$reason" | jq -Rs .)
-  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' \
-    "$reason_json"
+  local payload
+  payload=$(printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}' "$reason_json")
+  printf '%s\n' "$payload"
 }
 
-if [ "$JQ_EXIT" -ne 0 ]; then
-  emit_deny "Blocked: could not parse tool-input JSON for env-read gate."
+if ! . "$(dirname "$0")/_lib.sh" 2>/dev/null; then
+  emit_deny "Blocked by env-read gate: could not source _lib.sh."
   exit 0
 fi
+
+_lib_parse_tool_input_or_deny "Blocked: could not parse tool-input JSON for env-read gate."
 
 # Defense-in-depth: only act on Read calls (settings.json already matches Read).
 if [ "$TOOL_NAME" != "Read" ]; then

--- a/claude/.claude/hooks/deny-escaped-backticks-in-pr-body.sh
+++ b/claude/.claude/hooks/deny-escaped-backticks-in-pr-body.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# hook-class: gate
 # Gate: reject `gh pr create` and `gh pr edit` commands whose body
 # content (inline --body "..." or body-source file) contains literal
 # backslash-backtick sequences (\`). Those sequences appear when a
@@ -26,24 +27,21 @@
 
 set -uo pipefail
 
-INPUT=$(cat)
-COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
-JQ_EXIT=$?
-
 emit_deny() {
   local reason="$1"
   local reason_json
   reason_json=$(printf '%s' "$reason" | jq -Rs .)
-  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' \
-    "$reason_json"
+  local payload
+  payload=$(printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}' "$reason_json")
+  printf '%s\n' "$payload"
 }
 
-# Fail-closed on malformed input — if we can't parse stdin we can't
-# tell what's about to run, so deny rather than silently allow.
-if [ "$JQ_EXIT" -ne 0 ]; then
-  emit_deny "Blocked by backtick-escape gate: could not parse tool-input JSON. Refusing to evaluate PR body under malformed input."
+if ! . "$(dirname "$0")/_lib.sh" 2>/dev/null; then
+  emit_deny "Blocked by backtick-escape gate: could not source _lib.sh."
   exit 0
 fi
+
+_lib_parse_tool_input_or_deny "Blocked by backtick-escape gate: could not parse tool-input JSON. Refusing to evaluate PR body under malformed input."
 
 # Authoritative gate: only scan gh pr create / edit commands.
 IS_GH_PR=0

--- a/claude/.claude/hooks/deny-pii-in-commits.sh
+++ b/claude/.claude/hooks/deny-pii-in-commits.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# hook-class: gate
 # Gate: deny `git commit` when the commit's content — added lines of the
 # staged diff, the commit message, or a referenced commit-message file —
 # contains personally-identifying or protected health information (PII/PHI).
@@ -99,8 +100,9 @@ emit_deny() {
   local reason="$1"
   local reason_json
   reason_json=$(printf '%s' "$reason" | jq -Rs .)
-  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' \
-    "$reason_json"
+  local payload
+  payload=$(printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}' "$reason_json")
+  printf '%s\n' "$payload"
 }
 
 # emit_deny is defined before sourcing _lib.sh so a missing _lib.sh can
@@ -110,18 +112,7 @@ if ! . "$(dirname "$0")/_lib.sh" 2>/dev/null; then
   exit 0
 fi
 
-INPUT=$(cat)
-TOOL_NAME=$(printf '%s\n' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
-JQ_EXIT=$?
-
-# Fail-closed on unparseable input. jq parses the whole stdin document in
-# one pass: if INPUT is valid JSON every later field extraction succeeds,
-# and if it is malformed this first extraction already fails — so this
-# single check fully covers the malformed-JSON case.
-if [ "$JQ_EXIT" -ne 0 ]; then
-  emit_deny "Blocked by PII commit gate: could not parse tool-input JSON. Refusing to evaluate the commit under malformed input."
-  exit 0
-fi
+_lib_parse_tool_input_or_deny "Blocked by PII commit gate: could not parse tool-input JSON. Refusing to evaluate the commit under malformed input."
 
 # Defense-in-depth: only act on Bash calls (settings.json already matches Bash).
 if [ "$TOOL_NAME" != "Bash" ]; then
@@ -138,8 +129,6 @@ PII_PATTERNS_FILE="${HOME}/.claude/pii-patterns.md"
 if [ ! -f "$PII_PATTERNS_FILE" ] || [ ! -r "$PII_PATTERNS_FILE" ]; then
   exit 0
 fi
-
-COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
 
 # --- Detect `git commit`; decide whether `git diff HEAD` is also needed --
 # `-a`/`--all`, a `--` pathspec separator, or a bare pathspec argument all

--- a/claude/.claude/hooks/deny-private-project-refs.sh
+++ b/claude/.claude/hooks/deny-private-project-refs.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# hook-class: gate
 # Gate: reject `git commit`, `gh pr create`, `gh pr edit`, and mutating
 # `gh api` calls if their content (staged diff, commit message, PR
 # title/body, body-source file contents, gh-api JSON body, or
@@ -146,8 +147,9 @@ emit_deny() {
   local reason="$1"
   local reason_json
   reason_json=$(printf '%s' "$reason" | jq -Rs .)
-  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' \
-    "$reason_json"
+  local payload
+  payload=$(printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}' "$reason_json")
+  printf '%s\n' "$payload"
 }
 
 # emit_deny is defined before sourcing _lib.sh so a missing _lib.sh can
@@ -157,22 +159,7 @@ if ! . "$(dirname "$0")/_lib.sh" 2>/dev/null; then
   exit 0
 fi
 
-INPUT=$(cat)
-TOOL_NAME=$(printf '%s\n' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
-COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
-JQ_EXIT=$?
-
-# Fail-closed on malformed input. Matches the posture of
-# require-worktree-for-git-writes.sh: if we can't parse stdin, we can't
-# tell what's about to run, so deny rather than silently allow. JQ_EXIT
-# is captured from the .tool_input.command extraction deliberately: jq
-# parses the whole document, and that filter additionally surfaces a
-# type error when .tool_input is not an object — so a zero exit here
-# means both extractions ran against well-formed JSON.
-if [ "$JQ_EXIT" -ne 0 ]; then
-  emit_deny "Blocked by redaction gate: could not parse tool-input JSON. Refusing to evaluate redaction under malformed input."
-  exit 0
-fi
+_lib_parse_tool_input_or_deny "Blocked by redaction gate: could not parse tool-input JSON. Refusing to evaluate redaction under malformed input."
 
 # Defense-in-depth: only act on Bash calls. settings.json already matches
 # the Bash tool, but the hook does not rely on that alone (see repo

--- a/claude/.claude/hooks/enforce-marker-script-shape.sh
+++ b/claude/.claude/hooks/enforce-marker-script-shape.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# hook-class: gate
 # Gate: enforce strict invocation shape for ~/.claude/scripts/marker.sh.
 #
 # Fail posture: fail-closed — if jq cannot parse the input, deny.
@@ -17,15 +18,21 @@
 # those forms ungated.
 set -uo pipefail
 
-INPUT=$(cat)
-COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
-JQ_EXIT=$?
+emit_deny() {
+  local reason="$1"
+  local reason_json
+  reason_json=$(printf '%s' "$reason" | jq -Rs .)
+  local payload
+  payload=$(printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}' "$reason_json")
+  printf '%s\n' "$payload"
+}
 
-if [ "$JQ_EXIT" -ne 0 ]; then
-  REASON_JSON='"Blocked: could not parse tool-input JSON."'
-  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' "$REASON_JSON"
+if ! . "$(dirname "$0")/_lib.sh" 2>/dev/null; then
+  emit_deny "Blocked by marker-script-shape gate: could not source _lib.sh."
   exit 0
 fi
+
+_lib_parse_tool_input_or_deny "Blocked: could not parse tool-input JSON."
 
 # Strip leading/trailing whitespace — computed before the activation guards so
 # both the fast-reject and anchored-path check share one computation.
@@ -43,9 +50,7 @@ printf '%s' "$COMMAND" | grep -qF 'marker.sh' || exit 0
 # anchored regex does not match them.
 if printf '%s' "$TRIMMED" | grep -qE '(^|/)\.\.(/|$)'; then
   TRUNCATED=$(printf '%s' "$TRIMMED" | cut -c1-80)
-  REASON="marker.sh invocation denied (path traversal '..' detected). Command (truncated): $TRUNCATED"
-  REASON_JSON=$(printf '%s' "$REASON" | jq -Rs .)
-  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' "$REASON_JSON"
+  emit_deny "marker.sh invocation denied (path traversal '..' detected). Command (truncated): $TRUNCATED"
   exit 0
 fi
 
@@ -94,7 +99,7 @@ fi
 
 # Deny. Truncate to 80 chars to avoid echoing attacker-controlled bytes verbatim.
 TRUNCATED=$(printf '%s' "$TRIMMED" | cut -c1-80)
-REASON="marker.sh invocation denied. Command (truncated): $TRUNCATED
+emit_deny "marker.sh invocation denied. Command (truncated): $TRUNCATED
 
 Valid shapes:
   ~/.claude/scripts/marker.sh write code-review
@@ -114,5 +119,3 @@ Valid shapes:
 
 No chains (&&, ||, ;), redirects, or extra args. Env-var prefix, bash wrapper,
 and relative-path forms are not gated here — they are denied by permissions.allow."
-REASON_JSON=$(printf '%s' "$REASON" | jq -Rs .)
-printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' "$REASON_JSON"

--- a/claude/.claude/hooks/guard-settings-session-keys.sh
+++ b/claude/.claude/hooks/guard-settings-session-keys.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# hook-class: gate
 # PreToolUse hook: block git commit when claude/.claude/settings.json has
 # session-scoped keys (model, effortLevel, skipAutoPermissionPrompt) staged
 # relative to main.
@@ -29,15 +30,26 @@ git_capped() {
   timeout 5 git "$@"
 }
 
-INPUT=$(cat)
-TOOL_NAME=$(printf '%s\n' "$INPUT" | jq -r '.tool_name // empty')
+emit_deny() {
+  local reason="$1"
+  local reason_json
+  reason_json=$(printf '%s' "$reason" | jq -Rs .)
+  local payload
+  payload=$(printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}' "$reason_json")
+  printf '%s\n' "$payload"
+}
+
+if ! . "$(dirname "$0")/_lib.sh" 2>/dev/null; then
+  emit_deny "Blocked by settings session-keys gate: could not source _lib.sh."
+  exit 0
+fi
+
+_lib_parse_tool_input_or_deny "Blocked by settings session-keys gate: could not parse tool-input JSON."
 
 # Only gate Bash tool calls.
 if [ "$TOOL_NAME" != "Bash" ]; then
   exit 0
 fi
-
-COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command // empty')
 
 # Only gate commands that contain a git commit invocation.
 if ! printf '%s\n' "$COMMAND" | grep -qE '(^|&&?|;|\|\|?)\s*git\s+commit(\s|$)'; then
@@ -67,6 +79,9 @@ else
 fi
 
 # Extract the guarded keys from both versions using jq.
+# These 6 jq calls parse settings.json content, not hook input — they are
+# fail-open by design (a settings.json that can't be parsed doesn't block
+# the commit; the commit's own schema validation handles that).
 STAGED_MODEL=$(printf '%s\n' "$STAGED_CONTENT" | jq -r '.model // ""' 2>/dev/null)
 STAGED_EFFORT=$(printf '%s\n' "$STAGED_CONTENT" | jq -r '.effortLevel // ""' 2>/dev/null)
 STAGED_SKIP_AUTO_PROMPT=$(printf '%s\n' "$STAGED_CONTENT" | jq -r '.skipAutoPermissionPrompt // ""' 2>/dev/null)
@@ -89,6 +104,4 @@ if [ "$CHANGED" -eq 0 ]; then
   exit 0
 fi
 
-REASON="settings.json has session-scoped keys changed — commit these only if intentional. The staged settings.json differs from main on model, effortLevel, or skipAutoPermissionPrompt. These keys are typically ephemeral session state — model/effortLevel set via /config, and skipAutoPermissionPrompt written automatically by Claude Code — and should not be committed unless you are intentionally shipping a config change. Unstage the file (git restore --staged claude/.claude/settings.json) to allow the commit, or proceed only if this is a deliberate update."
-REASON_JSON=$(printf '%s' "$REASON" | jq -Rs .)
-printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' "$REASON_JSON"
+emit_deny "settings.json has session-scoped keys changed — commit these only if intentional. The staged settings.json differs from main on model, effortLevel, or skipAutoPermissionPrompt. These keys are typically ephemeral session state — model/effortLevel set via /config, and skipAutoPermissionPrompt written automatically by Claude Code — and should not be committed unless you are intentionally shipping a config change. Unstage the file (git restore --staged claude/.claude/settings.json) to allow the commit, or proceed only if this is a deliberate update."

--- a/claude/.claude/hooks/log-routing-read.sh
+++ b/claude/.claude/hooks/log-routing-read.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# hook-class: informational
 set -uo pipefail
 # PostToolUse: when plan-review is active and ROUTING.md is Read, write a
 # routing-read marker so require-routing-read.sh can verify consultation

--- a/claude/.claude/hooks/nudge-handoff-near-context-cap.sh
+++ b/claude/.claude/hooks/nudge-handoff-near-context-cap.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# hook-class: informational
 # UserPromptSubmit hook: injects a one-shot context-window nudge when the
 # estimated token count crosses 60% of the model's context window, prompting
 # the agent to suggest /handoff if the current task is not near completion.

--- a/claude/.claude/hooks/require-code-review.sh
+++ b/claude/.claude/hooks/require-code-review.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# hook-class: gate
 # Gate: require /code-review before git commit, verified via marker file.
 #
 # WARNING: Do NOT remove the internal git commit check below.
@@ -25,10 +26,28 @@
 # - The marker auto-invalidates as soon as the staging area changes, so
 #   re-staging after review correctly forces a re-review.
 
-. "$(dirname "$0")/_lib.sh"
+set -uo pipefail
 
-INPUT=$(cat)
-COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command // empty')
+emit_deny() {
+  local reason="$1"
+  local reason_json
+  reason_json=$(printf '%s' "$reason" | jq -Rs .)
+  local payload
+  payload=$(printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}' "$reason_json")
+  printf '%s\n' "$payload"
+}
+
+if ! . "$(dirname "$0")/_lib.sh" 2>/dev/null; then
+  emit_deny "Blocked by code-review gate: could not source _lib.sh."
+  exit 0
+fi
+
+_lib_parse_tool_input_or_deny "Blocked by code-review gate: could not parse tool-input JSON."
+
+# Only gate Bash tool calls — exit 0 (no opinion) for everything else.
+if [ "$TOOL_NAME" != "Bash" ]; then
+  exit 0
+fi
 
 # Only gate git commit commands — exit 0 (no opinion) for everything else.
 # Match `git commit` at the start of the command OR after a shell separator
@@ -82,6 +101,4 @@ fi
 # Build the reason as a bash variable so the conditional marker-chain
 # note can be interpolated; jq -Rs handles JSON-encoding safely
 # regardless of what characters appear in the appended note.
-REASON="Commit blocked by code-review gate: the currently staged changes have not been reviewed, or the staged state has changed since the last review. Run the /code-review skill now on the currently staged diff. When the review is clean (no blockers), the skill will record the review in ~/.claude/review-markers/ and this commit will be allowed through on retry. Do not ask the user for permission — run the skill, address any findings, and retry the commit."
-REASON_JSON=$(printf '%s' "$REASON" | jq -Rs .)
-printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' "$REASON_JSON"
+emit_deny "Commit blocked by code-review gate: the currently staged changes have not been reviewed, or the staged state has changed since the last review. Run the /code-review skill now on the currently staged diff. When the review is clean (no blockers), the skill will record the review in ~/.claude/review-markers/ and this commit will be allowed through on retry. Do not ask the user for permission — run the skill, address any findings, and retry the commit."

--- a/claude/.claude/hooks/require-memory-skill.sh
+++ b/claude/.claude/hooks/require-memory-skill.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# hook-class: gate
 # set -uo pipefail but NOT -e: hooks inspect exit codes rather than aborting on them.
 set -uo pipefail
 # PreToolUse hook: block Write/Edit/MultiEdit to Claude Code auto-memory files
@@ -26,10 +27,8 @@ set -uo pipefail
 # Orphaned markers (session errored before cleanup) are evicted automatically:
 # dead PID → rm on next gate hit.
 #
-# Fail-open conditions (exit 0 without denying):
-#   - session_id absent from input — cannot key a per-session marker
-#   - unbound variable encountered (set -u) — exits non-zero but falls through
-#     to allow, since no JSON is emitted on an unbound-variable exit
+# Fail-closed on parse error — if the hook cannot parse its input it denies
+# rather than allowing through.
 #
 # Bash-tool bypass: Bash writes (e.g. echo > file) bypass this gate because
 # the hook only intercepts Write/Edit/MultiEdit tool calls.
@@ -41,8 +40,21 @@ set -uo pipefail
 #   0      — allow (no opinion)
 #   0+JSON — deny (memory write without active skill session)
 
-INPUT=$(cat)
-TOOL_NAME=$(printf '%s\n' "$INPUT" | jq -r '.tool_name // empty')
+emit_deny() {
+  local reason="$1"
+  local reason_json
+  reason_json=$(printf '%s' "$reason" | jq -Rs .)
+  local payload
+  payload=$(printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}' "$reason_json")
+  printf '%s\n' "$payload"
+}
+
+if ! . "$(dirname "$0")/_lib.sh" 2>/dev/null; then
+  emit_deny "Blocked by memory-skill gate: could not source _lib.sh."
+  exit 0
+fi
+
+_lib_parse_tool_input_or_deny "Blocked by memory-skill gate: could not parse tool-input JSON."
 
 # Only gate Write, Edit, and MultiEdit tool calls.
 case "$TOOL_NAME" in
@@ -97,6 +109,4 @@ if [ -f "$ACTIVE_MARKER" ]; then
   rm -f "$ACTIVE_MARKER" 2>/dev/null
 fi
 
-REASON="Memory write blocked by ai-instruction-and-memory-files gate. You are writing to $FILE_PATH, which is part of Claude Code's auto-memory file system (MEMORY.md index or a new topic file). Invoke the ai-instruction-and-memory-files skill via the Skill tool first — it covers MEMORY.md index format, topic-file frontmatter, length budgets, and the type classification (user / feedback / project / reference). The skill's Step 0 activates a bypass marker so all memory writes in the session pass through after the skill is loaded."
-REASON_JSON=$(printf '%s' "$REASON" | jq -Rs .)
-printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' "$REASON_JSON"
+emit_deny "Memory write blocked by ai-instruction-and-memory-files gate. You are writing to $FILE_PATH, which is part of Claude Code's auto-memory file system (MEMORY.md index or a new topic file). Invoke the ai-instruction-and-memory-files skill via the Skill tool first — it covers MEMORY.md index format, topic-file frontmatter, length budgets, and the type classification (user / feedback / project / reference). The skill's Step 0 activates a bypass marker so all memory writes in the session pass through after the skill is loaded."

--- a/claude/.claude/hooks/require-plan-review.sh
+++ b/claude/.claude/hooks/require-plan-review.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# hook-class: gate
 # PreToolUse hook: block Write/Edit when an uncommitted or modified plan file
 # exists in .claude/plans/ without a current plan-review marker for this session.
 #
@@ -28,16 +29,33 @@
 #   0      — allow (no opinion)
 #   0+JSON — deny (plan exists but no review marker for this session)
 
-. "$(dirname "$0")/_lib.sh"
+set -uo pipefail
 
-INPUT=$(cat)
-TOOL_NAME=$(printf '%s\n' "$INPUT" | jq -r '.tool_name // empty')
+emit_deny() {
+  local reason="$1"
+  local reason_json
+  reason_json=$(printf '%s' "$reason" | jq -Rs .)
+  local payload
+  payload=$(printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}' "$reason_json")
+  printf '%s\n' "$payload"
+}
+
+if ! . "$(dirname "$0")/_lib.sh" 2>/dev/null; then
+  emit_deny "Blocked by plan-review gate: could not source _lib.sh."
+  exit 0
+fi
+
+_lib_parse_tool_input_or_deny "Blocked by plan-review gate: could not parse tool-input JSON."
 
 # Only gate Write, Edit, and MultiEdit tool calls.
 case "$TOOL_NAME" in
   Write|Edit|MultiEdit) ;;
   *) exit 0 ;;
 esac
+
+# Extract target path immediately after parsing — used both for the
+# repo-scope guard below and the deny gate.
+TARGET_PATH=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.file_path // empty')
 
 # Not in a git repo — can't check for plan files or key the marker.
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
@@ -94,7 +112,6 @@ fi
 # Scope the deny to writes inside this repo. Writes targeting user-home
 # directories (~/.claude/plans/), /tmp, or other repos are outside the gate's
 # intent — the gate guards this repo's code, not all files on disk.
-TARGET_PATH=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.file_path // empty')
 if [ -n "$TARGET_PATH" ]; then
   REAL_REPO=$(realpath -m "$REPO_ROOT")
   REAL_TARGET=$(realpath -m "$TARGET_PATH")
@@ -103,12 +120,10 @@ if [ -n "$TARGET_PATH" ]; then
   fi
 fi
 
-REASON="Write/Edit blocked by plan-review gate: an uncommitted or modified plan file exists in .claude/plans/ but no plan-review marker was found for this session. Committed, unmodified plan files are treated as historical and do not arm the gate. Next step depends on whether a plan covers this change:
+emit_deny "Write/Edit blocked by plan-review gate: an uncommitted or modified plan file exists in .claude/plans/ but no plan-review marker was found for this session. Committed, unmodified plan files are treated as historical and do not arm the gate. Next step depends on whether a plan covers this change:
 
   - If a plan covers this change → run /plan-review against it. The skill records the review in ~/.claude/plan-review-markers/ and this write will be allowed through on retry.
 
   - If no plan covers this change yet → run /plan-it first. It authors the plan and hands off to /plan-review at the end.
 
 The model judges which case applies from conversation context. Plans live wherever you put them — typically .claude/plans/, but also /tmp/<slug>.md, handoff docs, or external design doc URLs. The hook does not try to detect plan-change correlation."
-REASON_JSON=$(printf '%s' "$REASON" | jq -Rs .)
-printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' "$REASON_JSON"

--- a/claude/.claude/hooks/require-ready-for-review.sh
+++ b/claude/.claude/hooks/require-ready-for-review.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# hook-class: gate
 # Gate: require /ready-for-review to have run before pushing to a branch
 # with an open PR (or marking a draft PR ready). Verified via marker file.
 #
@@ -35,15 +36,28 @@
 # - gh pr view fails (network issue, gh not configured, etc.) — fail-open
 #   to keep the user unblocked; the skill's prose triggers still fire.
 
-. "$(dirname "$0")/_lib.sh"
+set -uo pipefail
 
-INPUT=$(cat)
-TOOL=$(printf '%s\n' "$INPUT" | jq -r '.tool_name // empty')
-if [ "$TOOL" != "Bash" ]; then
+emit_deny() {
+  local reason="$1"
+  local reason_json
+  reason_json=$(printf '%s' "$reason" | jq -Rs .)
+  local payload
+  payload=$(printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}' "$reason_json")
+  printf '%s\n' "$payload"
+}
+
+if ! . "$(dirname "$0")/_lib.sh" 2>/dev/null; then
+  emit_deny "Blocked by ready-for-review gate: could not source _lib.sh."
   exit 0
 fi
 
-COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command // empty')
+_lib_parse_tool_input_or_deny "Blocked by ready-for-review gate: could not parse tool-input JSON."
+
+if [ "$TOOL_NAME" != "Bash" ]; then
+  exit 0
+fi
+
 SESSION_ID=$(printf '%s\n' "$INPUT" | jq -r '.session_id // empty')
 CWD=$(printf '%s\n' "$INPUT" | jq -r '.cwd // empty')
 [ -z "$CWD" ] && CWD="$PWD"
@@ -162,9 +176,7 @@ fi
 # No active marker, no matching completion marker, gh pr view confirmed
 # the branch has an open PR — block.
 if $is_gh_pr_ready; then
-  REASON="PR ready-for-review marking blocked by ready-for-review gate: this PR has not been gated by /ready-for-review in THIS session, or HEAD has moved since the gate ran. Run the /ready-for-review skill now — it verifies tests/lint/typecheck, runs cumulative /code-review against the PR-vs-default-branch diff, syncs the PR body, and checks CI. When all halt-on-fail steps pass, the skill records completion in ~/.claude/ready-for-review-markers/ and this command will be allowed through. Do not ask the user for permission — run the skill, address any findings, and proceed. If HEAD moved because /code-review iteration produced fix commits this session, those commits are inside the approved scope of the gate; re-run and proceed without re-asking the user."
+  emit_deny "PR ready-for-review marking blocked by ready-for-review gate: this PR has not been gated by /ready-for-review in THIS session, or HEAD has moved since the gate ran. Run the /ready-for-review skill now — it verifies tests/lint/typecheck, runs cumulative /code-review against the PR-vs-default-branch diff, syncs the PR body, and checks CI. When all halt-on-fail steps pass, the skill records completion in ~/.claude/ready-for-review-markers/ and this command will be allowed through. Do not ask the user for permission — run the skill, address any findings, and proceed. If HEAD moved because /code-review iteration produced fix commits this session, those commits are inside the approved scope of the gate; re-run and proceed without re-asking the user."
 else
-  REASON="Push to a branch with an open PR blocked by ready-for-review gate: this branch's HEAD has not been gated by /ready-for-review in THIS session, or HEAD has moved since the gate ran. Run the /ready-for-review skill now — it verifies tests/lint/typecheck, runs cumulative /code-review against the PR-vs-default-branch diff, syncs the PR body, and checks CI. When all halt-on-fail steps pass, the skill records completion in ~/.claude/ready-for-review-markers/ and this push will be allowed through. Do not ask the user for permission — run the skill, address any findings, and retry the push. If HEAD moved because /code-review iteration produced fix commits this session, those commits are inside the approved scope of the gate; re-run and push without re-asking the user."
+  emit_deny "Push to a branch with an open PR blocked by ready-for-review gate: this branch's HEAD has not been gated by /ready-for-review in THIS session, or HEAD has moved since the gate ran. Run the /ready-for-review skill now — it verifies tests/lint/typecheck, runs cumulative /code-review against the PR-vs-default-branch diff, syncs the PR body, and checks CI. When all halt-on-fail steps pass, the skill records completion in ~/.claude/ready-for-review-markers/ and this push will be allowed through. Do not ask the user for permission — run the skill, address any findings, and retry the push. If HEAD moved because /code-review iteration produced fix commits this session, those commits are inside the approved scope of the gate; re-run and push without re-asking the user."
 fi
-REASON_JSON=$(printf '%s' "$REASON" | jq -Rs .)
-printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' "$REASON_JSON"

--- a/claude/.claude/hooks/require-respond-pr.sh
+++ b/claude/.claude/hooks/require-respond-pr.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# hook-class: gate
 # Gate: require /respond-pr when fetching or posting PR comments.
 #
 # Why: Claude habitually fetches only inline file comments
@@ -23,15 +24,28 @@
 # a comment in place; gating it forces any edit to flow through
 # /respond-pr's verified-author guidance.
 
-INPUT=$(cat)
-TOOL=$(printf '%s\n' "$INPUT" | jq -r '.tool_name // empty')
+set -uo pipefail
 
-# Only gate Bash tool use
-if [ "$TOOL" != "Bash" ]; then
+emit_deny() {
+  local reason="$1"
+  local reason_json
+  reason_json=$(printf '%s' "$reason" | jq -Rs .)
+  local payload
+  payload=$(printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}' "$reason_json")
+  printf '%s\n' "$payload"
+}
+
+if ! . "$(dirname "$0")/_lib.sh" 2>/dev/null; then
+  emit_deny "Blocked by respond-pr gate: could not source _lib.sh."
   exit 0
 fi
 
-COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command // empty')
+_lib_parse_tool_input_or_deny "Blocked by respond-pr gate: could not parse tool-input JSON."
+
+# Only gate Bash tool use
+if [ "$TOOL_NAME" != "Bash" ]; then
+  exit 0
+fi
 
 # Bypass: fresh marker for THIS session's session_id means we're inside the
 # skill and should let its own gh commands through. Empty session_id (older
@@ -92,4 +106,4 @@ if [ -n "$COMMAND_REPO" ]; then
   fi
 fi
 
-echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"PR comment access blocked by respond-pr gate. Run the /respond-pr skill instead — it fetches inline file comments, top-level review bodies, AND issue-level comments (Claude habitually fetches only the first and misses real feedback), and it enforces the [Claude Code] attribution prefix on replies so comments posted through the GitHub token are clearly labeled as AI-generated. Do not ask the user for permission — run /respond-pr and let it handle this operation."}}'
+emit_deny "PR comment access blocked by respond-pr gate. Run the /respond-pr skill instead — it fetches inline file comments, top-level review bodies, AND issue-level comments (Claude habitually fetches only the first and misses real feedback), and it enforces the [Claude Code] attribution prefix on replies so comments posted through the GitHub token are clearly labeled as AI-generated. Do not ask the user for permission — run /respond-pr and let it handle this operation."

--- a/claude/.claude/hooks/require-routing-read.sh
+++ b/claude/.claude/hooks/require-routing-read.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# hook-class: gate
 set -uo pipefail
 # PreToolUse: during an active plan-review session, require that ROUTING.md
 # was Read (tracked by log-routing-read.sh) before any Agent spawn.
@@ -7,8 +8,22 @@ set -uo pipefail
 # This hook deliberately does NOT cover Bash matchers — sub-agent spawning is
 # via the dedicated Agent tool, not shell.
 
-INPUT=$(cat)
-TOOL_NAME=$(printf '%s\n' "$INPUT" | jq -r '.tool_name // empty')
+emit_deny() {
+  local reason="$1"
+  local reason_json
+  reason_json=$(printf '%s' "$reason" | jq -Rs .)
+  local payload
+  payload=$(printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}' "$reason_json")
+  printf '%s\n' "$payload"
+}
+
+if ! . "$(dirname "$0")/_lib.sh" 2>/dev/null; then
+  emit_deny "Blocked by routing-read gate: could not source _lib.sh."
+  exit 0
+fi
+
+_lib_parse_tool_input_or_deny "Blocked by routing-read gate: could not parse tool-input JSON."
+
 [ "$TOOL_NAME" = "Agent" ] || exit 0
 
 SESSION_ID=$(printf '%s\n' "$INPUT" | jq -r '.session_id // empty')
@@ -24,6 +39,4 @@ if [ -f "$ROUTING_MARKER" ] && [ -n "$(find "$ROUTING_MARKER" -mmin -60 2>/dev/n
     exit 0
 fi
 
-REASON="Agent spawn blocked by plan-review routing gate: Read ~/.claude/skills/plan-review/ROUTING.md before spawning any specialist agent. All spawn criteria (always-spawn rules, item ownership, reconciliation logic) live exclusively in ROUTING.md."
-REASON_JSON=$(printf '%s' "$REASON" | jq -Rs .)
-printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' "$REASON_JSON"
+emit_deny "Agent spawn blocked by plan-review routing gate: Read ~/.claude/skills/plan-review/ROUTING.md before spawning any specialist agent. All spawn criteria (always-spawn rules, item ownership, reconciliation logic) live exclusively in ROUTING.md."

--- a/claude/.claude/hooks/require-stow-reminder.sh
+++ b/claude/.claude/hooks/require-stow-reminder.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# hook-class: gate
 # Gate: when a PR being opened/edited against claude-config introduces a
 # new top-level entry under `claude/.claude/`, require the PR body (or a
 # referenced body-source file, or a referenced commit message via
@@ -51,25 +52,24 @@
 
 set -uo pipefail
 
-INPUT=$(cat)
-COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
-JQ_EXIT=$?
-CWD=$(printf '%s\n' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)
-[ -z "$CWD" ] && CWD="$PWD"
-
 emit_deny() {
   local reason="$1"
   local reason_json
   reason_json=$(printf '%s' "$reason" | jq -Rs .)
-  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' \
-    "$reason_json"
+  local payload
+  payload=$(printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}' "$reason_json")
+  printf '%s\n' "$payload"
 }
 
-# Fail-closed on malformed input. Same posture as the other gates.
-if [ "$JQ_EXIT" -ne 0 ]; then
-  emit_deny "Blocked by stow-reminder gate: could not parse tool-input JSON. Refusing to evaluate under malformed input."
+if ! . "$(dirname "$0")/_lib.sh" 2>/dev/null; then
+  emit_deny "Blocked by stow-reminder gate: could not source _lib.sh."
   exit 0
 fi
+
+_lib_parse_tool_input_or_deny "Blocked by stow-reminder gate: could not parse tool-input JSON. Refusing to evaluate under malformed input."
+
+CWD=$(printf '%s\n' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)
+[ -z "$CWD" ] && CWD="$PWD"
 
 # Internal filter (defense-in-depth against settings.json `if` drift).
 # Only fire on `gh pr create` or `gh pr edit` invocations.

--- a/claude/.claude/hooks/require-worktree-for-file-writes.sh
+++ b/claude/.claude/hooks/require-worktree-for-file-writes.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# hook-class: gate
 # Gate: block Edit, Write, and MultiEdit to files in the main working tree of
 # a repo that has opted into worktree discipline (.claude/worktree-required
 # committed at the repo root). Companion to require-worktree-for-git-writes.sh,
@@ -28,24 +29,21 @@
 # env vars which git itself reads and which a committed config can pre-set.
 unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
-INPUT=$(cat)
-
 emit_deny() {
   local reason="$1"
   local reason_json
   reason_json=$(printf '%s' "$reason" | jq -Rs .)
-  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}' \
-    "$reason_json"
+  local payload
+  payload=$(printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}' "$reason_json")
+  printf '%s\n' "$payload"
 }
 
-# Fail-closed on malformed input: capture jq's exit code (not cat's) to detect
-# a broken jq binary or non-JSON harness output.
-TOOL_NAME=$(printf '%s\n' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
-JQ_EXIT=$?
-if [ "$JQ_EXIT" -ne 0 ]; then
-  emit_deny "Blocked by worktree-enforcement hook (file-writes): could not parse tool-input JSON. Refusing to evaluate worktree discipline under malformed input."
+if ! . "$(dirname "$0")/_lib.sh" 2>/dev/null; then
+  emit_deny "Blocked by worktree-enforcement hook (file-writes): could not source _lib.sh."
   exit 0
 fi
+
+_lib_parse_tool_input_or_deny "Blocked by worktree-enforcement hook (file-writes): could not parse tool-input JSON. Refusing to evaluate worktree discipline under malformed input."
 
 FILE_PATH=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
 

--- a/claude/.claude/hooks/require-worktree-for-git-writes.sh
+++ b/claude/.claude/hooks/require-worktree-for-git-writes.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# hook-class: gate
 # Gate: require git write operations to happen inside a linked worktree,
 # not the main working tree. Opt-in per-repo via a committed
 # .claude/worktree-required sentinel file at the repo root.
@@ -28,8 +29,9 @@ emit_deny() {
   local reason="$1"
   local reason_json
   reason_json=$(printf '%s' "$reason" | jq -Rs .)
-  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}' \
-    "$reason_json"
+  local payload
+  payload=$(printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}' "$reason_json")
+  printf '%s\n' "$payload"
 }
 
 if ! . "$(dirname "$0")/_lib.sh" 2>/dev/null; then
@@ -37,13 +39,12 @@ if ! . "$(dirname "$0")/_lib.sh" 2>/dev/null; then
   exit 0
 fi
 
+_lib_parse_tool_input_or_deny "Blocked by worktree-enforcement hook: could not parse tool-input JSON. Refusing to evaluate git discipline under malformed input."
+
 # Defensive: prevent GIT_DIR / GIT_WORK_TREE env overrides from making the
 # main tree impersonate a linked worktree via rev-parse output.
 unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
-INPUT=$(cat)
-COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
-JQ_EXIT=$?
 CWD=$(printf '%s\n' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)
 [ -z "$CWD" ] && CWD="$PWD"
 
@@ -115,13 +116,6 @@ git_C_note_if_present() {
     printf '%s' " If you used 'git -C <path>' expecting the -C path to be treated as the working tree: this hook reads cwd from Claude Code's session-persisted bash state (set by prior Bash calls), not from the -C path, because -C only retargets git's own working directory and doesn't change the session cwd. Anchor cwd by running 'cd /path/to/worktree' as its own Bash call first, then retry the git op in a follow-up call."
   fi
 }
-
-# Fail-closed on malformed input: if jq couldn't parse the stdin JSON, we
-# can't tell what Claude is about to run, so deny rather than silently allow.
-if [ "$JQ_EXIT" -ne 0 ]; then
-  emit_deny "Blocked by worktree-enforcement hook: could not parse tool-input JSON. Refusing to evaluate git discipline under malformed input."
-  exit 0
-fi
 
 # Fast-path: commands that don't mention `git` as a word are not our
 # concern. A plain `*git*` substring check false-positives on `.github`,

--- a/claude/.claude/hooks/session-marker-dashboard.sh
+++ b/claude/.claude/hooks/session-marker-dashboard.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# hook-class: informational
 # SessionStart hook: surface active gate-bypass marker state to the resuming
 # Claude session.
 #

--- a/claude/.claude/hooks/tests/test_block_gh_pr_merge.py
+++ b/claude/.claude/hooks/tests/test_block_gh_pr_merge.py
@@ -156,10 +156,10 @@ class TestBlockGhPrMerge:
     # Allow — structural edge cases (null-safety of jq extraction)       #
     # ------------------------------------------------------------------ #
 
-    def test_empty_json_object_allowed(self):
-        # {} has no tool_name → TOOL_NAME is empty → != "Bash" → exit 0 (allow)
+    def test_empty_json_object_denied(self):
+        # {} has no tool_name → _lib_parse_tool_input_or_deny denies on empty TOOL_NAME
         payload = {}
-        assert run_hook(BLOCK_GH_PR_MERGE_HOOK, payload) == "allow"
+        assert run_hook(BLOCK_GH_PR_MERGE_HOOK, payload) == "deny"
 
     def test_bash_tool_missing_command_allowed(self):
         # tool_name is Bash but tool_input.command absent → COMMAND empty → exit 0 (allow)

--- a/claude/.claude/hooks/tests/test_hook_alignment.py
+++ b/claude/.claude/hooks/tests/test_hook_alignment.py
@@ -122,6 +122,45 @@ class TestHookClassHeader:
             f"but declared '{value}'"
         )
 
+    def test_emit_deny_defined_before_lib_source(self, hook: Path) -> None:
+        """Gate hooks must define emit_deny before sourcing _lib.sh.
+
+        _lib_parse_tool_input_or_deny calls emit_deny at source time if parse
+        fails. If emit_deny is not yet defined when _lib.sh is sourced, all
+        three deny paths silently no-op (bash 'command not found' to stderr,
+        exit 0 without deny JSON). Static ordering check closes this gap.
+        """
+        if _hook_class(hook) != "gate":
+            pytest.skip("not a gate hook")
+        lines = hook.read_text().splitlines()
+        emit_deny_line = next(
+            (
+                i for i, ln in enumerate(lines)
+                if re.search(r"emit_deny\s*\(\s*\)", ln) and not ln.strip().startswith("#")
+            ),
+            None,
+        )
+        lib_source_line = next(
+            (
+                i for i, ln in enumerate(lines)
+                if re.search(r'[.]\s+.*_lib\.sh', ln) and not ln.strip().startswith("#")
+            ),
+            None,
+        )
+        assert emit_deny_line is not None, (
+            f"{hook.name}: emit_deny() definition not found — "
+            "gate hooks must define emit_deny before sourcing _lib.sh"
+        )
+        assert lib_source_line is not None, (
+            f"{hook.name}: _lib.sh source line not found — "
+            "gate hooks must source _lib.sh via '. \"$(dirname \"$0\")/_lib.sh\"'"
+        )
+        assert emit_deny_line < lib_source_line, (
+            f"{hook.name}: emit_deny() defined at line {emit_deny_line + 1} but "
+            f"_lib.sh sourced at line {lib_source_line + 1} — "
+            "emit_deny must be defined BEFORE sourcing _lib.sh"
+        )
+
 
 # ------------------------------------------------------------------ #
 # Layer 2 — Behavior checks                                          #

--- a/claude/.claude/hooks/tests/test_hook_alignment.py
+++ b/claude/.claude/hooks/tests/test_hook_alignment.py
@@ -1,0 +1,226 @@
+"""Two-layer hook alignment test suite.
+
+Layer 1 — Static checks: every .sh hook in claude/.claude/hooks/ and
+plugins/*/hooks/ (excluding _lib.sh siblings) must declare a
+`# hook-class: <value>` header on line 2 with a valid value, and hooks
+matching gate-naming prefixes or the EXPLICIT_GATES set must declare
+`# hook-class: gate`.
+
+Layer 2 — Behavior checks: every gate-class hook must deny on malformed
+input, empty stdin, non-object `.tool_input`, and missing `_lib.sh`; and
+every deny envelope it emits must match the expected schema shape.
+"""
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# ------------------------------------------------------------------ #
+# Paths                                                               #
+# ------------------------------------------------------------------ #
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_MAIN_HOOKS_DIR = _REPO_ROOT / "claude" / ".claude" / "hooks"
+_PLUGIN_HOOKS_DIRS = list((_REPO_ROOT / "plugins").glob("*/hooks"))
+
+
+def _all_hook_files() -> list[Path]:
+    """Return every .sh hook across claude/.claude/hooks/ and plugins/*/hooks/,
+    excluding _lib.sh files."""
+    hooks: list[Path] = []
+    for sh in sorted(_MAIN_HOOKS_DIR.glob("*.sh")):
+        if sh.name != "_lib.sh":
+            hooks.append(sh)
+    for hooks_dir in _PLUGIN_HOOKS_DIRS:
+        for sh in sorted(hooks_dir.glob("*.sh")):
+            if sh.name != "_lib.sh":
+                hooks.append(sh)
+    return hooks
+
+
+def _hook_class(hook: Path) -> str | None:
+    """Return the hook-class value from line 2, or None if absent."""
+    lines = hook.read_text().splitlines()
+    # Line 2 is index 1. Search first 5 lines to tolerate blank shebang lines.
+    for line in lines[1:6]:
+        m = re.match(r"#\s*hook-class:\s*(\S+)", line)
+        if m:
+            return m.group(1)
+    return None
+
+
+# ------------------------------------------------------------------ #
+# Gate-classification rules                                           #
+# ------------------------------------------------------------------ #
+
+# Filename-prefix patterns that mandate hook-class: gate.
+_GATE_PREFIX_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"^deny-.*\.sh$"),
+    re.compile(r"^require-.*\.sh$"),
+    re.compile(r"^enforce-.*\.sh$"),
+    re.compile(r"^guard-.*\.sh$"),
+    re.compile(r"^block-.*\.sh$"),
+    re.compile(r"^check-.*-guard\.sh$"),
+]
+
+# Hooks that are gates by behavior but don't match the prefix patterns.
+_EXPLICIT_GATES: frozenset[str] = frozenset(
+    {
+        "check-claude-md-length.sh",
+        "check-skill-length.sh",
+    }
+)
+
+ALL_HOOKS = _all_hook_files()
+GATE_HOOKS = [h for h in ALL_HOOKS if _hook_class(h) == "gate"]
+
+
+def _is_gate_by_naming(hook: Path) -> bool:
+    name = hook.name
+    if name in _EXPLICIT_GATES:
+        return True
+    return any(p.match(name) for p in _GATE_PREFIX_PATTERNS)
+
+
+# ------------------------------------------------------------------ #
+# Layer 1 — Static checks                                            #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.parametrize("hook", ALL_HOOKS, ids=[h.name for h in ALL_HOOKS])
+class TestHookClassHeader:
+    def test_hook_class_header_present(self, hook: Path) -> None:
+        """Every hook must declare # hook-class: <value>."""
+        value = _hook_class(hook)
+        assert value is not None, (
+            f"add `# hook-class: gate` or `# hook-class: informational` "
+            f"header to {hook.name}"
+        )
+
+    def test_hook_class_value_valid(self, hook: Path) -> None:
+        """hook-class value must be 'gate' or 'informational'."""
+        value = _hook_class(hook)
+        if value is None:
+            pytest.skip("header absent — tested by test_hook_class_header_present")
+        assert value in ("gate", "informational"), (
+            f"{hook.name}: expected one of: gate, informational; got '{value}'"
+        )
+
+    def test_gate_naming_convention_enforced(self, hook: Path) -> None:
+        """Hooks matching gate-naming patterns must declare hook-class: gate."""
+        if not _is_gate_by_naming(hook):
+            pytest.skip("filename does not match gate-naming patterns")
+        value = _hook_class(hook)
+        assert value == "gate", (
+            f"{hook.name} matches gate convention (prefix or explicit-gates set) "
+            f"but declared '{value}'"
+        )
+
+
+# ------------------------------------------------------------------ #
+# Layer 2 — Behavior checks                                          #
+# ------------------------------------------------------------------ #
+
+
+def _run_hook_raw(hook: Path, stdin_text: str, cwd: Path | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [str(hook)],
+        input=stdin_text,
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=cwd,
+    )
+
+
+def _assert_deny_schema(result: subprocess.CompletedProcess, hook_name: str, context: str) -> None:
+    """Assert stdout is valid JSON with the expected deny schema."""
+    stdout = result.stdout.strip()
+    assert stdout, (
+        f"{hook_name} [{context}]: hook must emit deny JSON on stdout, not silent exit"
+    )
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        pytest.fail(f"{hook_name} [{context}]: stdout is not valid JSON: {exc!r}\n  stdout={stdout!r}")
+    hso = payload.get("hookSpecificOutput", {})
+    assert hso.get("hookEventName") == "PreToolUse", (
+        f"{hook_name} [{context}]: hookEventName must be 'PreToolUse'"
+    )
+    assert hso.get("permissionDecision") == "deny", (
+        f"{hook_name} [{context}]: permissionDecision must be 'deny'"
+    )
+    reason = hso.get("permissionDecisionReason", "")
+    assert isinstance(reason, str) and reason, (
+        f"{hook_name} [{context}]: permissionDecisionReason must be a non-empty string"
+    )
+
+
+@pytest.mark.parametrize("hook", GATE_HOOKS, ids=[h.name for h in GATE_HOOKS])
+class TestGateHookBehavior:
+    def test_malformed_input_denied(self, hook: Path) -> None:
+        """Gate hook must deny on malformed JSON input (not silent exit)."""
+        result = _run_hook_raw(hook, "not json")
+        assert result.returncode == 0, f"{hook.name}: exit code must be 0, got {result.returncode}"
+        _assert_deny_schema(result, hook.name, "malformed-input")
+
+    def test_empty_stdin_denied(self, hook: Path) -> None:
+        """Gate hook must deny on empty stdin (CISO S1.a)."""
+        result = _run_hook_raw(hook, "")
+        assert result.returncode == 0, f"{hook.name}: exit code must be 0, got {result.returncode}"
+        _assert_deny_schema(result, hook.name, "empty-stdin")
+
+    def test_non_object_tool_input_denied(self, hook: Path) -> None:
+        """Gate hook must deny when .tool_input is a string, not an object.
+
+        This catches the structural-type error path in _lib_parse_tool_input_or_deny:
+        jq '.tool_input.command // empty' against {"tool_input":"a string"} raises
+        'Cannot index string with string "command"' and returns non-zero.
+        """
+        result = _run_hook_raw(hook, '{"tool_name":"Bash","tool_input":"a string"}')
+        assert result.returncode == 0, f"{hook.name}: exit code must be 0, got {result.returncode}"
+        _assert_deny_schema(result, hook.name, "non-object-tool-input")
+
+    def test_missing_lib_sh_denied(self, hook: Path) -> None:
+        """Gate hook must deny when _lib.sh is absent (rollback test).
+
+        The hook is COPIED (not symlinked) into a temp directory so that
+        dirname($0) resolves to the temp dir — a symlink would resolve to the
+        original location where _lib.sh IS present, defeating the test.
+
+        Convention relied on: every gate hook must define emit_deny and attempt
+        to source _lib.sh BEFORE any other logic that could emit a deny for a
+        different reason. The test cannot structurally distinguish "denied due to
+        missing _lib.sh" from "denied for another reason" — it only verifies that
+        a deny is emitted and that exit code is 0. If a future hook violates the
+        define-emit_deny → source-lib → gate-logic ordering, this test may give
+        a false pass on the missing-lib path while actually testing something else.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_hook = Path(tmpdir) / hook.name
+            shutil.copy2(hook, tmp_hook)
+            tmp_hook.chmod(0o755)
+            # Run with a valid PreToolUse payload so the deny must come from
+            # the missing _lib.sh path, not an unrelated guard.
+            payload = '{"tool_name":"Bash","tool_input":{"command":"echo hello"}}'
+            result = _run_hook_raw(tmp_hook, payload, cwd=Path(tmpdir))
+        assert result.returncode == 0, f"{hook.name}: exit code must be 0, got {result.returncode}"
+        _assert_deny_schema(result, hook.name, "missing-lib-sh")
+
+    def test_deny_envelope_schema_shape(self, hook: Path) -> None:
+        """Every deny envelope must match the required JSON schema shape.
+
+        Redundant with the schema assertions in the other tests, but kept as
+        a dedicated parametrized case so schema-drift regressions produce a
+        clear signal naming the exact hook and field.
+        """
+        result = _run_hook_raw(hook, "not json")
+        if not result.stdout.strip():
+            pytest.skip("hook did not emit output on malformed input — tested by test_malformed_input_denied")
+        _assert_deny_schema(result, hook.name, "schema-shape")

--- a/claude/.claude/hooks/tests/test_install_sh_timeout_warning.py
+++ b/claude/.claude/hooks/tests/test_install_sh_timeout_warning.py
@@ -1,0 +1,78 @@
+"""Tests for the `timeout` availability warning in install.sh."""
+from __future__ import annotations
+
+import contextlib
+import shutil
+import subprocess
+from pathlib import Path
+
+_INSTALL_SH = Path(__file__).resolve().parents[4] / "install.sh"
+_BASH = shutil.which("bash") or "/bin/bash"
+
+
+class TestInstallShTimeoutWarning:
+    def test_warning_emitted_to_stderr_when_timeout_absent(self, tmp_path: Path) -> None:
+        """install.sh emits a timeout-not-found warning to stderr when `timeout`
+        is not in PATH, exit code is 0, and stdout does not contain the warning.
+
+        Strategy: extract only the timeout-availability check block from install.sh
+        and run it in a sandboxed environment where `timeout` is absent. This avoids
+        the complexity of stubbing out all of install.sh's runtime dependencies (stow,
+        claude, jq, etc.) just to reach the warning code.
+
+        The extracted check block is:
+            if ! command -v timeout >/dev/null 2>&1; then
+              printf '[install] warning: ...' >&2
+              ...
+            fi
+        """
+        # Build a PATH with standard POSIX tools but no timeout binary.
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+
+        # Symlink all system binaries from /usr/bin and /bin EXCEPT timeout.
+        for system_dir in [Path("/usr/bin"), Path("/bin")]:
+            if not system_dir.is_dir():
+                continue
+            for cmd_path in system_dir.iterdir():
+                if cmd_path.name == "timeout":
+                    continue  # Deliberately omit timeout — that is what we test.
+                dest = bin_dir / cmd_path.name
+                if not dest.exists():
+                    with contextlib.suppress(OSError, PermissionError):
+                        dest.symlink_to(cmd_path)
+
+        # Extract the timeout warning block from install.sh and run it directly.
+        # This is more robust than running install.sh in full (which requires
+        # stow, claude, gh, etc. to be present or stubbed).
+        install_text = _INSTALL_SH.read_text()
+        # Find the timeout warning block.
+        warning_marker = "if ! command -v timeout"
+        start = install_text.find(warning_marker)
+        assert start != -1, f"timeout warning block not found in {_INSTALL_SH}"
+        # Extract to the matching fi.
+        block_start = start
+        fi_pos = install_text.find("\nfi\n", block_start)
+        assert fi_pos != -1, "closing 'fi' for timeout block not found"
+        timeout_block = install_text[block_start:fi_pos + 4]  # include '\nfi\n'
+
+        result = subprocess.run(
+            [_BASH, "-c", timeout_block],
+            capture_output=True,
+            text=True,
+            check=False,
+            env={"PATH": str(bin_dir)},
+        )
+        # Warning goes to stderr, not stdout.
+        assert "timeout" in result.stderr, (
+            f"Expected timeout warning on stderr; got stderr={result.stderr!r}\n"
+            f"stdout={result.stdout!r}\nreturncode={result.returncode}"
+        )
+        assert "timeout" not in result.stdout, (
+            f"Warning must go to stderr only; found 'timeout' in stdout={result.stdout!r}"
+        )
+        # The timeout block must exit 0 — it is a warning, not a hard failure.
+        assert result.returncode == 0, (
+            f"Timeout warning block must exit 0; got {result.returncode}\n"
+            f"stderr={result.stderr!r}"
+        )

--- a/claude/.claude/hooks/tests/test_lib.py
+++ b/claude/.claude/hooks/tests/test_lib.py
@@ -202,6 +202,14 @@ def test_missing_emit_deny_loud_fail() -> None:
         "Calling _lib_parse_tool_input_or_deny without emit_deny must not "
         "silently allow — SHOULD_NOT_REACH must never appear in stdout"
     )
+    # An undefined emit_deny causes bash to write "command not found" to stderr.
+    # Verifies loudness: the failure is observable (even without a deny JSON),
+    # so a hook author who forgets to define emit_deny gets an immediate signal.
+    assert result.stderr, (
+        "Calling _lib_parse_tool_input_or_deny without emit_deny must produce "
+        "a bash 'command not found' error on stderr — per the CALLER MUST define "
+        "emit_deny contract in _lib.sh"
+    )
 
 
 def test_null_literal_input_denied() -> None:
@@ -222,11 +230,10 @@ def test_newline_injection_in_tool_name_denied() -> None:
     """tool_name with embedded newline → DENY (path d: invalid TOOL_NAME shape).
 
     A JSON string value with an escaped newline (e.g. "Bash\\ninjected") is
-    decoded by jq -r into a real newline. The helper uses a unit-separator
-    delimiter to split TOOL_NAME from COMMAND, so TOOL_NAME receives
-    "Bash\\ninjected" rather than "Bash". The post-extraction newline check
-    detects the embedded newline and denies rather than allowing with a
-    corrupted TOOL_NAME or COMMAND.
+    decoded by jq -r into a real newline. The 0x1f delimiter split correctly
+    extracts TOOL_NAME = "Bash\\ninjected" (the full multi-line string) and
+    COMMAND = "echo safe". The deny fires from the post-extraction
+    `case "$TOOL_NAME" in *$'\\n'*)` check (path d), not from the split itself.
     """
     result = _run_harness('{"tool_name":"Bash\\ninjected","tool_input":{"command":"echo safe"}}')
     assert result.returncode == 0

--- a/claude/.claude/hooks/tests/test_lib.py
+++ b/claude/.claude/hooks/tests/test_lib.py
@@ -1,0 +1,233 @@
+"""Unit tests for _lib_parse_tool_input_or_deny and _lib_jq in _lib.sh.
+
+Each test drives the helpers via a throwaway shell harness that defines
+emit_deny before sourcing _lib.sh (the canonical caller pattern), then calls
+_lib_parse_tool_input_or_deny and reports either DENY:<msg> or OK:<tool>:<cmd>.
+"""
+from __future__ import annotations
+
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+# Path to _lib.sh: test lives in hooks/tests/, _lib.sh is in hooks/.
+_LIB_SH = Path(__file__).resolve().parents[1] / "_lib.sh"
+
+# Shell harness: define emit_deny BEFORE sourcing _lib.sh (canonical pattern),
+# call the helper, then print OK:<TOOL_NAME>:<COMMAND> on success.
+# {lib} is substituted by the test with the absolute path to _lib.sh.
+_HARNESS_TEMPLATE = (
+    'emit_deny() {{ printf "DENY:%s\\n" "$1"; exit 0; }}; '
+    ". {lib}; "
+    '_lib_parse_tool_input_or_deny "test-msg"; '
+    'printf "OK:%s:%s\\n" "$TOOL_NAME" "$COMMAND"'
+)
+
+
+def _run_harness(stdin_text: str, env: dict | None = None) -> subprocess.CompletedProcess:
+    harness = _HARNESS_TEMPLATE.format(lib=_LIB_SH)
+    return subprocess.run(
+        ["bash", "-c", harness],
+        input=stdin_text,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+
+def test_valid_bash_payload_returns_ok() -> None:
+    """Valid Bash PreToolUse payload → OK with TOOL_NAME=Bash and COMMAND set."""
+    result = _run_harness('{"tool_name":"Bash","tool_input":{"command":"ls -la"}}')
+    assert result.returncode == 0
+    assert result.stdout.startswith("OK:Bash:ls -la"), repr(result.stdout)
+
+
+def test_empty_stdin_denied() -> None:
+    """Empty stdin → DENY (CISO S1.a: empty INPUT path)."""
+    result = _run_harness("")
+    assert result.returncode == 0
+    assert result.stdout.startswith("DENY:"), repr(result.stdout)
+
+
+def test_whitespace_only_stdin_denied() -> None:
+    """Whitespace-only stdin → DENY via jq parse failure (path a).
+
+    Whitespace-only input is non-empty after `$(cat)` (trailing-newline stripping
+    doesn't affect leading whitespace), so the empty-INPUT check (path b) does not
+    fire. jq rejects the whitespace-only string as invalid JSON and exits non-zero.
+    """
+    result = _run_harness("   \n\t  ")
+    assert result.returncode == 0
+    assert result.stdout.startswith("DENY:"), repr(result.stdout)
+
+
+def test_empty_json_object_denied() -> None:
+    """'{}' → DENY (empty TOOL_NAME, CISO S1.a: no .tool_name)."""
+    result = _run_harness("{}")
+    assert result.returncode == 0
+    assert result.stdout.startswith("DENY:"), repr(result.stdout)
+
+
+def test_empty_tool_name_denied() -> None:
+    """Empty .tool_name → DENY."""
+    result = _run_harness('{"tool_name":""}')
+    assert result.returncode == 0
+    assert result.stdout.startswith("DENY:"), repr(result.stdout)
+
+
+def test_non_object_tool_input_denied_via_jq_exit() -> None:
+    """Non-object .tool_input → DENY via jq_exit != 0 (path a).
+
+    The helper uses a single jq string-interpolation call that extracts both
+    .tool_name and .tool_input.command. When .tool_input is a string, jq raises
+    'Cannot index string with string "command"' and returns non-zero.
+    The deny fires from the jq_exit path (a), NOT from the empty-TOOL_NAME
+    path (c) — .tool_name would extract cleanly as "Bash" if jq succeeded.
+    """
+    result = _run_harness('{"tool_name":"Bash","tool_input":"a string"}')
+    assert result.returncode == 0
+    assert result.stdout.startswith("DENY:"), repr(result.stdout)
+
+
+def test_non_bash_tool_with_file_path_returns_ok_empty_command() -> None:
+    """Edit payload (no .tool_input.command) → OK with empty COMMAND.
+
+    Legitimate non-Bash tools have no 'command' field; the helper allows them
+    through with COMMAND set to empty string.
+    """
+    result = _run_harness('{"tool_name":"Edit","tool_input":{"file_path":"x"}}')
+    assert result.returncode == 0
+    # COMMAND is empty for non-Bash tools — OK:<tool>:<cmd> where <cmd> is ""
+    assert result.stdout.startswith("OK:Edit:"), repr(result.stdout)
+
+
+def test_hung_jq_denied_within_timeout(tmp_path: Path) -> None:
+    """Hung jq (sleeping >5s) → DENY via timeout exit=124, within 6s.
+
+    Verifies _lib_jq's 5s backstop against a jq binary that never terminates.
+    Only runs when timeout(1) is available in PATH.
+    """
+    import shutil
+
+    timeout_path = shutil.which("timeout")
+    if not timeout_path:
+        pytest.skip("timeout(1) not available — BSD/macOS without coreutils")
+
+    bash_path = shutil.which("bash")
+    if not bash_path:
+        pytest.skip("bash not found in PATH")
+
+    # Create a fake jq that sleeps 10 seconds, plus stubs for required tools.
+    fake_jq = tmp_path / "jq"
+    fake_jq.write_text("#!/bin/bash\nsleep 10\n")
+    fake_jq.chmod(0o755)
+
+    # Symlink real timeout and bash so the harness can find them.
+    (tmp_path / "timeout").symlink_to(timeout_path)
+    (tmp_path / "bash").symlink_to(bash_path)
+    # Also symlink standard commands needed by the harness.
+    for cmd in ["head", "tail", "cat", "cut", "printf"]:
+        cmd_path = shutil.which(cmd)
+        if cmd_path:
+            (tmp_path / cmd).symlink_to(cmd_path)
+
+    env = {"PATH": str(tmp_path), "HOME": str(tmp_path)}
+    start = time.monotonic()
+    result = _run_harness('{"tool_name":"Bash","tool_input":{"command":"ls"}}', env=env)
+    elapsed = time.monotonic() - start
+
+    assert result.returncode == 0
+    assert result.stdout.startswith("DENY:"), repr(result.stdout)
+    assert elapsed < 6, f"hung-jq test took {elapsed:.1f}s — timeout did not fire within 6s"
+
+
+def test_timeout_absent_fallback_valid_payload_returns_ok(tmp_path: Path) -> None:
+    """Without timeout(1), valid payload still returns OK via bare jq."""
+    import shutil
+
+    # Build a PATH that excludes `timeout` but keeps jq and bash.
+    jq_path = shutil.which("jq")
+    if not jq_path:
+        pytest.skip("jq not found in PATH")
+
+    bash_path = shutil.which("bash")
+    if not bash_path:
+        pytest.skip("bash not found in PATH")
+
+    # Symlink jq and bash into tmp_path but intentionally omit timeout.
+    (tmp_path / "jq").symlink_to(jq_path)
+    (tmp_path / "bash").symlink_to(bash_path)
+    for cmd in ["head", "tail", "cat", "cut", "printf"]:
+        cmd_path = shutil.which(cmd)
+        if cmd_path:
+            (tmp_path / cmd).symlink_to(cmd_path)
+
+    env = {"PATH": str(tmp_path), "HOME": str(tmp_path)}
+    result = _run_harness('{"tool_name":"Bash","tool_input":{"command":"ls"}}', env=env)
+    assert result.returncode == 0
+    assert result.stdout.startswith("OK:Bash:ls"), repr(result.stdout)
+
+
+def test_missing_emit_deny_loud_fail() -> None:
+    """Source _lib.sh WITHOUT defining emit_deny, call helper on empty stdin.
+
+    Verifies that calling _lib_parse_tool_input_or_deny without emit_deny
+    produces a loud failure (non-zero exit or error output) rather than
+    silent allow. Per the contract comment in _lib.sh: "CALLER MUST define
+    emit_deny before sourcing _lib.sh."
+    """
+    # Harness that sources _lib.sh but intentionally omits emit_deny.
+    harness = (
+        f". {_LIB_SH}; "
+        "_lib_parse_tool_input_or_deny 'test-msg'; "
+        'printf "SHOULD_NOT_REACH\\n"'
+    )
+    result = subprocess.run(
+        ["bash", "-c", harness],
+        input="",
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    # SHOULD_NOT_REACH must never appear on stdout. Hook contract specifies
+    # exit 0 always (hooks signal via stdout JSON, not exit code), so we do
+    # not assert returncode != 0 — the helper always exits 0 by design.
+    # The invariant is that `exit 0` inside the helper terminates the shell
+    # before the printf can run; if someone replaces `exit 0` with `return 0`,
+    # SHOULD_NOT_REACH would appear and this assertion would catch it.
+    assert "SHOULD_NOT_REACH" not in result.stdout, (
+        "Calling _lib_parse_tool_input_or_deny without emit_deny must not "
+        "silently allow — SHOULD_NOT_REACH must never appear in stdout"
+    )
+
+
+def test_null_literal_input_denied() -> None:
+    """JSON null literal → DENY (empty TOOL_NAME after jq, path c).
+
+    `null` is valid JSON and non-empty as a string, so the empty-INPUT check
+    (path b) does not fire. jq's `.tool_name // ""` against `null` exits 0 and
+    produces an empty string — TOOL_NAME is empty, triggering the empty-TOOL_NAME
+    deny (path c). This pins the invariant so a future refactor that removes
+    or weakens the empty-TOOL_NAME check cannot silently re-open this path.
+    """
+    result = _run_harness("null")
+    assert result.returncode == 0
+    assert result.stdout.startswith("DENY:"), repr(result.stdout)
+
+
+def test_newline_injection_in_tool_name_denied() -> None:
+    """tool_name with embedded newline → DENY (path d: invalid TOOL_NAME shape).
+
+    A JSON string value with an escaped newline (e.g. "Bash\\ninjected") is
+    decoded by jq -r into a real newline. The helper uses a unit-separator
+    delimiter to split TOOL_NAME from COMMAND, so TOOL_NAME receives
+    "Bash\\ninjected" rather than "Bash". The post-extraction newline check
+    detects the embedded newline and denies rather than allowing with a
+    corrupted TOOL_NAME or COMMAND.
+    """
+    result = _run_harness('{"tool_name":"Bash\\ninjected","tool_input":{"command":"echo safe"}}')
+    assert result.returncode == 0
+    assert result.stdout.startswith("DENY:"), repr(result.stdout)

--- a/claude/.claude/hooks/tests/test_require_memory_skill.py
+++ b/claude/.claude/hooks/tests/test_require_memory_skill.py
@@ -98,6 +98,11 @@ class TestRequireMemorySkill:
         payload = _memory_input(edit_input(readme), "sess-non-memory")
         assert run_hook(HOOK_PATH, payload) == "allow"
 
+    def test_empty_json_object_denied(self):
+        """'{}' → DENY (empty TOOL_NAME; path c: no .tool_name in payload)."""
+        payload = {}
+        assert run_hook(HOOK_PATH, payload) == "deny"
+
     def test_bash_tool_allowed(self, isolated_home):
         """Bash input passes through — self-filter by tool name."""
         payload = bash_input("echo hello", session_id="sess-bash")

--- a/claude/.claude/hooks/tests/test_require_memory_skill.py
+++ b/claude/.claude/hooks/tests/test_require_memory_skill.py
@@ -110,7 +110,8 @@ class TestRequireMemorySkill:
         assert run_hook(HOOK_PATH, payload) == "allow"
 
     def test_malformed_json_stdin(self, isolated_home):
-        """Malformed JSON stdin must not crash the hook and must exit 0."""
+        """Malformed JSON stdin must fail closed (deny), not silently allow."""
+        import json
         result = subprocess.run(
             [str(HOOK_PATH)],
             input="not-valid-json{{{",
@@ -118,7 +119,9 @@ class TestRequireMemorySkill:
             text=True,
         )
         assert result.returncode == 0
-        assert result.stdout.strip() == ""
+        assert result.stdout.strip(), "Hook must emit a deny message on malformed JSON, not silent exit"
+        payload = json.loads(result.stdout)
+        assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
 
     def test_deny_message_mentions_skill_name(self, isolated_home, memory_tree):
         """Deny reason must reference ai-instruction-and-memory-files."""

--- a/install.sh
+++ b/install.sh
@@ -83,6 +83,11 @@ check_private_projects_file() {
   fi
 }
 
+if ! command -v timeout >/dev/null 2>&1; then
+  printf '[install] warning: GNU coreutils `timeout` not in PATH; guard hooks will run jq without timeout protection.\n' >&2
+  printf '[install] hint: install via `brew install coreutils` (macOS) or `apt install coreutils` (debian). On macOS, coreutils installs `gtimeout` by default — either re-run with `--with-default-names` (older brew) or symlink `gtimeout` to `timeout` in PATH.\n' >&2
+fi
+
 check_private_projects_file
 
 if ! python3 -c "import ensurepip" >/dev/null 2>&1; then

--- a/plugins/claude-hook-review/skills/claude-hook-review/SKILL.md
+++ b/plugins/claude-hook-review/skills/claude-hook-review/SKILL.md
@@ -32,7 +32,7 @@ Rejected forms: bare `./<rest>`, `../<rest>`, or unprefixed script names. Concre
 
 ## 3. Script skeleton
 
-The idiomatic pattern from `deny-private-project-refs.sh` and `require-stow-reminder.sh`:
+New gate hooks must follow the canonical pattern in Section 4 (`_lib_parse_tool_input_or_deny`) rather than reimplementing this inline form. The structural conventions — `set -uo pipefail`, `emit_deny` defined before sourcing `_lib.sh`, exit-0 contract — still apply:
 
 ```bash
 #!/bin/bash
@@ -42,37 +42,65 @@ set -uo pipefail   # explicit failure modes: unbound vars fail loudly,
                    # Older hooks predate this convention; don't perpetuate
                    # the gap in new gates.
 
-INPUT=$(cat)
-COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
-JQ_EXIT=$?
-
 emit_deny() {
   local reason="$1"
   local reason_json
   reason_json=$(printf '%s' "$reason" | jq -Rs .)
-  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' \
-    "$reason_json"
+  local payload
+  payload=$(printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}' "$reason_json")
+  printf '%s\n' "$payload"
 }
 
-if [ "$JQ_EXIT" -ne 0 ]; then
-  emit_deny "Blocked: could not parse tool-input JSON."
+if ! . "$(dirname "$0")/_lib.sh" 2>/dev/null; then
+  emit_deny "Blocked by <gate-name> gate: could not source _lib.sh."
   exit 0
 fi
+
+_lib_parse_tool_input_or_deny "Blocked by <gate-name> gate: could not parse tool-input JSON."
+# INPUT, TOOL_NAME, COMMAND now set. Gate logic follows.
 ```
 
 Exit code is always `0`; the hook signals via stdout JSON, not via exit code.
 
 Two non-obvious constraints for new gates:
 - `"permissionDecision"` must be exactly `"deny"` (lowercase) — the runtime is case-sensitive; `"Deny"`, `"block"`, or any variant silently allows.
-- `jq -r '... // empty'` exits **0** on missing fields (empty string, not a non-zero exit). `JQ_EXIT` guards against JSON parse failures only. For allow-list-style gates (deny anything outside a known set), also guard on `[ -z "$COMMAND" ]`. For deny-list-style gates (deny specific operations, allow all else), empty `COMMAND` correctly falls through.
+- After `_lib_parse_tool_input_or_deny`, `COMMAND` may still be empty: `jq -r '... // empty'` exits **0** on missing fields (empty string, not non-zero). For allow-list-style gates (deny anything outside a known set), guard on `[ -z "$COMMAND" ]`. For deny-list-style gates (deny specific operations, allow all else), empty `COMMAND` correctly falls through.
 
 ## 4. Fail-open vs fail-closed posture
 
-**Fail-closed** when the gate prevents a leak: parse failure → deny (a hook that can't read its input can't verify the operation is safe). Example: `deny-private-project-refs.sh:101–104`.
+**Fail-closed** when the gate prevents a leak: parse failure → deny (a hook that can't read its input can't verify the operation is safe). All 21 gate-class hooks use `_lib.sh::_lib_parse_tool_input_or_deny` as the canonical fail-closed pattern — source that function rather than reimplementing the inline JQ_EXIT check.
+
+The helper uses a single `_lib_jq` call to extract both `.tool_name` and `.tool_input.command`. Three deny paths protect against silent-allow:
+- **(a) jq non-zero exit** — parse failure, `timeout` exit=124, or missing jq binary; also fires when `.tool_input` is not an object (jq structural-type error). Per [Anthropic's PreToolUse hook contract](https://docs.claude.com/en/docs/claude-code/hooks#pretooluse), `.tool_name` and `.tool_input` are always present on a real hook event; jq failure indicates malformed or spoofed input.
+- **(b) empty INPUT** — stdin EOF, closed pipe, or harness misbehavior.
+- **(c) empty TOOL_NAME** — valid JSON but `.tool_name` absent (e.g. `{}`), indicating the call did not originate from a real tool invocation.
+
+The helper uses a 5s `timeout` backstop around every jq call (citing `guard-settings-session-keys.sh`'s `git_capped` precedent). On systems without `timeout` (BSD/macOS default), the helper falls back to bare `jq`; `install.sh` warns at onboarding time (including the `gtimeout` macOS alias case). This is a latency backstop, not a correctness boundary.
+
+The canonical pattern — define `emit_deny` **before** sourcing `_lib.sh`, then call the helper:
+
+```bash
+emit_deny() { ... }  # defined before sourcing so a missing _lib.sh can still deny
+
+if ! . "$(dirname "$0")/_lib.sh" 2>/dev/null; then
+  emit_deny "Blocked by <gate-name> gate: could not source _lib.sh."
+  exit 0
+fi
+
+_lib_parse_tool_input_or_deny "Blocked by <gate-name> gate: could not parse tool-input JSON."
+```
+
+After the helper call, `INPUT`, `TOOL_NAME`, and `COMMAND` are set as globals. Hooks that perform **post-validation** extracts from `$INPUT` (e.g. `.session_id`, `.tool_input.file_path`) still need `// empty` defaults and explicit presence checks for required fields — the helper validates parse-shape, not semantic completeness.
 
 **Fail-open** when the gate is advisory and absence of input is normal: if `~/.claude/private-projects.md` is missing, allow normally (`deny-private-project-refs.sh:259–260`).
 
 State the chosen posture in the script header. Reviewers shouldn't have to re-derive it from the code.
+
+**`# hook-class:` header** — every hook must declare its class on the second line:
+- `# hook-class: gate` — fires PreToolUse and may deny. Required on all 21 guard hooks.
+- `# hook-class: informational` — fires PostToolUse/SessionStart/etc. and never denies.
+
+Flipping a marker from `gate` to `informational` is a security-class change that removes a deny path; the commit message must state the rationale.
 
 ## 5. Dispatch design and drift risk
 
@@ -90,6 +118,8 @@ Prefer named variables over magic strings buried in a regex; future contributors
 ## 7. Performance budget
 
 Hooks fire on every matching tool call. Budget <100ms per fire. Subprocess spawns (`jq`, `grep`) add up — avoid loops over them. No network calls. No unbounded file I/O. If the hook reads user-controlled input, cap the read before scanning. External commands that contact a daemon, socket, or network (`docker`, `systemctl`, `curl`, package managers) must run under an explicit timeout — a hanging external call blocks the entire tool invocation until the OS timeout fires.
+
+The `_lib_jq` wrapper in `_lib.sh` applies a 5s `timeout` to every jq call inside `_lib_parse_tool_input_or_deny`. Hooks that call jq directly for post-validation extracts (e.g. `.session_id`, `.tool_input.file_path`) do not need an additional timeout on those calls — they operate on content already proven parseable by the helper, so the only failure mode is a slow or missing jq binary, both of which are benign (field is missing → `// empty` → gate falls through to allow).
 
 ## 8. Test patterns
 

--- a/plugins/claude-hook-review/skills/claude-hook-review/SKILL.md
+++ b/plugins/claude-hook-review/skills/claude-hook-review/SKILL.md
@@ -68,7 +68,7 @@ Two non-obvious constraints for new gates:
 
 ## 4. Fail-open vs fail-closed posture
 
-**Fail-closed** when the gate prevents a leak: parse failure → deny (a hook that can't read its input can't verify the operation is safe). All 21 gate-class hooks use `_lib.sh::_lib_parse_tool_input_or_deny` as the canonical fail-closed pattern — source that function rather than reimplementing the inline JQ_EXIT check.
+**Fail-closed** when the gate prevents a leak: parse failure → deny (a hook that can't read its input can't verify the operation is safe). All gate-class hooks use `_lib.sh::_lib_parse_tool_input_or_deny` as the canonical fail-closed pattern — source that function rather than reimplementing the inline JQ_EXIT check.
 
 The helper uses a single `_lib_jq` call to extract both `.tool_name` and `.tool_input.command`. Three deny paths protect against silent-allow:
 - **(a) jq non-zero exit** — parse failure, `timeout` exit=124, or missing jq binary; also fires when `.tool_input` is not an object (jq structural-type error). Per [Anthropic's PreToolUse hook contract](https://docs.claude.com/en/docs/claude-code/hooks#pretooluse), `.tool_name` and `.tool_input` are always present on a real hook event; jq failure indicates malformed or spoofed input.
@@ -97,8 +97,8 @@ After the helper call, `INPUT`, `TOOL_NAME`, and `COMMAND` are set as globals. H
 State the chosen posture in the script header. Reviewers shouldn't have to re-derive it from the code.
 
 **`# hook-class:` header** — every hook must declare its class on the second line:
-- `# hook-class: gate` — fires PreToolUse and may deny. Required on all 21 guard hooks.
-- `# hook-class: informational` — fires PostToolUse/SessionStart/etc. and never denies.
+- `# hook-class: gate` — fires PreToolUse and may deny. Required on all guard hooks.
+- `# hook-class: informational` — fires PostToolUse/SessionStart/etc. and never denies. The label describes the hardening posture (cannot deny), not functional importance — an essential workflow hook (e.g., `capture-session-id.sh`) and a purely advisory one both carry this label if neither issues a PreToolUse denial.
 
 Flipping a marker from `gate` to `informational` is a security-class change that removes a deny path; the commit message must state the rationale.
 

--- a/plugins/skill-management/hooks/_lib.sh
+++ b/plugins/skill-management/hooks/_lib.sh
@@ -54,6 +54,10 @@ _lib_parse_tool_input_or_deny() {
   # error when .tool_input is non-object (e.g. "Cannot index string with string
   # 'command'"), returning non-zero.
   local jq_out
+  # WARNING: the format string below contains a literal 0x1f (ASCII Unit Separator)
+  # byte between the two interpolated fields - invisible in editors and diff views.
+  # Do not remove it. test_lib.py::test_valid_bash_payload_returns_ok will fail
+  # immediately if the delimiter is absent, catching accidental deletion.
   jq_out=$(printf '%s\n' "$INPUT" | _lib_jq -r '"\(.tool_name // "")\(.tool_input.command // "")"' 2>/dev/null)
   local jq_exit=$?
   if [ "$jq_exit" -ne 0 ]; then

--- a/plugins/skill-management/hooks/_lib.sh
+++ b/plugins/skill-management/hooks/_lib.sh
@@ -4,6 +4,75 @@
 # byte-identical output on both the read side (hooks) and the write side
 # (marker.sh). Source it; do not invoke it directly.
 
+# Backstop against a hung jq (~5s, not a per-fire latency budget).
+# Cites guard-settings-session-keys.sh's git_capped 5s precedent.
+# Fallback to bare jq when timeout(1) is absent (BSD/macOS default).
+# install.sh warns about missing timeout at onboarding time.
+# Security implication: on BSD/macOS without coreutils, a stalled or
+# replaced jq binary can hold a gate hook open indefinitely. The harness's
+# own hook timeout (if any) then governs — not this wrapper.
+_lib_jq() {
+  if command -v timeout >/dev/null 2>&1; then
+    timeout 5 jq "$@"
+  else
+    jq "$@"
+  fi
+}
+
+# Reads stdin into INPUT (global), extracts TOOL_NAME and COMMAND (globals)
+# via a single _lib_jq call using ASCII Unit Separator (0x1f) as delimiter.
+# The single call surfaces a structural-type error when .tool_input is non-object
+# (jq non-zero exit).
+#
+# Three deny paths protect against silent-allow:
+#   (a) jq non-zero exit (parse failure, timeout exit=124, missing jq binary)
+#   (b) empty INPUT (stdin EOF, closed pipe, harness misbehavior)
+#   (c) empty TOOL_NAME (valid JSON but PreToolUse contract not honored, e.g. "{}")
+# Per Anthropic PreToolUse contract, every legitimate event has a non-empty
+# .tool_name; absence indicates the call did not originate from a real tool
+# invocation. Without (b)/(c), downstream gates that early-exit on
+# `[ "$TOOL_NAME" = "Bash" ]` silently allow on zero-byte or "{}" inputs.
+#
+# Contract: if this function returns, parse succeeded AND TOOL_NAME is set.
+# On failure, calls emit_deny (caller-defined) with the supplied message and
+# exits 0 — caller never checks $?. Never call this with `|| true` or in
+# a pipeline. CALLER MUST define emit_deny before sourcing _lib.sh so this
+# helper can resolve it; the canonical pattern (define-emit_deny-then-source)
+# is enforced by test_hook_alignment.py.
+_lib_parse_tool_input_or_deny() {
+  local deny_msg="${1:-Blocked: could not parse tool-input JSON.}"
+  INPUT=$(cat)  # command substitution strips trailing newlines — safe for JSON payloads
+  if [ -z "$INPUT" ]; then
+    emit_deny "$deny_msg"
+    exit 0
+  fi
+  # Single jq call extracts both fields delimited by ASCII Unit Separator (0x1f)
+  # rather than newlines, preventing a tool_name value containing an embedded
+  # newline from corrupting COMMAND via head/tail line splitting. Unit Separator
+  # cannot appear in a valid Claude Code tool name or shell command.
+  # The .tool_input.command extraction additionally surfaces a structural-type
+  # error when .tool_input is non-object (e.g. "Cannot index string with string
+  # 'command'"), returning non-zero.
+  local jq_out
+  jq_out=$(printf '%s\n' "$INPUT" | _lib_jq -r '"\(.tool_name // "")\(.tool_input.command // "")"' 2>/dev/null)
+  local jq_exit=$?
+  if [ "$jq_exit" -ne 0 ]; then
+    emit_deny "$deny_msg"
+    exit 0
+  fi
+  TOOL_NAME="${jq_out%%$'\x1f'*}"
+  COMMAND="${jq_out#*$'\x1f'}"
+  # Embedded newline in TOOL_NAME means the payload violated the PreToolUse
+  # contract; deny rather than allow with a corrupted TOOL_NAME value.
+  if [ -z "$TOOL_NAME" ]; then
+    emit_deny "$deny_msg"
+    exit 0
+  fi
+  case "$TOOL_NAME" in
+    *$'\n'*) emit_deny "$deny_msg"; exit 0 ;;
+  esac
+}
+
 # Compute the marker repo-hash for an absolute repo-toplevel path.
 # Input must have no trailing newline -- printf '%s' omits one, so the SHA
 # covers exactly the bytes of $1.

--- a/plugins/skill-management/hooks/provision-validator-venv.sh
+++ b/plugins/skill-management/hooks/provision-validator-venv.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# hook-class: informational
 # SessionStart bootstrap for the SKILL.md structural validator.
 #
 # Provisions a per-plugin Python venv with pyyaml at

--- a/plugins/skill-management/hooks/require-skill-review.sh
+++ b/plugins/skill-management/hooks/require-skill-review.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# hook-class: gate
 # Gate: require /skill-review before git commit when SKILL.md files are staged,
 # verified via marker file.
 #
@@ -27,10 +28,21 @@
 #   so re-staging non-SKILL.md files after a clean skill-review does not
 #   invalidate the marker.
 
-. "$(dirname "$0")/_lib.sh"
+emit_deny() {
+  local reason="$1"
+  local reason_json
+  reason_json=$(printf '%s' "$reason" | jq -Rs .)
+  local payload
+  payload=$(printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}' "$reason_json")
+  printf '%s\n' "$payload"
+}
 
-INPUT=$(cat)
-COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command // empty')
+if ! . "$(dirname "$0")/_lib.sh" 2>/dev/null; then
+  emit_deny "Blocked by skill-review gate: could not source _lib.sh."
+  exit 0
+fi
+
+_lib_parse_tool_input_or_deny "Blocked by skill-review gate: could not parse tool-input JSON."
 
 # Only gate git commit commands — exit 0 (no opinion) for everything else.
 # Match `git commit` at the start of the command OR after a shell separator
@@ -111,9 +123,7 @@ if [ "${#STAGED_SKILL_PATHS[@]}" -gt 0 ]; then
       # Strip the tmp-dir prefix so the user sees the original repo-relative
       # SKILL.md path in the deny reason rather than /tmp/tmp.XXXX/...
       VALIDATOR_STDERR=${VALIDATOR_STDERR//"$STAGED_BLOB_DIR/"/}
-      REASON="Commit blocked by skill-management structural validator: ${VALIDATOR_STDERR}"
-      REASON_JSON=$(printf '%s' "$REASON" | jq -Rs .)
-      printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' "$REASON_JSON"
+      emit_deny "Commit blocked by skill-management structural validator: ${VALIDATOR_STDERR}"
       exit 0
     fi
   fi
@@ -182,6 +192,4 @@ fi
 # Build the reason as a bash variable so the conditional marker-chain
 # note can be interpolated; jq -Rs handles JSON-encoding safely
 # regardless of what characters appear in the appended note.
-REASON="Commit blocked by skill-review gate: Staged skill changes have not been audited by /skill-review. Run /skill-review on the staged SKILL.md diff; the skill must produce an explicit behavioral-equivalence table for any removed or shortened lines before committing."
-REASON_JSON=$(printf '%s' "$REASON" | jq -Rs .)
-printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' "$REASON_JSON"
+emit_deny "Commit blocked by skill-review gate: Staged skill changes have not been audited by /skill-review. Run /skill-review on the staged SKILL.md diff; the skill must produce an explicit behavioral-equivalence table for any removed or shortened lines before committing."


### PR DESCRIPTION
## Summary

- **Security gap closed:** 10 of the gate-class hooks were fail-open on jq parse failure — malformed or absent JSON produced an empty COMMAND, matched no denylist pattern, and silently allowed the blocked operation.
- Adds `_lib_jq` (5s timeout backstop) + `_lib_parse_tool_input_or_deny` to `_lib.sh` (main + plugin mirror); all gate hooks adopt the helper.
- Uses ASCII Unit Separator (0x1f) as field delimiter instead of newlines, preventing a crafted `tool_name` with embedded newline from corrupting COMMAND (newline injection fix from CISO review).
- Adds suite-wide alignment enforcement: `test_hook_alignment.py` (Layer 1 static + Layer 2 behavior, including static emit_deny ordering check), `test_lib.py` (unit tests including null literal, newline injection, hung jq), `test_install_sh_timeout_warning.py`.
- Updates `plugins/claude-hook-review/skills/claude-hook-review/SKILL.md` to document the canonical pattern, three deny paths, `# hook-class:` headers, and post-validation jq guidance.
- Follow-up commits address reviewer comments: removed stale numeric counts from SKILL.md, clarified `# hook-class: informational` = hardening posture (not functional importance), closed test gaps identified in code review.

## Security model

Three deny paths protect against silent-allow:
- **(a) jq non-zero exit** — parse failure, `timeout` exit=124, or missing jq binary; also fires on structural-type errors (`.tool_input` not an object).
- **(b) empty INPUT** — stdin EOF, closed pipe, or harness misbehavior.
- **(c) empty TOOL_NAME** — valid JSON but `.tool_name` absent (e.g. `{}`).

`emit_deny` now pre-assembles the JSON payload before `printf` (atomic write). `# hook-class: gate|informational` header added to every hook.

## Design decisions

- D1: Hybrid — helper in `_lib.sh`, `emit_deny` inline per hook.
- D2: 5s timeout, matching `git_capped` precedent in `guard-settings-session-keys.sh`.
- D3: Uniform across all gate hooks.
- D4: `# hook-class:` header + filename-prefix enforcement in `test_hook_alignment.py`.

## Incidental edits

`# hook-class: informational` added to 7 informational hooks, `check-branch-divergence.sh`, and `provision-validator-venv.sh` — required by the alignment test's exhaustive hook enumeration.

## Test plan

- [ ] Review `_lib.sh` helper logic (three deny paths, unit separator delimiter, newline injection guard)
- [ ] Review `test_hook_alignment.py` Layer 1 (static, including emit_deny ordering) + Layer 2 (behavior) coverage
- [ ] Review `test_lib.py` boundary cases (null literal, newline injection, hung jq, absent timeout)
- [ ] Spot-check 2-3 gate hooks for correct `_lib_parse_tool_input_or_deny` adoption
- [ ] Verify `# hook-class:` headers present on all changed hooks

<!-- code-review:deferred:start -->
## Deferred review findings

| Finding | Source | DEFER criterion | Rationale |
|---------|--------|-----------------|-----------|
| 0x1f byte in `tool_input.command` truncates COMMAND at delimiter split (field-confusion, not silent-allow) | ciso-reviewer + staff-sdet | Orthogonal scope | Requires prompt injection through Claude's Bash tool generation — distinct attack surface from the fail-closed parse-failure scope of this PR; no silent-allow path exists |
| Lone-newline stdin takes path (b) rather than path (a) — untested as a distinct execution path | staff-sdet | Edge case below current scale | Different code path, same deny result; no bypass risk at operating scale |
| BSD/macOS bare-jq fallback (no timeout bound) when coreutils absent | ciso-reviewer + staff-backend-engineer | Gold-plating beyond declared user surface | Post-exploitation scenario; documented in code comments + install.sh warning; accepted tradeoff for developer-workflow tool |
<!-- code-review:deferred:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)