### PR TITLE
feat(transcript-analysis): add skill-invocation subcommand

### DIFF
--- a/claude/.claude/scripts/tests/test_transcript_analysis.py
+++ b/claude/.claude/scripts/tests/test_transcript_analysis.py
@@ -2943,8 +2943,10 @@ class TestSkillInvocation:
         asst_rec["attributionSkill"] = "ready-for-review"
         _write_jsonl(fake_projects / "s2.jsonl", [asst_rec])
         out = self._run(capsys)
-        # Routed pair must appear in the ROUTED PAIRS section
-        assert "ready-for-review -> code-review" in out
+        # Routed pair must appear in the ROUTED PAIRS section with count 1
+        pair_lines = [ln for ln in out.splitlines() if "ready-for-review -> code-review" in ln]
+        assert pair_lines, "ready-for-review -> code-review pair line not found in output"
+        assert ": 1" in pair_lines[0], f"expected count=1 in pair line: {pair_lines[0]!r}"
 
     def test_routed_column_count_correct(self, fake_projects, capsys):
         """Routed invocation increments the routed column and not top-level."""
@@ -2960,6 +2962,8 @@ class TestSkillInvocation:
                 assert int(parts[1]) == 0, f"expected top-level=0, got: {line!r}"
                 assert int(parts[2]) >= 1, f"expected routed≥1, got: {line!r}"
                 break
+        else:
+            pytest.fail("plan-review data row not found in output")
 
     def test_slash_invocation_counted(self, fake_projects, capsys):
         """User record whose content contains <command-name>/plan-it</command-name> → user-slash count."""
@@ -3094,11 +3098,16 @@ class TestSkillInvocation:
         ])
         _write_jsonl(fake_projects / "s_multi_skill.jsonl", [rec])
         out = self._run(capsys)
+        found_code_review = found_plan_review = False
         for line in out.splitlines():
             if line.startswith("code-review"):
+                found_code_review = True
                 assert int(line.split()[1]) == 1, f"code-review top-level count should be 1: {line!r}"
             if line.startswith("plan-review"):
+                found_plan_review = True
                 assert int(line.split()[1]) == 1, f"plan-review top-level count should be 1: {line!r}"
+        assert found_code_review, "code-review data row not found in output"
+        assert found_plan_review, "plan-review data row not found in output"
 
     def test_multiple_slash_tags_in_one_user_record(self, fake_projects, capsys):
         """Two <command-name> tags in a single user record → both skill names counted in slash column."""
@@ -3108,11 +3117,16 @@ class TestSkillInvocation:
         )
         _write_jsonl(fake_projects / "s_multi_slash.jsonl", [user_rec])
         out = self._run(capsys)
+        found_plan_it = found_code_review = False
         for line in out.splitlines():
             if line.startswith("plan-it"):
+                found_plan_it = True
                 assert int(line.split()[3]) >= 1, f"plan-it slash count should be ≥1: {line!r}"
             if line.startswith("code-review"):
+                found_code_review = True
                 assert int(line.split()[3]) >= 1, f"code-review slash count should be ≥1: {line!r}"
+        assert found_plan_it, "plan-it data row not found in output"
+        assert found_code_review, "code-review data row not found in output"
 
     def test_slash_detection_with_list_form_user_content(self, fake_projects, capsys):
         """User record whose content is a list-of-blocks → slash command still detected via _content_text."""
@@ -3192,15 +3206,20 @@ class TestSkillInvocation:
         rec["attributionSkill"] = "ready-for-review"
         _write_jsonl(fake_projects / "s_multi_routed.jsonl", [rec])
         out = self._run(capsys)
+        found_code_review = found_plan_review = False
         for line in out.splitlines():
             if line.startswith("code-review"):
+                found_code_review = True
                 parts = line.split()
                 assert int(parts[1]) == 0, f"code-review top-level should be 0: {line!r}"
                 assert int(parts[2]) == 1, f"code-review routed should be 1: {line!r}"
             if line.startswith("plan-review"):
+                found_plan_review = True
                 parts = line.split()
                 assert int(parts[1]) == 0, f"plan-review top-level should be 0: {line!r}"
                 assert int(parts[2]) == 1, f"plan-review routed should be 1: {line!r}"
+        assert found_code_review, "code-review data row not found in output"
+        assert found_plan_review, "plan-review data row not found in output"
 
     def test_cross_project_aggregation(self, tmp_path, monkeypatch, capsys):
         """Default glob aggregates counts across multiple project directories."""

--- a/claude/.claude/scripts/tests/test_transcript_analysis.py
+++ b/claude/.claude/scripts/tests/test_transcript_analysis.py
@@ -2901,3 +2901,252 @@ class TestCmdStruggle:
         assert "feat" in out, (
             f"phrase {phrase!r} (text={text!r}) should register as a struggle signal; branch absent from output: {out!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# skill-invocation
+# ---------------------------------------------------------------------------
+
+
+class TestSkillInvocation:
+    def _run(self, fake_projects, capsys):
+        args = argparse.Namespace(projects="*")
+        _mod.cmd_skill_invocation(args)
+        return capsys.readouterr().out
+
+    def test_top_level_invocation_counted(self, fake_projects, capsys):
+        """Assistant record with Skill tool_use and no attributionSkill → counted as top-level."""
+        asst_rec = _asst("claude-opus-4-7", branch="main", content=[
+            _skill_use("t1", "code-review")
+        ])
+        # No attributionSkill field → top-level
+        _write_jsonl(fake_projects / "s1.jsonl", [asst_rec])
+        out = self._run(fake_projects, capsys)
+        assert "code-review" in out
+        # Top-level column should be ≥1; find the data row for code-review
+        for line in out.splitlines():
+            if line.startswith("code-review"):
+                parts = line.split()
+                # Format: skill top-level routed user-slash total
+                assert int(parts[1]) >= 1, f"expected top-level ≥1, got: {line!r}"
+                assert int(parts[2]) == 0, f"expected routed=0, got: {line!r}"
+                assert int(parts[3]) == 0, f"expected slash=0, got: {line!r}"
+                break
+        else:
+            pytest.fail("code-review data row not found in output")
+
+    def test_routed_invocation_counted(self, fake_projects, capsys):
+        """Assistant record with Skill tool_use AND attributionSkill → counted as routed."""
+        asst_rec = _asst("claude-haiku-4-5", branch="main", content=[
+            _skill_use("t2", "code-review")
+        ])
+        asst_rec["attributionSkill"] = "ready-for-review"
+        _write_jsonl(fake_projects / "s2.jsonl", [asst_rec])
+        out = self._run(fake_projects, capsys)
+        # Routed pair must appear in the ROUTED PAIRS section
+        assert "ready-for-review -> code-review" in out
+
+    def test_routed_column_count_correct(self, fake_projects, capsys):
+        """Routed invocation increments the routed column and not top-level."""
+        asst_rec = _asst("claude-haiku-4-5", branch="main", content=[
+            _skill_use("t3", "plan-review")
+        ])
+        asst_rec["attributionSkill"] = "plan-it"
+        _write_jsonl(fake_projects / "s3.jsonl", [asst_rec])
+        out = self._run(fake_projects, capsys)
+        for line in out.splitlines():
+            if line.startswith("plan-review"):
+                parts = line.split()
+                assert int(parts[1]) == 0, f"expected top-level=0, got: {line!r}"
+                assert int(parts[2]) >= 1, f"expected routed≥1, got: {line!r}"
+                break
+
+    def test_slash_invocation_counted(self, fake_projects, capsys):
+        """User record whose content contains <command-name>/plan-it</command-name> → user-slash count."""
+        user_rec = _user_msg(
+            "<command-message>plan-it</command-message>\n<command-name>/plan-it</command-name>",
+            branch="main",
+        )
+        _write_jsonl(fake_projects / "s4.jsonl", [user_rec])
+        out = self._run(fake_projects, capsys)
+        # plan-it must appear in the table
+        assert "plan-it" in out
+        # The slash column for plan-it should be ≥1
+        for line in out.splitlines():
+            if line.startswith("plan-it"):
+                parts = line.split()
+                assert int(parts[3]) >= 1, f"expected slash≥1, got: {line!r}"
+                break
+
+    def test_sidechain_excluded(self, fake_projects, capsys):
+        """Sidechain assistant records are not counted in any bucket."""
+        asst_rec = _asst("claude-opus-4-7", branch="main", sidechain=True, content=[
+            _skill_use("t5", "code-review")
+        ])
+        _write_jsonl(fake_projects / "s5.jsonl", [asst_rec])
+        out = self._run(fake_projects, capsys)
+        # No non-sidechain invocations → no data → "No skill invocations found."
+        assert "No skill invocations found." in out
+
+    def test_routed_pair_grouping(self, fake_projects, capsys):
+        """Two records both with attributionSkill='ready-for-review' and skill='code-review'
+        → routed_pairs contains (ready-for-review, code-review): 2."""
+        rec1 = _asst("claude-haiku-4-5", branch="main", content=[_skill_use("t6a", "code-review")])
+        rec1["attributionSkill"] = "ready-for-review"
+        rec2 = _asst("claude-haiku-4-5", branch="main", content=[_skill_use("t6b", "code-review")])
+        rec2["attributionSkill"] = "ready-for-review"
+        _write_jsonl(fake_projects / "s6.jsonl", [rec1, rec2])
+        out = self._run(fake_projects, capsys)
+        # The pair should appear exactly once in the routed pairs section with count 2
+        pair_lines = [ln for ln in out.splitlines() if "ready-for-review -> code-review" in ln]
+        assert len(pair_lines) == 1, f"Expected exactly one pair line, got: {pair_lines}"
+        assert ": 2" in pair_lines[0], f"Expected count=2 in pair line: {pair_lines[0]!r}"
+
+    def test_routed_only_candidate_in_summary(self, fake_projects, capsys):
+        """A skill with only routed invocations appears in the 'Routed-only candidates' section."""
+        rec = _asst("claude-haiku-4-5", branch="main", content=[_skill_use("t7", "agent-review")])
+        rec["attributionSkill"] = "code-review"
+        _write_jsonl(fake_projects / "s7.jsonl", [rec])
+        out = self._run(fake_projects, capsys)
+        assert "Routed-only candidates" in out, f"section header not found in output: {out!r}"
+        assert "agent-review" in out
+        # agent-review must appear in the routed-only section, not load-bearing
+        routed_only_start = out.find("Routed-only candidates")
+        slash_only_start = out.find("Slash-only candidates")
+        assert routed_only_start != -1, "Routed-only candidates section not found"
+        assert slash_only_start != -1, "Slash-only candidates section not found"
+        routed_only_section = out[routed_only_start:slash_only_start]
+        assert "agent-review" in routed_only_section
+
+    def test_load_bearing_in_summary(self, fake_projects, capsys):
+        """A skill with top-level invocations appears in the 'Load-bearing' section."""
+        rec = _asst("claude-sonnet-4-6", branch="main", content=[_skill_use("t8", "skill-review")])
+        _write_jsonl(fake_projects / "s8.jsonl", [rec])
+        out = self._run(fake_projects, capsys)
+        load_bearing_start = out.find("Load-bearing")
+        routed_only_start = out.find("Routed-only candidates")
+        assert load_bearing_start != -1, "Load-bearing section not found"
+        assert routed_only_start != -1, "Routed-only candidates section not found"
+        load_bearing_section = out[load_bearing_start:routed_only_start]
+        assert "skill-review" in load_bearing_section
+
+    def test_slash_only_candidate_in_summary(self, fake_projects, capsys):
+        """A skill with only slash invocations appears in the 'Slash-only candidates' section."""
+        user_rec = _user_msg(
+            "<command-name>/handoff</command-name>",
+            branch="main",
+        )
+        _write_jsonl(fake_projects / "s9.jsonl", [user_rec])
+        out = self._run(fake_projects, capsys)
+        slash_only_start = out.find("Slash-only candidates")
+        assert slash_only_start != -1, "Slash-only candidates section not found"
+        slash_only_section = out[slash_only_start:]
+        assert "handoff" in slash_only_section
+
+    def test_no_invocations_prints_not_found(self, fake_projects, capsys):
+        """Empty corpus prints 'No skill invocations found.'"""
+        # Write a session with only a Bash call — no Skill tool_use or slash
+        _write_jsonl(fake_projects / "s_empty.jsonl", [
+            _asst("claude-sonnet-4-6", branch="main", content=[
+                _bash_use("b1", "git status")
+            ])
+        ])
+        out = self._run(fake_projects, capsys)
+        assert "No skill invocations found." in out
+
+    def test_projects_filter_restricts_to_named_project(self, tmp_path, monkeypatch, capsys):
+        """--projects filter causes only the named project dir to be scanned."""
+        projects = tmp_path / "projects"
+        proj_a = projects / "-home-user-repoA"
+        proj_b = projects / "-home-user-repoB"
+        proj_a.mkdir(parents=True)
+        proj_b.mkdir(parents=True)
+        monkeypatch.setattr(_mod, "PROJECTS_DIR", projects)
+        # repoA has a skill invocation; repoB has a different skill
+        rec_a = _asst("claude-sonnet-4-6", branch="main", content=[_skill_use("ta1", "code-review")])
+        rec_b = _asst("claude-sonnet-4-6", branch="main", content=[_skill_use("tb1", "plan-review")])
+        _write_jsonl(proj_a / "s_a.jsonl", [rec_a])
+        _write_jsonl(proj_b / "s_b.jsonl", [rec_b])
+        # Filter to repoA only
+        args = argparse.Namespace(projects="-home-user-repoA")
+        _mod.cmd_skill_invocation(args)
+        out = capsys.readouterr().out
+        assert "code-review" in out, "repoA skill not found"
+        assert "plan-review" not in out, "repoB skill leaked through the project filter"
+
+    def test_empty_skill_field_in_tool_use_skipped(self, fake_projects, capsys):
+        """Skill tool_use with empty or absent input.skill is not counted."""
+        rec_empty = _asst("claude-sonnet-4-6", branch="main", content=[
+            {"type": "tool_use", "id": "te1", "name": "Skill", "input": {"skill": ""}},
+        ])
+        rec_absent = _asst("claude-sonnet-4-6", branch="main", content=[
+            {"type": "tool_use", "id": "te2", "name": "Skill", "input": {}},
+        ])
+        _write_jsonl(fake_projects / "s_empty_skill.jsonl", [rec_empty, rec_absent])
+        out = self._run(fake_projects, capsys)
+        assert "No skill invocations found." in out
+
+    def test_multiple_skills_in_one_assistant_record(self, fake_projects, capsys):
+        """Two Skill tool_use blocks in a single assistant record's content → both counted."""
+        rec = _asst("claude-sonnet-4-6", branch="main", content=[
+            _skill_use("tm1", "code-review"),
+            _skill_use("tm2", "plan-review"),
+        ])
+        _write_jsonl(fake_projects / "s_multi_skill.jsonl", [rec])
+        out = self._run(fake_projects, capsys)
+        for line in out.splitlines():
+            if line.startswith("code-review"):
+                assert int(line.split()[1]) == 1, f"code-review top-level count should be 1: {line!r}"
+            if line.startswith("plan-review"):
+                assert int(line.split()[1]) == 1, f"plan-review top-level count should be 1: {line!r}"
+
+    def test_multiple_slash_tags_in_one_user_record(self, fake_projects, capsys):
+        """Two <command-name> tags in a single user record → both skill names counted in slash column."""
+        user_rec = _user_msg(
+            "<command-name>/plan-it</command-name>\n<command-name>/code-review</command-name>",
+            branch="main",
+        )
+        _write_jsonl(fake_projects / "s_multi_slash.jsonl", [user_rec])
+        out = self._run(fake_projects, capsys)
+        for line in out.splitlines():
+            if line.startswith("plan-it"):
+                assert int(line.split()[3]) >= 1, f"plan-it slash count should be ≥1: {line!r}"
+            if line.startswith("code-review"):
+                assert int(line.split()[3]) >= 1, f"code-review slash count should be ≥1: {line!r}"
+
+    def test_slash_detection_with_list_form_user_content(self, fake_projects, capsys):
+        """User record whose content is a list-of-blocks → slash command still detected via _content_text."""
+        user_rec = {
+            "type": "user",
+            "gitBranch": "main",
+            "message": {
+                "content": [
+                    {"type": "text", "text": "<command-name>/plan-it</command-name>"},
+                ]
+            },
+        }
+        _write_jsonl(fake_projects / "s_list_content.jsonl", [user_rec])
+        out = self._run(fake_projects, capsys)
+        assert "plan-it" in out
+        for line in out.splitlines():
+            if line.startswith("plan-it"):
+                assert int(line.split()[3]) >= 1, f"plan-it slash count should be ≥1: {line!r}"
+                break
+
+    def test_mixed_top_and_routed_in_same_session(self, fake_projects, capsys):
+        """A session with both top-level and routed calls for the same skill tallies both columns."""
+        top_rec = _asst("claude-sonnet-4-6", branch="main", content=[_skill_use("t10a", "code-review")])
+        # No attributionSkill → top-level
+        routed_rec = _asst("claude-haiku-4-5", branch="main", content=[_skill_use("t10b", "code-review")])
+        routed_rec["attributionSkill"] = "ready-for-review"
+        _write_jsonl(fake_projects / "s10.jsonl", [top_rec, routed_rec])
+        out = self._run(fake_projects, capsys)
+        for line in out.splitlines():
+            if line.startswith("code-review"):
+                parts = line.split()
+                assert int(parts[1]) == 1, f"expected top-level=1, got: {line!r}"
+                assert int(parts[2]) == 1, f"expected routed=1, got: {line!r}"
+                assert int(parts[4]) == 2, f"expected total=2, got: {line!r}"
+                break
+        else:
+            pytest.fail("code-review data row not found in output")

--- a/claude/.claude/scripts/tests/test_transcript_analysis.py
+++ b/claude/.claude/scripts/tests/test_transcript_analysis.py
@@ -2909,7 +2909,7 @@ class TestCmdStruggle:
 
 
 class TestSkillInvocation:
-    def _run(self, fake_projects, capsys):
+    def _run(self, capsys):
         args = argparse.Namespace(projects="*")
         _mod.cmd_skill_invocation(args)
         return capsys.readouterr().out
@@ -2921,7 +2921,7 @@ class TestSkillInvocation:
         ])
         # No attributionSkill field → top-level
         _write_jsonl(fake_projects / "s1.jsonl", [asst_rec])
-        out = self._run(fake_projects, capsys)
+        out = self._run(capsys)
         assert "code-review" in out
         # Top-level column should be ≥1; find the data row for code-review
         for line in out.splitlines():
@@ -2942,7 +2942,7 @@ class TestSkillInvocation:
         ])
         asst_rec["attributionSkill"] = "ready-for-review"
         _write_jsonl(fake_projects / "s2.jsonl", [asst_rec])
-        out = self._run(fake_projects, capsys)
+        out = self._run(capsys)
         # Routed pair must appear in the ROUTED PAIRS section
         assert "ready-for-review -> code-review" in out
 
@@ -2953,7 +2953,7 @@ class TestSkillInvocation:
         ])
         asst_rec["attributionSkill"] = "plan-it"
         _write_jsonl(fake_projects / "s3.jsonl", [asst_rec])
-        out = self._run(fake_projects, capsys)
+        out = self._run(capsys)
         for line in out.splitlines():
             if line.startswith("plan-review"):
                 parts = line.split()
@@ -2968,7 +2968,7 @@ class TestSkillInvocation:
             branch="main",
         )
         _write_jsonl(fake_projects / "s4.jsonl", [user_rec])
-        out = self._run(fake_projects, capsys)
+        out = self._run(capsys)
         # plan-it must appear in the table
         assert "plan-it" in out
         # The slash column for plan-it should be ≥1
@@ -2984,7 +2984,7 @@ class TestSkillInvocation:
             _skill_use("t5", "code-review")
         ])
         _write_jsonl(fake_projects / "s5.jsonl", [asst_rec])
-        out = self._run(fake_projects, capsys)
+        out = self._run(capsys)
         # No non-sidechain invocations → no data → "No skill invocations found."
         assert "No skill invocations found." in out
 
@@ -2996,7 +2996,7 @@ class TestSkillInvocation:
         rec2 = _asst("claude-haiku-4-5", branch="main", content=[_skill_use("t6b", "code-review")])
         rec2["attributionSkill"] = "ready-for-review"
         _write_jsonl(fake_projects / "s6.jsonl", [rec1, rec2])
-        out = self._run(fake_projects, capsys)
+        out = self._run(capsys)
         # The pair should appear exactly once in the routed pairs section with count 2
         pair_lines = [ln for ln in out.splitlines() if "ready-for-review -> code-review" in ln]
         assert len(pair_lines) == 1, f"Expected exactly one pair line, got: {pair_lines}"
@@ -3007,7 +3007,7 @@ class TestSkillInvocation:
         rec = _asst("claude-haiku-4-5", branch="main", content=[_skill_use("t7", "agent-review")])
         rec["attributionSkill"] = "code-review"
         _write_jsonl(fake_projects / "s7.jsonl", [rec])
-        out = self._run(fake_projects, capsys)
+        out = self._run(capsys)
         assert "Routed-only candidates" in out, f"section header not found in output: {out!r}"
         assert "agent-review" in out
         # agent-review must appear in the routed-only section, not load-bearing
@@ -3022,7 +3022,7 @@ class TestSkillInvocation:
         """A skill with top-level invocations appears in the 'Load-bearing' section."""
         rec = _asst("claude-sonnet-4-6", branch="main", content=[_skill_use("t8", "skill-review")])
         _write_jsonl(fake_projects / "s8.jsonl", [rec])
-        out = self._run(fake_projects, capsys)
+        out = self._run(capsys)
         load_bearing_start = out.find("Load-bearing")
         routed_only_start = out.find("Routed-only candidates")
         assert load_bearing_start != -1, "Load-bearing section not found"
@@ -3037,7 +3037,7 @@ class TestSkillInvocation:
             branch="main",
         )
         _write_jsonl(fake_projects / "s9.jsonl", [user_rec])
-        out = self._run(fake_projects, capsys)
+        out = self._run(capsys)
         slash_only_start = out.find("Slash-only candidates")
         assert slash_only_start != -1, "Slash-only candidates section not found"
         slash_only_section = out[slash_only_start:]
@@ -3051,7 +3051,7 @@ class TestSkillInvocation:
                 _bash_use("b1", "git status")
             ])
         ])
-        out = self._run(fake_projects, capsys)
+        out = self._run(capsys)
         assert "No skill invocations found." in out
 
     def test_projects_filter_restricts_to_named_project(self, tmp_path, monkeypatch, capsys):
@@ -3083,7 +3083,7 @@ class TestSkillInvocation:
             {"type": "tool_use", "id": "te2", "name": "Skill", "input": {}},
         ])
         _write_jsonl(fake_projects / "s_empty_skill.jsonl", [rec_empty, rec_absent])
-        out = self._run(fake_projects, capsys)
+        out = self._run(capsys)
         assert "No skill invocations found." in out
 
     def test_multiple_skills_in_one_assistant_record(self, fake_projects, capsys):
@@ -3093,7 +3093,7 @@ class TestSkillInvocation:
             _skill_use("tm2", "plan-review"),
         ])
         _write_jsonl(fake_projects / "s_multi_skill.jsonl", [rec])
-        out = self._run(fake_projects, capsys)
+        out = self._run(capsys)
         for line in out.splitlines():
             if line.startswith("code-review"):
                 assert int(line.split()[1]) == 1, f"code-review top-level count should be 1: {line!r}"
@@ -3107,7 +3107,7 @@ class TestSkillInvocation:
             branch="main",
         )
         _write_jsonl(fake_projects / "s_multi_slash.jsonl", [user_rec])
-        out = self._run(fake_projects, capsys)
+        out = self._run(capsys)
         for line in out.splitlines():
             if line.startswith("plan-it"):
                 assert int(line.split()[3]) >= 1, f"plan-it slash count should be ≥1: {line!r}"
@@ -3126,7 +3126,7 @@ class TestSkillInvocation:
             },
         }
         _write_jsonl(fake_projects / "s_list_content.jsonl", [user_rec])
-        out = self._run(fake_projects, capsys)
+        out = self._run(capsys)
         assert "plan-it" in out
         for line in out.splitlines():
             if line.startswith("plan-it"):
@@ -3140,13 +3140,86 @@ class TestSkillInvocation:
         routed_rec = _asst("claude-haiku-4-5", branch="main", content=[_skill_use("t10b", "code-review")])
         routed_rec["attributionSkill"] = "ready-for-review"
         _write_jsonl(fake_projects / "s10.jsonl", [top_rec, routed_rec])
-        out = self._run(fake_projects, capsys)
+        out = self._run(capsys)
         for line in out.splitlines():
             if line.startswith("code-review"):
                 parts = line.split()
                 assert int(parts[1]) == 1, f"expected top-level=1, got: {line!r}"
                 assert int(parts[2]) == 1, f"expected routed=1, got: {line!r}"
                 assert int(parts[4]) == 2, f"expected total=2, got: {line!r}"
+                break
+        else:
+            pytest.fail("code-review data row not found in output")
+
+    def test_sidechain_user_records_excluded_from_slash(self, fake_projects, capsys):
+        """User records with isSidechain=True are not scanned for slash invocations."""
+        sidechain_user = {
+            "type": "user",
+            "isSidechain": True,
+            "gitBranch": "main",
+            "message": {"content": "<command-name>/code-review</command-name>"},
+        }
+        _write_jsonl(fake_projects / "s_sidechain_user.jsonl", [sidechain_user])
+        out = self._run(capsys)
+        assert "No skill invocations found." in out
+
+    def test_sidechain_user_excluded_main_thread_user_counted(self, fake_projects, capsys):
+        """Mixed session: sidechain user slash is excluded, main-thread user slash is counted."""
+        sidechain_user = {
+            "type": "user",
+            "isSidechain": True,
+            "gitBranch": "main",
+            "message": {"content": "<command-name>/plan-review</command-name>"},
+        }
+        main_user = _user_msg("<command-name>/code-review</command-name>", branch="main")
+        _write_jsonl(fake_projects / "s_sidechain_mixed.jsonl", [sidechain_user, main_user])
+        out = self._run(capsys)
+        assert "code-review" in out, "main-thread slash should be counted"
+        assert "plan-review" not in out, "sidechain slash should be excluded"
+        for line in out.splitlines():
+            if line.startswith("code-review"):
+                assert int(line.split()[3]) == 1, f"expected slash=1, got: {line!r}"
+                break
+        else:
+            pytest.fail("code-review data row not found in output")
+
+    def test_multiple_skill_blocks_on_routed_record(self, fake_projects, capsys):
+        """An attributed record with two Skill tool_use blocks counts both as routed, not top-level."""
+        rec = _asst("claude-haiku-4-5", branch="main", content=[
+            _skill_use("tr1", "code-review"),
+            _skill_use("tr2", "plan-review"),
+        ])
+        rec["attributionSkill"] = "ready-for-review"
+        _write_jsonl(fake_projects / "s_multi_routed.jsonl", [rec])
+        out = self._run(capsys)
+        for line in out.splitlines():
+            if line.startswith("code-review"):
+                parts = line.split()
+                assert int(parts[1]) == 0, f"code-review top-level should be 0: {line!r}"
+                assert int(parts[2]) == 1, f"code-review routed should be 1: {line!r}"
+            if line.startswith("plan-review"):
+                parts = line.split()
+                assert int(parts[1]) == 0, f"plan-review top-level should be 0: {line!r}"
+                assert int(parts[2]) == 1, f"plan-review routed should be 1: {line!r}"
+
+    def test_cross_project_aggregation(self, tmp_path, monkeypatch, capsys):
+        """Default glob aggregates counts across multiple project directories."""
+        projects = tmp_path / "projects"
+        proj_a = projects / "-home-user-repoA"
+        proj_b = projects / "-home-user-repoB"
+        proj_a.mkdir(parents=True)
+        proj_b.mkdir(parents=True)
+        monkeypatch.setattr(_mod, "PROJECTS_DIR", projects)
+        rec_a = _asst("claude-sonnet-4-6", branch="main", content=[_skill_use("tc1", "code-review")])
+        rec_b = _asst("claude-sonnet-4-6", branch="main", content=[_skill_use("tc2", "code-review")])
+        _write_jsonl(proj_a / "s_a.jsonl", [rec_a])
+        _write_jsonl(proj_b / "s_b.jsonl", [rec_b])
+        args = argparse.Namespace(projects="*")
+        _mod.cmd_skill_invocation(args)
+        out = capsys.readouterr().out
+        for line in out.splitlines():
+            if line.startswith("code-review"):
+                assert int(line.split()[1]) == 2, f"expected 2 top-level from both projects: {line!r}"
                 break
         else:
             pytest.fail("code-review data row not found in output")

--- a/claude/.claude/scripts/transcript-analysis.py
+++ b/claude/.claude/scripts/transcript-analysis.py
@@ -867,7 +867,7 @@ def cmd_skill_invocation(args: argparse.Namespace) -> None:
                         routed_pairs[(attribution, skill)] += 1
                     else:
                         skill_top[skill] += 1
-            elif rec.get("type") == "user":
+            elif rec.get("type") == "user" and not bool(rec.get("isSidechain")):
                 content_raw = (rec.get("message") or {}).get("content", "")
                 content_str = content_raw if isinstance(content_raw, str) else _content_text(content_raw)
                 for m in re.finditer(r"<command-name>/([^<]+)</command-name>", content_str):

--- a/claude/.claude/scripts/transcript-analysis.py
+++ b/claude/.claude/scripts/transcript-analysis.py
@@ -829,6 +829,106 @@ def cmd_review_trace(args: argparse.Namespace) -> None:
                 print(f"  [{ts_label}] line {lno:>5}  reviewer     {evt['subagent_type']}")
 
 
+def cmd_skill_invocation(args: argparse.Namespace) -> None:
+    """Per-skill invocation-source tally across the full corpus.
+
+    Three invocation buckets are counted per skill:
+    - top-level: Skill tool_use on a main-thread assistant turn with no attributionSkill.
+    - routed: Skill tool_use on a main-thread assistant turn where attributionSkill is
+      non-empty (the call was fired while another skill's body was active).
+    - user-slash: user record whose message content contains a
+      <command-name>/skillname</command-name> tag (the /slash invocation path, which
+      injects the skill body directly without a Skill tool_use).
+
+    Identifies routed-only candidates (zero top-level or slash) and slash-only candidates
+    (zero top-level or routed) for skill-description budget analysis.
+    """
+    projects_glob = _projects_glob(args)
+
+    skill_top: dict[str, int] = defaultdict(int)    # skill -> top-level invocation count
+    skill_routed: dict[str, int] = defaultdict(int)  # skill -> routed invocation count
+    skill_slash: dict[str, int] = defaultdict(int)   # skill -> user-slash invocation count
+    routed_pairs: dict[tuple[str, str], int] = defaultdict(int)  # (parent, child) -> count
+
+    for _jsonl, records in iter_sessions(PROJECTS_DIR, projects_glob):
+        for rec in records:
+            if rec.get("type") == "assistant" and not bool(rec.get("isSidechain")):
+                for block in ((rec.get("message") or {}).get("content") or []):
+                    if not isinstance(block, dict) or block.get("type") != "tool_use":
+                        continue
+                    if block.get("name") != "Skill":
+                        continue
+                    skill = (block.get("input") or {}).get("skill") or ""
+                    if not skill:
+                        continue
+                    attribution = rec.get("attributionSkill") or ""
+                    if attribution:
+                        skill_routed[skill] += 1
+                        routed_pairs[(attribution, skill)] += 1
+                    else:
+                        skill_top[skill] += 1
+            elif rec.get("type") == "user":
+                content_raw = (rec.get("message") or {}).get("content", "")
+                content_str = content_raw if isinstance(content_raw, str) else _content_text(content_raw)
+                for m in re.finditer(r"<command-name>/([^<]+)</command-name>", content_str):
+                    skill_slash[m.group(1)] += 1
+
+    all_skills: set[str] = set(skill_top) | set(skill_routed) | set(skill_slash)
+
+    if not all_skills:
+        print("No skill invocations found.")
+        return
+
+    # Sort by total descending, then alphabetically for ties.
+    def _skill_total(s: str) -> int:
+        return skill_top[s] + skill_routed[s] + skill_slash[s]
+
+    sorted_skills = sorted(all_skills, key=lambda s: (-_skill_total(s), s))
+
+    print("SKILL INVOCATION SOURCES (full corpus)")
+    header = f"{'skill':<40} {'top-level':>10}  {'routed':>6}  {'user-slash':>10}  {'total':>7}"
+    print(header)
+    print("-" * len(header))
+    for skill in sorted_skills:
+        top = skill_top[skill]
+        routed = skill_routed[skill]
+        slash = skill_slash[skill]
+        total = top + routed + slash
+        print(f"{skill:<40} {top:>10}  {routed:>6}  {slash:>10}  {total:>7}")
+
+    if routed_pairs:
+        print("\nROUTED PAIRS (parent -> child : count)")
+        for (parent, child), count in sorted(routed_pairs.items(), key=lambda kv: (-kv[1], kv[0])):
+            print(f"  {parent} -> {child} : {count}")
+
+    # Classification summary: load-bearing, routed-only, slash-only.
+    load_bearing = [s for s in sorted_skills if skill_top[s] > 0 or skill_slash[s] > 0]
+    routed_only = [s for s in sorted_skills if skill_top[s] == 0 and skill_slash[s] == 0 and skill_routed[s] > 0]
+    slash_only = [s for s in sorted_skills if skill_top[s] == 0 and skill_routed[s] == 0 and skill_slash[s] > 0]
+
+    print("\nCLASSIFICATION SUMMARY")
+    print("  Load-bearing (any top-level or slash invocations):")
+    if load_bearing:
+        for s in load_bearing:
+            print(f"    {s} ({skill_top[s]} top, {skill_slash[s]} slash)")
+    else:
+        print("    (none)")
+
+    print("  Routed-only candidates (zero top-level and zero slash — name-only eligible):")
+    if routed_only:
+        for s in routed_only:
+            print(f"    {s} (0 top, {skill_routed[s]} routed, 0 slash)")
+    else:
+        print("    (none)")
+
+    print("  Slash-only candidates (zero top, zero routed — disable-model-invocation eligible):")
+    if slash_only:
+        for s in slash_only:
+            print(f"    {s} (0 top, 0 routed, {skill_slash[s]} slash)")
+    else:
+        print("    (none)")
+
+
 def cmd_subagent_mix(args: argparse.Namespace) -> None:
     projects_glob = _projects_glob(args)
     branch_filter = _branch_filter(args)
@@ -2152,6 +2252,17 @@ def main() -> None:
     )
     p_gate.add_argument("--branches", metavar="B1,B2,...", help="Branch name filter (default: all)")
     p_gate.set_defaults(func=cmd_commit_gate)
+
+    p_skill_inv = sub.add_parser(
+        "skill-invocation",
+        help=(
+            "Per-skill invocation-source tally: top-level (description-dependent auto-trigger),"
+            " routed (fired while another skill's body was active), and user /slash commands."
+            " Identifies name-only and disable-model-invocation candidates for budget relief."
+        ),
+    )
+    p_skill_inv.add_argument("--projects", default="*", metavar="GLOB")
+    p_skill_inv.set_defaults(func=cmd_skill_invocation)
 
     p_review_trace = sub.add_parser(
         "review-trace",

--- a/docs/transcript-analysis.md
+++ b/docs/transcript-analysis.md
@@ -218,6 +218,44 @@ bin          sessions   turns  skill-inv  skill/1k commits  w-skill  wo-skill  n
 
 ---
 
+## skill-invocation
+
+**Purpose.** Per-skill invocation-source tally across the full corpus, split into three buckets: `top-level` (description-triggered Skill tool_use on a main-thread turn with no parent skill active), `routed` (Skill tool_use fired while another skill's body was active — `attributionSkill` is non-empty), and `user-slash` (user record containing `<command-name>/skillname</command-name>`, the `/slash` invocation path). The classification summary at the bottom identifies routed-only candidates (name-only eligible) and slash-only candidates (disable-model-invocation eligible) for skill-description budget analysis.
+
+**Flags.**
+- `--projects GLOB` — project directory glob (default: `*`, all projects)
+
+**Sample output.**
+```
+SKILL INVOCATION SOURCES (full corpus)
+skill                                    top-level  routed  user-slash    total
+--------------------------------------------------------------------------------
+code-review                                    207       8           2      217
+plan-review                                     91       4           5      100
+subagent-delegation                             44       0           0       44
+skill-review                                     0      38           1       39
+ready-for-review                                 0       3          31       34
+
+ROUTED PAIRS (parent -> child : count)
+  code-review -> skill-review : 38
+
+CLASSIFICATION SUMMARY
+  Load-bearing (any top-level or slash invocations):
+    code-review (207 top, 2 slash)
+    plan-review (91 top, 5 slash)
+    subagent-delegation (44 top, 0 slash)
+    ready-for-review (0 top, 31 slash)
+    skill-review (0 top, 1 slash)
+  Routed-only candidates (zero top-level and zero slash — name-only eligible):
+    (none)
+  Slash-only candidates (zero top, zero routed — disable-model-invocation eligible):
+    (none)
+```
+
+**When to reach for it.** Audit which skills are reaching users via description-matching versus only via explicit `/slash` invocation or routing from a parent skill. The classification summary surfaces routed-only candidates (their description never independently fires — name-only conversion saves description-budget tokens) and slash-only candidates (only reach users via explicit command — disable-model-invocation conversion is safe).
+
+---
+
 ## review-trace
 
 **Purpose.** Emit an ordered event timeline per session — skill invocations, hook denials, and reviewer-agent spawns.


### PR DESCRIPTION
## Summary

- Adds `skill-invocation` subcommand to `transcript-analysis.py` — tallies per-skill invocation counts across three buckets: top-level (description-driven auto-trigger), routed (fired while another skill's body was active via `attributionSkill`), and user-slash (`<command-name>` tag in user records)
- Reports routed pairs and a classification summary (load-bearing, routed-only, slash-only candidates) useful for skill-description budget analysis
- 20 tests covering all three buckets, sidechain exclusion (assistant and user records), edge cases (empty skill field, multi-block records), project filtering, cross-project aggregation, and mixed-session invariants
- Adds `skill-invocation` reference section to `docs/transcript-analysis.md` with purpose, flags, sample output, and when-to-reach-for-it guidance

## Test plan

- [ ] Run `transcript-analysis.py skill-invocation` against real corpus and verify the three columns and classification summary look plausible
- [ ] Confirm routed-only candidates list matches known dispatcher-only skill invocations

<!-- code-review:deferred:start -->
## Deferred review findings

| Finding | Source | DEFER criterion | Rationale |
|---------|--------|-----------------|-----------|
| Output-parsing via `split()[N]` in test assertions is format-coupled — column-width or column-order changes break assertions simultaneously rather than the counting logic they intend to cover | staff-sdet | Orthogonal scope | Format coupling is a test-maintenance concern; counting correctness is covered by the tests; restructuring assertions to read module-level dicts instead of formatted strings is disproportionate to the regression risk |
<!-- code-review:deferred:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)