### PR TITLE
feat(skills): convert 4 utility skills to skillOverrides: name-only

### DIFF
--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -39,6 +39,10 @@
   },
   "model": "opusplan",
   "skillOverrides": {
+    "brief": "name-only",
+    "handoff": "name-only",
+    "read-docx-comments": "name-only",
+    "transcript-analysis": "name-only",
     "claude-api": "off",
     "fewer-permission-prompts": "off",
     "init": "off",

--- a/claude/.claude/skills/brief/SKILL.md
+++ b/claude/.claude/skills/brief/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: brief
 description: Produce a cold-start task briefing at /tmp/<slug>-task.md for a fresh session to pick up known, well-scoped work (abandoned PR, surfaced follow-up, ticket whose scope is settled). Distinct from /handoff, which captures mid-flight session state.
-disable-model-invocation: true
 ---
 
 Write a cold-start task briefing at `/tmp/<descriptive-slug>-task.md` using the structure below. A fresh session — with no memory of the originating conversation — must be able to read the file and execute the work.

--- a/claude/.claude/skills/handoff/SKILL.md
+++ b/claude/.claude/skills/handoff/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: handoff
 description: Write a cross-session handoff file at /tmp/<descriptive-slug>-handoff.md capturing goal, status, next step, files modified, active markers, open questions, and resume command.
-disable-model-invocation: true
 ---
 
 Write a cross-session handoff file at `/tmp/<descriptive-slug>-handoff.md` using the structure below.

--- a/claude/.claude/skills/read-docx-comments/SKILL.md
+++ b/claude/.claude/skills/read-docx-comments/SKILL.md
@@ -2,7 +2,6 @@
 name: read-docx-comments
 description: Extract all comments from a .docx file (Google Docs / Word feedback) and present them grouped by document location with author and anchored text.
 argument-hint: "<path/to/file.docx>"
-disable-model-invocation: true
 ---
 
 Extract all comments from the provided .docx file. The user uses this to give feedback on plans and documents by adding comments in Google Docs / Word.

--- a/claude/.claude/skills/tests/test_skills.py
+++ b/claude/.claude/skills/tests/test_skills.py
@@ -142,10 +142,9 @@ def _model_invokable_skills() -> list[str]:
     """Discover all skills whose descriptions auto-load into the model's context budget.
 
     A skill auto-loads when its frontmatter does NOT contain
-    disable-model-invocation: true AND it is not listed as name-only (or off /
-    user-invocable-only) in skillOverrides. These skills must carry TRIGGER
-    when: / DO NOT TRIGGER when: discipline so the harness fires them at the
-    right time.
+    disable-model-invocation: true AND it is not listed as name-only in
+    skillOverrides. These skills must carry TRIGGER when: / DO NOT TRIGGER
+    when: discipline so the harness fires them at the right time.
 
     name-only skills are excluded: their descriptions are not in the budget, so
     description-based auto-triggering is disabled and no TRIGGER blocks apply.
@@ -284,6 +283,15 @@ class TestNameOnlySkillContracts:
     """
 
     NAME_ONLY_SKILLS = _name_only_skills()
+
+    @pytest.mark.parametrize("skill_name", NAME_ONLY_SKILLS)
+    def test_name_only_skill_has_skill_file(self, skill_name):
+        """name-only skills listed in skillOverrides must have an existing SKILL.md."""
+        skill_path = _skill_file(skill_name)
+        assert skill_path.exists(), (
+            f"{skill_name} is listed as name-only in skillOverrides but has no "
+            f"SKILL.md at {skill_path}. Remove the skillOverrides entry or create the SKILL.md."
+        )
 
     @pytest.mark.parametrize("skill_name", NAME_ONLY_SKILLS)
     def test_name_only_skill_does_not_carry_disable_flag(self, skill_name):

--- a/claude/.claude/skills/tests/test_skills.py
+++ b/claude/.claude/skills/tests/test_skills.py
@@ -1,13 +1,18 @@
 """Static contract tests for skill SKILL.md description fields.
 
-Skills in this repo fall into three invocation categories:
+Skills in this repo fall into four invocation categories:
 - Model-invokable (default): the Claude Code harness reads the frontmatter
   `description` at session start and auto-loads the skill body when the
   description matches context. These skills MUST carry TRIGGER when: /
   DO NOT TRIGGER when: discipline so the harness fires at the right time.
-- User-only commands (disable-model-invocation: true): descriptions are
-  suppressed from the always-loaded listing budget; the user invokes directly
-  via /skill-name. These skills must be registered in COMMAND_SKILLS.
+- name-only (skillOverrides: name-only in settings.json): description excluded
+  from the always-loaded listing budget; the model can still invoke by exact
+  name when referenced in conversation. No TRIGGER discipline required (no
+  description to match on). Also slash-invocable by the user. Controlled via
+  settings.json, not frontmatter — must NOT carry disable-model-invocation: true.
+- User-only commands (disable-model-invocation: true): description excluded from
+  the listing budget; only the user can invoke via /skill-name. Must be
+  registered in COMMAND_SKILLS.
 - Model-only reference (user-invocable: false): invoked by model auto-trigger
   only; same TRIGGER discipline requirement as default.
 
@@ -23,6 +28,7 @@ docs/skills.md "Project-specific layers" for rationale.
 Contracts enforced:
 (a) Every model-invokable skill has TRIGGER when: and DO NOT TRIGGER when:.
 (b) Every registered command skill carries disable-model-invocation: true.
+(c) Every name-only skill does NOT carry disable-model-invocation: true.
 
 Run with: pytest claude/.claude/
 """
@@ -109,18 +115,49 @@ def _specialist_skills() -> list[str]:
     return skills
 
 
-def _model_invokable_skills() -> list[str]:
-    """Discover all skills the model can auto-load — i.e., NOT disable-model-invocation: true.
+def _settings_skill_overrides() -> dict[str, str]:
+    """Read skillOverrides from the stowed settings.json.
 
-    Any skill without disable-model-invocation: true is presented to the model
-    in the always-loaded skill listing and must carry TRIGGER when: / DO NOT
-    TRIGGER when: discipline so the harness fires it at the right time.
+    Returns the override map keyed by skill name. Skills absent from the map
+    default to "on" (fully model-invokable with description in budget).
     """
+    settings_path = Path(__file__).resolve().parents[4] / "claude/.claude/settings.json"
+    settings = json.loads(settings_path.read_text())
+    return settings.get("skillOverrides", {})
+
+
+def _name_only_skills() -> list[str]:
+    """Skills with skillOverrides: name-only in settings.json.
+
+    These skills are model-invokable by exact name but their descriptions are
+    excluded from the always-loaded listing budget — the harness shows only the
+    skill name to the model, so auto-triggering from description matching is
+    disabled. Also slash-invocable by the user. No TRIGGER discipline required.
+    """
+    overrides = _settings_skill_overrides()
+    return [name for name, state in overrides.items() if state == "name-only"]
+
+
+def _model_invokable_skills() -> list[str]:
+    """Discover all skills whose descriptions auto-load into the model's context budget.
+
+    A skill auto-loads when its frontmatter does NOT contain
+    disable-model-invocation: true AND it is not listed as name-only (or off /
+    user-invocable-only) in skillOverrides. These skills must carry TRIGGER
+    when: / DO NOT TRIGGER when: discipline so the harness fires them at the
+    right time.
+
+    name-only skills are excluded: their descriptions are not in the budget, so
+    description-based auto-triggering is disabled and no TRIGGER blocks apply.
+    """
+    budget_excluded = set(_name_only_skills())
     skills = []
     for skill_dir in sorted(SKILLS_DIR.iterdir()):
         if not skill_dir.is_dir():
             continue
         if not (skill_dir / "SKILL.md").exists():
+            continue
+        if skill_dir.name in budget_excluded:
             continue
         frontmatter = _skill_description(skill_dir.name)
         if frontmatter and "disable-model-invocation: true" not in frontmatter:
@@ -135,6 +172,8 @@ def _model_invokable_skills() -> list[str]:
                     continue
                 if not (skill_dir / "SKILL.md").exists():
                     continue
+                if skill_dir.name in budget_excluded:
+                    continue
                 frontmatter = _skill_description(skill_dir.name)
                 if (
                     frontmatter
@@ -145,12 +184,14 @@ def _model_invokable_skills() -> list[str]:
     return skills
 
 
-# Explicit registry of user-only command skills. Each must carry
-# disable-model-invocation: true in its frontmatter so the description is
-# suppressed from the model's always-loaded listing budget. Add to this list
-# whenever a new command-style skill (user-invoked slash workflow, no model
-# auto-discovery needed) is created under skills/.
-COMMAND_SKILLS = ["handoff", "read-docx-comments", "transcript-analysis"]
+# Explicit registry of user-only command skills that use the frontmatter
+# disable-model-invocation: true flag. Currently empty — the four former command
+# skills (brief, handoff, read-docx-comments, transcript-analysis) now use
+# skillOverrides: name-only, making them model-invokable by name while keeping
+# their descriptions out of the budget. Add to this list only when a new skill
+# needs strict slash-only access (no model invocation at all) via frontmatter
+# rather than skillOverrides.
+COMMAND_SKILLS: list[str] = []
 
 
 class TestSpecialistSkillTriggerContracts:
@@ -228,6 +269,30 @@ class TestSpecialistSkillTriggerContracts:
         assert "disable-model-invocation: true" in desc, (
             f"{skill_name}/SKILL.md is registered as a command skill but is missing "
             f"disable-model-invocation: true; add it or remove from COMMAND_SKILLS"
+        )
+
+
+class TestNameOnlySkillContracts:
+    """Contract tests for skills with skillOverrides: name-only.
+
+    These skills are model-invokable by exact name (the harness lists them by
+    name only, no description) but their descriptions are excluded from the
+    always-loaded listing budget. They must NOT carry disable-model-invocation:
+    true — skillOverrides: name-only is the single source of truth for their
+    invocation mode, and stacking the frontmatter flag would create ambiguous
+    precedence. See docs/skills.md "Skills available by name" for rationale.
+    """
+
+    NAME_ONLY_SKILLS = _name_only_skills()
+
+    @pytest.mark.parametrize("skill_name", NAME_ONLY_SKILLS)
+    def test_name_only_skill_does_not_carry_disable_flag(self, skill_name):
+        """name-only skills must not carry disable-model-invocation: true."""
+        desc = _skill_description(skill_name)
+        assert "disable-model-invocation: true" not in desc, (
+            f"{skill_name}/SKILL.md carries disable-model-invocation: true but is also "
+            f"set to name-only in skillOverrides. Remove the frontmatter flag — "
+            f"skillOverrides: name-only is the single source of truth for invocation control."
         )
 
 
@@ -500,14 +565,21 @@ def test_trigger_cases_files_well_formed() -> None:
 
 
 def test_skill_overrides_documented_in_docs_skills_md() -> None:
-    """Every disabled bundled skill in skillOverrides must have a row in docs/skills.md."""
+    """Every non-on skillOverride must have a table row in docs/skills.md.
+
+    Covers both "off" entries (bundled skills disabled) and "name-only" entries
+    (repo skills available by name without description budget cost). Each must
+    appear as a | `/<name>` | table row so its rationale is visible to contributors.
+    """
     repo_root = Path(__file__).resolve().parents[4]
     settings = json.loads((repo_root / "claude/.claude/settings.json").read_text())
     docs_text = (repo_root / "docs/skills.md").read_text()
-    for skill_name in settings.get("skillOverrides", {}):
+    for skill_name, state in settings.get("skillOverrides", {}).items():
+        if state == "on":
+            continue
         marker = f"| `/{skill_name}` |"
         assert marker in docs_text, (
-            f"skillOverrides has {skill_name!r} but docs/skills.md has no "
-            f"`{marker}` row. Every disabled bundled skill needs a rationale "
-            'row in the "Bundled skills disabled by default" table.'
+            f"skillOverrides has {skill_name!r} ({state!r}) but docs/skills.md has no "
+            f"`{marker}` row. Every non-on skillOverride entry needs a rationale row "
+            "in docs/skills.md."
         )

--- a/claude/.claude/skills/transcript-analysis/SKILL.md
+++ b/claude/.claude/skills/transcript-analysis/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: transcript-analysis
 description: Analyze Claude Code transcripts — model comparison by branch, test-failure convergence sequences, correction-signal frequency, active-vs-idle duration, subagent-vs-main turn split, PR-to-branch mapping, or per-session review-activity timelines (skill invocations, hook denials, reviewer spawns). For token-cost or cache-efficiency analysis use token-analyzer.py directly.
-disable-model-invocation: true
 ---
 
 The toolkit lives at `~/.claude/scripts/transcript-analysis.py`. Run it directly from the shell.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -19,12 +19,34 @@ Full descriptions for skills, slash commands, and project-scoped plugins in this
 - **`/sql-query-conventions`** — read-path conventions for SQL and PostgREST/Supabase queries: pagination, limits, N+1 avoidance, batch-size ceilings, explicit column selection.
 - **`/ai-instruction-and-memory-files`** — how AI coding agents load instruction files (CLAUDE.md, AGENTS.md, Cursor rules, Lovable knowledge) and Claude Code auto-memory: precedence, duplication rules, length targets, import patterns.
 - **`/verify-primary-sources`** — when web research informs a code or design decision, read the primary documentation directly rather than trusting agent summaries or secondary sources.
-- **`/handoff`** — write a structured cross-session handoff file at `/tmp/<slug>-handoff.md` capturing goal, status, next step, modified files, active markers, open questions, and the resume incantation. User-invoked only — implemented at `claude/.claude/skills/handoff/SKILL.md` with `disable-model-invocation: true`, which suppresses the description from the always-loaded skill listing budget while preserving slash invocation.
-- **`/brief`** — write a cold-start task briefing at `/tmp/<slug>-task.md` for a fresh session to pick up known, well-scoped work (abandoned PR, surfaced follow-up, settled-scope ticket) — covers goal, scope, anchors, current state, decisions to make, steps to ship, out of scope. Distinct from `/handoff`, which captures mid-flight session state; `/brief` is for work the current session is *not* going to do. User-invoked only — implemented at `claude/.claude/skills/brief/SKILL.md` with `disable-model-invocation: true`.
-- **`/read-docx-comments`** — extract comments from `.docx` files with anchored text context. User-invoked only — implemented at `claude/.claude/skills/read-docx-comments/SKILL.md` with `disable-model-invocation: true`, which suppresses the description from the always-loaded skill listing budget while preserving slash invocation.
-- **`/transcript-analysis`** — reference guidance for the `transcript-analysis.py` toolkit: which subcommand answers which analysis question, how to read `fail-seq` convergence-vs-thrashing output, and the measurement caveats. `disable-model-invocation: true` — user-invoked only.
+- **`/handoff`** — write a structured cross-session handoff file at `/tmp/<slug>-handoff.md` capturing goal, status, next step, modified files, active markers, open questions, and the resume incantation. Model-invocable by exact name; description excluded from the listing budget via `skillOverrides: name-only` — see [Skills available by name](#skills-available-by-name-no-description-budget-cost).
+- **`/brief`** — write a cold-start task briefing at `/tmp/<slug>-task.md` for a fresh session to pick up known, well-scoped work (abandoned PR, surfaced follow-up, settled-scope ticket) — covers goal, scope, anchors, current state, decisions to make, steps to ship, out of scope. Distinct from `/handoff`, which captures mid-flight session state; `/brief` is for work the current session is *not* going to do. Model-invocable by exact name; description excluded from the listing budget via `skillOverrides: name-only`.
+- **`/read-docx-comments`** — extract comments from `.docx` files with anchored text context. Model-invocable by exact name; description excluded from the listing budget via `skillOverrides: name-only`.
+- **`/transcript-analysis`** — reference guidance for the `transcript-analysis.py` toolkit: which subcommand answers which analysis question, how to read `fail-seq` convergence-vs-thrashing output, and the measurement caveats. Model-invocable by exact name; description excluded from the listing budget via `skillOverrides: name-only`.
 
 Each skill lives in `claude/.claude/skills/<skill-name>/SKILL.md`. A skill directory may also contain co-located auxiliary files — see architecture notes below for the two distinct roles they play. Skills that primarily apply to this repo's own workflow (editing SKILL.md files, authoring hooks) live as project-scoped plugins instead — see [Project-scoped plugins](#project-scoped-plugins) below.
+
+## Skills available by name (no description budget cost)
+
+Four repo skills use `skillOverrides: name-only` — the model can invoke them when referenced by name in conversation, but their descriptions are excluded from the always-loaded listing budget. These skills are also slash-invocable directly. Requires Claude Code **v2.1.129+**; on older clients the override is silently ignored and these skills fall back to `on` (description loaded, weak auto-trigger since they carry no TRIGGER blocks).
+
+| Skill | Role |
+|---|---|
+| `/brief` | Cold-start task briefing for a fresh session to pick up well-scoped work |
+| `/handoff` | Cross-session handoff file capturing mid-flight session state |
+| `/read-docx-comments` | Extract comments from `.docx` files (Google Docs / Word feedback) |
+| `/transcript-analysis` | Reference guide for the `transcript-analysis.py` toolkit |
+
+The `skillOverrides` setting controls skill visibility from settings rather than frontmatter. The four values (Claude Code v2.1.129+):
+
+| Override value | Listed to model | Model can invoke | Description in budget | In `/` menu |
+|---|---|---|---|---|
+| `on` (default) | name + description | yes (auto-triggers) | yes | yes |
+| `name-only` | name only | yes, by name | no | yes |
+| `user-invocable-only` | hidden | no | no | yes |
+| `off` | hidden | no | no | no |
+
+Source: [Claude Code settings — skillOverrides](https://code.claude.com/docs/en/settings) · [Override skill visibility from settings](https://code.claude.com/docs/en/skills#override-skill-visibility-from-settings).
 
 ## Bundled skills disabled by default
 


### PR DESCRIPTION
## Summary

- Remove `disable-model-invocation: true` from `brief`, `handoff`, `read-docx-comments`, and `transcript-analysis` — the four former slash-only command skills now use `skillOverrides: name-only` in `settings.json` instead
- Add `name-only` entries to `settings.json` `skillOverrides` block for all four skills
- Expand `test_skills.py` to model the new invocation category: `_settings_skill_overrides()` + `_name_only_skills()` helpers, `TestNameOnlySkillContracts` class (positive SKILL.md existence + no-disable-flag tests), and `_model_invokable_skills()` updated to exclude name-only from TRIGGER-block enforcement
- Add "Skills available by name" section and four-value override reference table to `docs/skills.md`

**Why:** `skillOverrides: name-only` (v2.1.129+) lets the model invoke these skills by exact name without loading their descriptions into the always-on listing budget. The previous `disable-model-invocation: true` flag prevented model invocation entirely; `name-only` enables name-based invocation while keeping descriptions out of budget — a strictly better tradeoff for skills that are useful in mid-session but not worth auto-trigger description cost.

## Test plan

- [x] `../../../.venv/bin/pytest claude/.claude/` passes (verified in this PR: 1628+ passed)
- [x] `../../../.venv/bin/ruff check claude/.claude/` passes (verified in this PR: clean)
- [ ] In a Claude Code session (v2.1.129+): invoke `/brief`, `/handoff`, `/read-docx-comments`, `/transcript-analysis` by name — all should fire without description in the always-loaded listing
- [ ] Confirm `/skills` menu still shows all four skills (they remain slash-invocable via `name-only`)

<!-- code-review:deferred:start -->
## Deferred review findings

| Finding | Source | DEFER criterion | Rationale |
|---|---|---|---|
| `COMMAND_SKILLS = []` produces skipped parametrize tests; a new skill with `disable-model-invocation: true` not added to `COMMAND_SKILLS` would fail silently | staff-sdet Q1 (cumulative review) | Orthogonal scope | No command skills exist today; a forward-looking guard for a category with zero current members is outside this PR's scope |

<!-- code-review:deferred:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)