### PR TITLE
feat(lovable-cloud-knowledge): extend skill to cover workspace skills + 100k char limit

### DIFF
--- a/plugins/lovable-cloud/.claude-plugin/plugin.json
+++ b/plugins/lovable-cloud/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lovable-cloud",
   "description": "Skills for Lovable Cloud projects — Project/Workspace Knowledge fields, edge-function auth model, and migration-sync workflow.",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "author": {
     "name": "Cordova Strategy"
   },

--- a/plugins/lovable-cloud/skills/lovable-cloud-knowledge/REFERENCES.md
+++ b/plugins/lovable-cloud/skills/lovable-cloud-knowledge/REFERENCES.md
@@ -13,9 +13,10 @@ Effective priority (highest to lowest):
 
 All four are loaded every session. Lovable docs warn that in very long conversations instructions can drift; the "always read" guarantee for AGENTS.md is the defense-in-depth.
 
-## Primary source
+## Primary sources
 
 - [Lovable Docs — Knowledge](https://docs.lovable.dev/features/knowledge) — canonical reference for all Lovable knowledge-field behavior.
+- [Lovable Docs — Skills](https://docs.lovable.dev/features/skills) — canonical reference for Lovable workspace-skill behavior.
 
 ## Source quotes
 
@@ -30,6 +31,12 @@ All four are loaded every session. Lovable docs warn that in very long conversat
 ### Project vs Workspace tiebreaker (informs SKILL §1)
 
 > "Keep shared rules in workspace knowledge and project-specific details in project knowledge to avoid confusion and maximize clarity."
+
+### Workspace-skill limits (informs SKILL §1 table, §3, §4 items 6–8)
+
+> "The full `SKILL.md`, including the description and instructions, can be up to 100,000 characters."
+
+> "Use lowercase letters, numbers, and hyphens only" — names must be "between 1 and 64 characters," cannot "start or end with a hyphen, and cannot contain consecutive hyphens."
 
 ## Cross-agent context
 

--- a/plugins/lovable-cloud/skills/lovable-cloud-knowledge/SKILL.md
+++ b/plugins/lovable-cloud/skills/lovable-cloud-knowledge/SKILL.md
@@ -76,7 +76,7 @@ When reviewing a PR that touches `.lovable/*.md` or `.lovable/skills/*.md`:
 3. **Scope** — Cross-project conventions → `workspace-knowledge.md`;
    this-app-specific → `project-knowledge.md`. Project knowledge wins
    on conflict.
-4. **Char budget** — Is the knowledge file approaching the 10,000-char limit?
+4. **Char budget** — Is the file approaching its char limit? (Check the table above.)
 5. **Sync status** — If `project-knowledge.md` or
    `workspace-knowledge.md` changed, has the "Last synced" date been
    bumped in the same PR? Does the PR description note that the human
@@ -87,7 +87,5 @@ For `.lovable/skills/*.md` changes, also check:
 6. **Skill name** — Is the name 1–64 chars, lowercase letters / numbers /
    hyphens only, not starting or ending with a hyphen, with no consecutive
    hyphens?
-7. **Skill body char budget** — Is the body (description + instructions)
-   within the 100,000-char limit?
-8. **Skills sync status** — Does the PR description note that the skill
+7. **Skills sync status** — Does the PR description note that the skill
    body must be pasted into Lovable Settings → Skills to take effect?

--- a/plugins/lovable-cloud/skills/lovable-cloud-knowledge/SKILL.md
+++ b/plugins/lovable-cloud/skills/lovable-cloud-knowledge/SKILL.md
@@ -77,11 +77,10 @@ When reviewing a PR that touches `.lovable/*.md` or `.lovable/skills/*.md`:
    this-app-specific → `project-knowledge.md`. Project knowledge wins
    on conflict.
 4. **Char budget** — Is the file approaching its char limit? (Check the table above.)
-5. **Sync status** — Does the PR description note that the human must
-   paste the merged content into the Lovable UI after merge? (Knowledge
-   files → Settings → Knowledge; skill bodies → Settings → Skills.) For
-   knowledge files, also verify the "Last synced" date is bumped in the
-   same PR.
+5. **Sync status** — Has the "Last synced" date been bumped in the same
+   PR? Does the PR description note that the human must paste the merged
+   content into the Lovable UI after merge? (Knowledge files → Settings →
+   Knowledge; skill bodies → Settings → Skills.)
 
 For `.lovable/skills/*.md` changes, also check:
 

--- a/plugins/lovable-cloud/skills/lovable-cloud-knowledge/SKILL.md
+++ b/plugins/lovable-cloud/skills/lovable-cloud-knowledge/SKILL.md
@@ -77,15 +77,14 @@ When reviewing a PR that touches `.lovable/*.md` or `.lovable/skills/*.md`:
    this-app-specific → `project-knowledge.md`. Project knowledge wins
    on conflict.
 4. **Char budget** — Is the file approaching its char limit? (Check the table above.)
-5. **Sync status** — If `project-knowledge.md` or
-   `workspace-knowledge.md` changed, has the "Last synced" date been
-   bumped in the same PR? Does the PR description note that the human
-   needs to paste the merged content into the Lovable UI?
+5. **Sync status** — Does the PR description note that the human must
+   paste the merged content into the Lovable UI after merge? (Knowledge
+   files → Settings → Knowledge; skill bodies → Settings → Skills.) For
+   knowledge files, also verify the "Last synced" date is bumped in the
+   same PR.
 
 For `.lovable/skills/*.md` changes, also check:
 
 6. **Skill name** — Is the name 1–64 chars, lowercase letters / numbers /
    hyphens only, not starting or ending with a hyphen, with no consecutive
    hyphens?
-7. **Skills sync status** — Does the PR description note that the skill
-   body must be pasted into Lovable Settings → Skills to take effect?

--- a/plugins/lovable-cloud/skills/lovable-cloud-knowledge/SKILL.md
+++ b/plugins/lovable-cloud/skills/lovable-cloud-knowledge/SKILL.md
@@ -3,8 +3,8 @@ name: lovable-cloud-knowledge
 description: >
   Lovable's UI knowledge fields — `.lovable/*.md` repo-mirror workflow,
   Project/Workspace scope split, precedence, review criteria.
-  TRIGGER when: editing `.lovable/*.md`; drafting Project/Workspace Knowledge
-  changes; reviewing `.lovable/**` PRs.
+  TRIGGER when: editing `.lovable/*.md` or `.lovable/skills/*.md`; drafting
+  Project/Workspace Knowledge or workspace-skill changes; reviewing `.lovable/**` PRs.
   DO NOT TRIGGER when: not a Lovable project; editing CLAUDE.md or AGENTS.md;
   editing agent rules files; writing code.
 user-invocable: false
@@ -12,14 +12,14 @@ user-invocable: false
 
 # Lovable Knowledge — Workflow & Review
 
-## 1. Project Knowledge vs Workspace Knowledge
+## 1. Knowledge fields and Workspace Skills
 
-| | Workspace Knowledge | Project Knowledge |
-|---|---|---|
-| Scope | Cross-project (the Lovable workspace) | Single-project |
-| Use for | Coding style, naming, libraries/frameworks, architectural patterns, testing requirements, lint rules, brand/voice, **Lovable-platform behavior** | What the app does, user personas, schema/tables, architecture decisions, domain terminology, project-specific constraints, design specifics, security/compliance, links to important references |
-| Precedence | — | **Prioritized on conflict** |
-| Char limit | 10,000 | 10,000 |
+| | Workspace Knowledge | Project Knowledge | Workspace Skills |
+|---|---|---|---|
+| Scope | Cross-project (the Lovable workspace) | Single-project | Cross-project (the Lovable workspace) |
+| Use for | Coding style, naming, libraries/frameworks, architectural patterns, testing requirements, lint rules, brand/voice, **Lovable-platform behavior** | What the app does, user personas, schema/tables, architecture decisions, domain terminology, project-specific constraints, design specifics, security/compliance, links to important references | Reusable procedures Lovable runs on demand |
+| Precedence | — | **Prioritized on conflict** | — |
+| Char limit | 10,000 | 10,000 | **100,000** |
 
 When a rule could plausibly fit in either: ask whether it would apply to
 a *different* project in the same Lovable workspace. If yes →
@@ -59,14 +59,15 @@ When writing content for either field:
 - **Specificity.** Lovable follows literally and may over-apply vague
   guidance. "Be careful with auth" can become "add auth checks to public
   endpoints." Spell out the boundary cases.
-- **Context budget.** Both fields cap at 10,000 chars. Beyond that,
-  Lovable drops content. Even before the cap, length displaces active
-  task instructions — apply the same length and behavior-test discipline
-  as Claude Code skills (see `ai-instruction-and-memory-files` §3).
+- **Context budget.** Both knowledge fields cap at 10,000 chars. Beyond
+  that, Lovable drops content. Skill bodies (`.lovable/skills/*.md`) have
+  a separate 100,000-char limit. Even before either cap, length displaces
+  active task instructions — apply the same length and behavior-test
+  discipline as Claude Code skills (see `ai-instruction-and-memory-files` §3).
 
 ## 4. Review checklist for `.lovable/**` changes
 
-When reviewing a PR that touches `.lovable/*.md`:
+When reviewing a PR that touches `.lovable/*.md` or `.lovable/skills/*.md`:
 
 1. **Perspective** — Is the new content addressed to Lovable in second
    person?
@@ -75,8 +76,18 @@ When reviewing a PR that touches `.lovable/*.md`:
 3. **Scope** — Cross-project conventions → `workspace-knowledge.md`;
    this-app-specific → `project-knowledge.md`. Project knowledge wins
    on conflict.
-4. **Char budget** — Is the file approaching the 10,000-char limit?
+4. **Char budget** — Is the knowledge file approaching the 10,000-char limit?
 5. **Sync status** — If `project-knowledge.md` or
    `workspace-knowledge.md` changed, has the "Last synced" date been
    bumped in the same PR? Does the PR description note that the human
    needs to paste the merged content into the Lovable UI?
+
+For `.lovable/skills/*.md` changes, also check:
+
+6. **Skill name** — Is the name 1–64 chars, lowercase letters / numbers /
+   hyphens only, not starting or ending with a hyphen, with no consecutive
+   hyphens?
+7. **Skill body char budget** — Is the body (description + instructions)
+   within the 100,000-char limit?
+8. **Skills sync status** — Does the PR description note that the skill
+   body must be pasted into Lovable Settings → Skills to take effect?


### PR DESCRIPTION
## Summary

- Expands the `lovable-cloud-knowledge` skill trigger to fire on `.lovable/skills/*.md` edits in addition to knowledge files
- Adds a Workspace Skills column to the Section 1 comparison table (100,000-char body limit vs 10,000 for knowledge fields), grounded in primary source quotes from `docs.lovable.dev/features/skills`
- Updates Section 3 char-budget note to distinguish knowledge (10,000) from skill-body (100,000) limits
- Generalizes the Section 4 char-budget checklist item (#4) to cover all file types by pointing to the §1 table; generalizes the sync-status item (#5) to cover both knowledge files and skill bodies — same "Last synced" date bump and paste-into-UI reminder, different destinations (Settings → Knowledge vs Settings → Skills); adds one skills-specific item: name constraints (1–64 chars, lowercase/numbers/hyphens, no leading/trailing/consecutive hyphens)
- Adds Lovable Docs — Skills as a second primary source in REFERENCES.md with exact verbatim quotes
- Bumps plugin to 2.4.0 (minor — backward-compatible additive coverage)

Context: surfaced during work on a Lovable workspace skill where the 10,000-char knowledge-field limit was mistakenly applied to a skill body (the actual limit is 100,000). This PR corrects the documented limit and teaches the skill to cover `.lovable/skills/*.md` PRs.

## Post-merge install command

Consuming repos refresh with:
```
claude plugin install lovable-cloud@claude-config --scope project
```

## Test plan

- [ ] Trigger fires on a `.lovable/skills/*.md` edit (frontmatter TRIGGER updated)
- [ ] Section 1 table renders correctly with three columns in GitHub markdown
- [ ] Source quotes in REFERENCES.md match live `docs.lovable.dev/features/skills` verbatim

🤖 Generated with [Claude Code](https://claude.com/claude-code)