### PR TITLE
fix(transcript-analysis): read split subagents/ files in iter_sessions

### DIFF
--- a/.claude/plans/fix-transcript-subagent-split-format.md
+++ b/.claude/plans/fix-transcript-subagent-split-format.md
@@ -1,0 +1,247 @@
+# Fix `transcript-analysis.py` subagent false-negative (split-transcript format)
+
+## Context
+
+**Goal:** Make `transcript-analysis.py subagents` (and the sibling `skill-followers`
+metric) correctly count turns that ran inside named subagents — check-runner,
+Explore, `staff-*` reviewers — instead of reporting zero.
+
+**Problem & why now:** Running
+`transcript-analysis.py subagents --branches day-285-sentry-edge-pr1` reports
+**0 subagent turns / 208 main-thread turns**, even though that branch dispatched
+many subagents. A real post-hoc analysis trusted this output and wrongly concluded
+no check-runner agents were ever dispatched. The script is stowed from this repo
+(`claude/.claude/scripts/transcript-analysis.py` → `~/.claude/scripts/`), so the
+false metric ships to every stow user.
+
+**Root cause (verified, not the brief's hypothesis):** The brief guessed a wrong
+`isSidechain` field name or a missing flag. Neither is true. Subagent transcripts
+have moved to **separate files** at
+`~/.claude/projects/<project>/<session-id>/subagents/agent-*.jsonl`, each with a
+`.meta.json` sidecar naming `agentType`. Those records carry `isSidechain: true`
+and `gitBranch` **correctly**. The defect is in the shared `iter_sessions` helper
+(line 314–329): its glob `projects_dir.glob(f"{projects_glob}/*.jsonl")` matches
+only top-level session files and never descends into the `subagents/` subdir, so
+subagent records are never loaded. The `subagents` filter (`isSidechain ?
+"sidechain" : "main"`, line 566) is correct but only ever sees main-thread records.
+No top-level session file contains `"isSidechain":true` (verified by grep), so the
+old assumption that sidechain turns are inlined no longer holds.
+
+**Verified evidence:** For `day-285-sentry-edge-pr1`, session `4319050d` has 9
+subagent files carrying that branch with 18/40/3/39/13/4/5/40/19 sidechain
+assistant turns respectively — so the corrected output will show dozens of
+sidechain turns, not the brief's conservative "≥2".
+
+**Sibling defect (same root cause, in scope per user decision):**
+`cmd_skill_pair` (the `skill-pair` subcommand, defined line 991; its
+`iter_sessions` call is at line 1009) does per-session correlation and tracks
+`has_sidechain_follower` → `follower_sidechain_only`. Because the sidechain
+follower records are never read, that bucket is **always 0** — a silently false
+metric with the identical cause.
+
+**Why existing tests didn't catch it:** The test fixtures model sidechain records
+as inlined entries in the top-level session file (the old format) via
+`_asst(..., sidechain=True)` written into the same `<id>.jsonl` (see
+`test_leader_plus_sidechain_only_follower`, which passes today). The on-disk
+reality moved to the split `subagents/` layout, which no fixture exercises.
+
+**Two on-disk formats, mutually exclusive per session:** Old sessions inline
+sidechain records into `<id>.jsonl` and have no `subagents/` dir; new sessions
+split them into `<id>/subagents/*.jsonl` and never inline. A single session uses
+one or the other, so merging the subagent-dir files cannot double-count against
+inlined records. The merge is purely additive — it only *adds* subagent-dir
+records — so the existing inlined-format tests remain valid and serve as the
+regression guard that the old format still works.
+
+## Approach
+
+Add an **opt-in** parameter `include_subagents: bool = False` to
+`iter_sessions`. When `True`, after reading a top-level session file
+`<project>/<id>.jsonl`, also read every `*.jsonl` under
+`<project>/<id>/subagents/` and **append** those records to the *same* session's
+record list (merged, single yield per session). Default `False` preserves the
+exact current behavior for every other subcommand — zero blast radius.
+
+- Subagent dir derivation from the session file path:
+  `jsonl.parent / jsonl.stem / "subagents"`, globbed for `*.jsonl`; guard for a
+  missing dir (sessions with no subagents).
+- Route `cmd_subagents` (iter_sessions call at line 558) and `cmd_skill_pair`
+  (iter_sessions call at line 1009) through
+  `iter_sessions(..., include_subagents=True)`. No other call site changes.
+- Add a one-line comment in `iter_sessions` naming the `subagents/` subdir layout
+  and that subagent records are the `isSidechain: true` turns, so the next
+  diagnoser doesn't have to re-derive the on-disk shape from JSONL.
+
+**Why merge into the parent session rather than yield subagent files separately:**
+`cmd_subagents` only counts per branch/thread, so either shape works for it. But
+`cmd_skill_pair` requires the main-thread leader (in `<id>.jsonl`) and the
+sidechain follower (in a `subagents/` file) to co-occur in **one** record list;
+yielding subagent files as separate sessions would put them in different
+iterations and the correlation would never fire. Merging is the primitive that
+serves both consumers, so it is the correct shared shape.
+
+### Lighter alternatives considered
+
+- **Fix only `cmd_subagents` to read its own subagent files (no `iter_sessions`
+  change).** Rejected: duplicates the file-discovery + JSON-parse loop that
+  `iter_sessions` already owns, and does nothing for the `skill-followers`
+  sibling, leaving the second false metric live.
+- **Rename / change the field the filter checks (the brief's hypothesis).**
+  Rejected: the field is already correct (`isSidechain: true` is present on
+  subagent records); the records are simply never read. A field change fixes
+  nothing.
+- **Globally broaden the glob** to `**/*.jsonl` or add `*/subagents/*.jsonl` for
+  all subcommands. Rejected as over-powered: it feeds subagent records as
+  separate "sessions" into every subcommand, breaking `skill-followers`
+  per-session correlation and risking session-count/timing distortion in
+  per-session subcommands (idle, struggle). The opt-in merge flag is the lighter
+  primitive that touches only the two consumers that want sidechain data.
+
+The audit of all 14 `isSidechain` references confirms exactly two consumers want
+sidechain data (`subagents`, `skill-pair`); the rest either deliberately skip
+sidechain turns (`main-only`) or count main-thread spawn tool_uses
+(`subagent-mix`, `review-trace`) and are unaffected by the default-`False` flag.
+
+### Format-drift canary (catch the next silent format change at point-of-use)
+
+The failure that motivated this fix was **silent**: the format changed and the
+tool returned `0`, which a human trusted. A hermetic unit test guards *our* code
+against regressions but cannot catch Claude Code changing the on-disk format
+again — a fixture pinned to today's shape goes stale exactly as the code did. So
+add a runtime canary that validates **live data** against the shapes the script
+accepts and warns loudly when they no longer match.
+
+**Signal — corpus-wide cross-check of two independent counts already in the data:**
+- `spawns` = main-thread subagent **spawn** tool_uses (`type==assistant`,
+  `not isSidechain`, `tool_use` block with `name in ("Agent","Task")` —
+  the exact predicate at `cmd_subagent_mix` line 956).
+- `sidechain_turns` = subagent **turns** actually read (`isSidechain==true`
+  assistant records, post-merge).
+- Drift signature: `spawns > 0 and sidechain_turns == 0`. This catches **both**
+  drift modes — the `subagents/` path relocating (files never read → 0 turns)
+  **and** a field rename like `isSidechain`→something (files read but the filter
+  matches 0). On a healthy corpus `sidechain_turns > 0`; on a genuinely
+  subagent-free corpus `spawns == 0`; on the old inlined format the sidechain
+  turns come from the top-level file so the count is non-zero — none of these
+  fire.
+
+**Computed corpus-wide, independent of `--branches`.** Format validity is a
+global property of the on-disk data, not a per-branch one. Tallying across the
+whole `--projects` corpus (ignoring the branch filter) is what makes the signal
+robust: it removes the branch-mismatch false positive (a subagent whose
+`gitBranch` differs from its spawning main turn) and the small-sample
+zero-turn-subagent false positive (every subagent in the entire corpus producing
+zero turns is effectively impossible). A binary `turns==0` test is correct here —
+a ratio would only add noise at low counts.
+
+**Placement — both sidechain consumers, via one shared warner.** The canary lives
+in `cmd_subagents` **and** `cmd_skill_pair`; scoping it to `subagents` alone would
+leave `cmd_skill_pair`'s `follower_sidechain_only` to silently re-zero on the next
+drift — the original incident replayed on the sibling. Both already make a full
+pass over every record, so each accumulates the two corpus-wide tallies during
+that pass and calls a shared `_warn_if_subagent_format_drift(spawns,
+sidechain_turns)` before printing.
+
+**Output contract:** warning → `sys.stderr`, **exit code 0**, never interleaved
+into the stdout table (so `| column -t` / `> file` of the table stays clean —
+matches the file's existing `file=sys.stderr` convention, e.g. `cmd_fail_seq`
+line 397). Text is self-explanatory on one line: names the `subagents/` subdir and
+states the transcript format may have drifted, so a scrollback reader can act.
+
+**Single-source the drifting discriminators (not a half-migration).** Introduce
+two module-scope constants beside the existing format-knowledge constants
+(`REVIEW_SKILLS` line 589): `SUBAGENT_SUBDIR = "subagents"` (the new subdir-path
+knowledge, referenced by the reader, the canary, and the contract test) and
+`_SPAWN_TOOL_NAMES = ("Agent", "Task")` (referenced by `cmd_subagent_mix` line 956
+and the canary tally). Do **not** introduce constants for `isSidechain` /
+`gitBranch`: those appear in ~14 sites, and a constant used in only the 2 new
+sites creates a partial spelling where a reader can't tell which form is
+authoritative — worse than leaving the literals. A full 14-site sweep is
+out of scope; note the choice in the commit message.
+
+## Critical files
+
+- **`claude/.claude/scripts/transcript-analysis.py`**
+  - Module-scope constants beside `REVIEW_SKILLS` (≈589): `SUBAGENT_SUBDIR =
+    "subagents"`, `_SPAWN_TOOL_NAMES = ("Agent", "Task")`.
+  - `iter_sessions` (≈314–329): add `include_subagents` param + subagent-dir
+    read/merge (dir = `jsonl.parent / jsonl.stem / SUBAGENT_SUBDIR`, glob
+    `*.jsonl`, guard missing dir) + explanatory comment.
+  - `cmd_subagents` (iter_sessions call ≈558): pass `include_subagents=True`;
+    accumulate corpus-wide `spawns` / `sidechain_turns`; call the shared warner.
+  - `cmd_skill_pair` (function line 991; iter_sessions call ≈1009): pass
+    `include_subagents=True`; accumulate the same two tallies; call the shared
+    warner.
+  - `cmd_subagent_mix` (≈956): reference `_SPAWN_TOOL_NAMES` instead of the inline
+    `("Agent","Task")` literal — single-source the discriminator the canary shares.
+  - New helpers: `_count_subagent_spawns(records)` (main-thread Agent/Task
+    tool_uses) and `_warn_if_subagent_format_drift(spawns, sidechain_turns)`
+    (stderr, exit-0, self-explanatory text). Add a one-line comment distinguishing
+    the two guards: contract **test** = our-code-vs-our-expectation (runs in CI on
+    fixtures); **canary** = our-expectation-vs-live-disk (runtime).
+  - **Reuse:** the existing in-loop JSON-decode/`OSError` handling in
+    `iter_sessions` — extend it over the subagent files, don't write a second
+    reader. `_fam`, `_branch_filter`, `_projects_glob` are unchanged.
+- **`claude/.claude/scripts/tests/test_transcript_analysis.py`**
+  - Add a fixture helper that writes the **new** layout: a top-level
+    `<id>.jsonl` plus `<id>/subagents/agent-*.jsonl` containing
+    `isSidechain: true` records. Build on existing `_write_jsonl` / `_asst`.
+  - New tests: (a) `subagents` counts sidechain turns from a subagent file and
+    splits them by model family on the right branch; (b) `iter_sessions` default
+    (`include_subagents=False`) still ignores subagent files — guards the
+    zero-blast-radius claim; (c) `skill-pair` `follower_sidechain_only`
+    increments when the leader is main-thread and the follower lives in a
+    subagent file; (d) missing/empty `subagents/` dir is handled.
+  - Canary tests: (e) drift case — a corpus with main-thread spawns but **no**
+    readable subagent turns warns: assert the warning is in
+    `capsys.readouterr().err` and `.out` contains only table rows (stdout stays
+    clean); (f) no false positive — a subagent-free corpus (no spawns) and an
+    old inlined-format corpus (sidechain turns in the top-level file) both emit
+    **no** warning.
+  - **Accepted-shapes contract test:** pin the structural invariants the reader
+    depends on — subagent dir path `<id>/SUBAGENT_SUBDIR/*.jsonl`, and per record
+    type: all subagent records carry `isSidechain` / `gitBranch` / `type`;
+    `message.model` only on `assistant`-type records (a `user`-type subagent
+    record has none). Derive the pinned shape from a real captured record, not the
+    idealized `_asst` helper, so the test locks the actual on-disk contract.
+  - Keep the existing inlined-format sidechain tests (e.g.
+    `test_leader_plus_sidechain_only_follower`) unchanged — they confirm the
+    merge stays additive and the old inlined format still counts.
+
+## Verification
+
+1. `../../../.venv/bin/pytest claude/.claude/scripts/tests/test_transcript_analysis.py`
+   (from the implementation worktree root; `../../../` resolves to the repo root).
+2. `.venv/bin/ruff check claude/.claude/scripts/`.
+3. End-to-end repro against real data:
+   `python3 ~/.claude/scripts/transcript-analysis.py subagents --branches day-285-sentry-edge-pr1`
+   → expect a `sidechain` row with dozens of turns (not 0), main row still ~208.
+4. Regression spot-check that other subcommands are unchanged: run `fail-seq` and
+   `struggle` for the same branch and confirm output matches pre-change (they must
+   not gain subagent turns — brief §7).
+5. `skill-pair` smoke check on a corpus known to have sidechain followers →
+   confirm the `Side` column can now be non-zero.
+6. Canary smoke check: `subagents 2>/dev/null` against the real corpus prints the
+   clean table to stdout with no warning (healthy data); confirm the warning text
+   is well-formed by reading the `_warn_if_subagent_format_drift` unit test output.
+
+## Out of scope
+
+- Per-`agentType` breakdown of the `subagents` output using the `.meta.json`
+  sidecar (check-runner vs Explore vs reviewer split) — useful, but an
+  enhancement beyond the false-negative fix.
+- Changing how `fail-seq` / `struggle` / `review-trace` / `subagent-mix` treat
+  subagent turns (brief §7) — they keep `include_subagents=False`.
+- Auditing other branches for the same symptom — the fix is general; the
+  `day-285-sentry-edge-pr1` repro is sufficient validation.
+- Any harness-level concern about the transcript format itself — we are adapting
+  the reader to the format, not changing the format.
+- A full sweep replacing the ~14 `isSidechain` / `gitBranch` string literals with
+  named constants — only `SUBAGENT_SUBDIR` and `_SPAWN_TOOL_NAMES` (the
+  discriminators the new code and canary actually share) are introduced now;
+  a partial field-name constant would be worse than the literals.
+- A standalone `validate-format` subcommand — rejected for its forgot-to-run
+  failure mode; the inline point-of-use canary fires when the answer is consumed.
+- The canary reports a corpus-wide "format looks wrong" signal; it does not
+  pinpoint which branch or session drifted. Accepted — it is a soft pointer for a
+  human to investigate, not a precise locator.

--- a/claude/.claude/scripts/tests/test_transcript_analysis.py
+++ b/claude/.claude/scripts/tests/test_transcript_analysis.py
@@ -19,6 +19,15 @@ def _write_jsonl(path: Path, records: list[dict]) -> None:
     path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
 
 
+def _write_subagent_jsonl(
+    proj: Path, session_id: str, agent_id: str, records: list[dict]
+) -> None:
+    """Write records to the split subagent layout: <session_id>/subagents/<agent_id>.jsonl."""
+    subdir = proj / session_id / _mod.SUBAGENT_SUBDIR
+    subdir.mkdir(parents=True, exist_ok=True)
+    _write_jsonl(subdir / f"{agent_id}.jsonl", records)
+
+
 def _asst(
     model: str,
     *,
@@ -3242,3 +3251,319 @@ class TestSkillInvocation:
                 break
         else:
             pytest.fail("code-review data row not found in output")
+
+
+# ---------------------------------------------------------------------------
+# iter_sessions subagent merge
+# ---------------------------------------------------------------------------
+
+
+class TestIterSessionsSubagentMerge:
+    def test_include_subagents_false_ignores_subdir(self, fake_projects):
+        """include_subagents=False must not read the subagents/ subdirectory."""
+        session_id = "sess-abc"
+        _write_jsonl(fake_projects / f"{session_id}.jsonl", [
+            _asst("claude-opus-4-7", branch="main"),
+        ])
+        _write_subagent_jsonl(fake_projects, session_id, "agent-1", [
+            _asst("claude-sonnet-4-6", branch="main", sidechain=True),
+        ])
+        results = list(_mod.iter_sessions(fake_projects.parent, include_subagents=False))
+        assert len(results) == 1
+        _path, records = results[0]
+        # Only the main record; sidechain record must not appear.
+        assert len(records) == 1
+        assert records[0].get("isSidechain") is False
+
+    def test_include_subagents_true_merges_subagent_records(self, fake_projects):
+        """include_subagents=True appends subagent file records to the session's record list."""
+        session_id = "sess-def"
+        _write_jsonl(fake_projects / f"{session_id}.jsonl", [
+            _asst("claude-opus-4-7", branch="main"),
+        ])
+        _write_subagent_jsonl(fake_projects, session_id, "agent-1", [
+            _asst("claude-sonnet-4-6", branch="main", sidechain=True),
+        ])
+        results = list(_mod.iter_sessions(fake_projects.parent, include_subagents=True))
+        assert len(results) == 1
+        _path, records = results[0]
+        assert len(records) == 2
+        types = [r.get("isSidechain") for r in records]
+        assert False in types
+        assert True in types
+
+    def test_missing_subagent_dir_is_safe(self, fake_projects):
+        """A session with no subagents/ directory yields normally with include_subagents=True."""
+        _write_jsonl(fake_projects / "lone-session.jsonl", [
+            _asst("claude-opus-4-7", branch="main"),
+        ])
+        # No subagents/ dir for this session.
+        results = list(_mod.iter_sessions(fake_projects.parent, include_subagents=True))
+        assert len(results) == 1
+        _path, records = results[0]
+        assert len(records) == 1
+
+    def test_multiple_subagent_files_all_merged(self, fake_projects):
+        """All *.jsonl files in the subagents/ dir are merged into one record list."""
+        session_id = "sess-multi"
+        _write_jsonl(fake_projects / f"{session_id}.jsonl", [
+            _asst("claude-opus-4-7", branch="main"),
+        ])
+        _write_subagent_jsonl(fake_projects, session_id, "agent-1", [
+            _asst("claude-sonnet-4-6", branch="main", sidechain=True),
+        ])
+        _write_subagent_jsonl(fake_projects, session_id, "agent-2", [
+            _asst("claude-haiku-4-5", branch="main", sidechain=True),
+        ])
+        results = list(_mod.iter_sessions(fake_projects.parent, include_subagents=True))
+        assert len(results) == 1
+        _path, records = results[0]
+        assert len(records) == 3, "expected main + 2 subagent records"
+        models = [(r.get("message") or {}).get("model") for r in records]
+        assert "claude-opus-4-7" in models
+        assert "claude-sonnet-4-6" in models
+        assert "claude-haiku-4-5" in models
+
+    def test_corrupt_line_in_subagent_file_skipped_gracefully(self, fake_projects):
+        """A corrupt JSON line in a subagent file is skipped; valid records still merge."""
+        session_id = "sess-corrupt"
+        _write_jsonl(fake_projects / f"{session_id}.jsonl", [
+            _asst("claude-opus-4-7", branch="main"),
+        ])
+        # Write a subagent file with one valid record and one corrupt line.
+        subdir = fake_projects / session_id / _mod.SUBAGENT_SUBDIR
+        subdir.mkdir(parents=True, exist_ok=True)
+        (subdir / "agent-corrupt.jsonl").write_text(
+            '{"type":"assistant","isSidechain":true,"gitBranch":"main",'
+            '"message":{"model":"claude-sonnet-4-6","content":[],"usage":{}}}\n'
+            'THIS IS NOT JSON\n'
+        )
+        results = list(_mod.iter_sessions(fake_projects.parent, include_subagents=True))
+        assert len(results) == 1
+        _path, records = results[0]
+        sidechain = [r for r in records if r.get("isSidechain")]
+        assert len(sidechain) == 1, "corrupt line skipped; valid sidechain record present"
+
+
+# ---------------------------------------------------------------------------
+# subagents (cmd_subagents)
+# ---------------------------------------------------------------------------
+
+
+def _subagents_args(*, projects: str = "*", branches: str | None = None) -> object:
+    return type("A", (), {"projects": projects, "branches": branches})()
+
+
+class TestSubagents:
+    def test_split_subagent_file_populates_sidechain_row(self, fake_projects, capsys):
+        """Sidechain records from a split subagent file appear in the sidechain row."""
+        session_id = "sess-split"
+        _write_jsonl(fake_projects / f"{session_id}.jsonl", [
+            _asst("claude-opus-4-7", branch="test-branch"),
+        ])
+        _write_subagent_jsonl(fake_projects, session_id, "agent-1", [
+            _asst("claude-sonnet-4-6", branch="test-branch", sidechain=True),
+        ])
+        _mod.cmd_subagents(_subagents_args(branches="test-branch"))
+        out = capsys.readouterr().out
+        main_lines = [ln for ln in out.splitlines() if "main" in ln]
+        sidechain_lines = [ln for ln in out.splitlines() if "sidechain" in ln]
+        assert main_lines, "expected a main row in output"
+        assert sidechain_lines, "expected a sidechain row in output"
+        # Verify actual counts: 1 opus main turn, 1 sonnet sidechain turn.
+        # main row format: branch thread opus sonnet haiku other
+        main_cols = main_lines[0].split()
+        assert main_cols[2] == "1", "expected 1 opus main turn"
+        assert main_cols[3] == "0", "expected 0 sonnet main turns"
+        # sidechain row: branch label absent on second row → thread opus sonnet haiku other
+        sidechain_cols = sidechain_lines[0].split()
+        assert sidechain_cols[1] == "0", "expected 0 opus sidechain turns"
+        assert sidechain_cols[2] == "1", "expected 1 sonnet sidechain turn"
+
+    def test_branch_filter_still_applies_to_output(self, fake_projects, capsys):
+        """Branch filter limits the output rows even with split subagent files."""
+        session_id = "sess-two-branches"
+        _write_jsonl(fake_projects / f"{session_id}.jsonl", [
+            _asst("claude-opus-4-7", branch="branch-a"),
+            _asst("claude-opus-4-7", branch="branch-b"),
+        ])
+        _write_subagent_jsonl(fake_projects, session_id, "agent-1", [
+            _asst("claude-sonnet-4-6", branch="branch-a", sidechain=True),
+        ])
+        _mod.cmd_subagents(_subagents_args(branches="branch-a"))
+        out = capsys.readouterr().out
+        assert "branch-a" in out
+        assert "branch-b" not in out
+
+
+# ---------------------------------------------------------------------------
+# skill-pair: subagent file support
+# ---------------------------------------------------------------------------
+
+
+class TestSkillPairSubagentFile:
+    def test_follower_in_subagent_file_increments_sidechain_only(self, fake_projects, capsys):
+        """Follower skill in a split subagent file (isSidechain=True) counts as Side, not Main."""
+        session_id = "sess-pair"
+        _write_jsonl(fake_projects / f"{session_id}.jsonl", [
+            _asst("claude-sonnet-4-6", branch="main", ts=_TS_FIXED, content=[
+                _skill_use("s1", "plan-it"),
+            ]),
+        ])
+        _write_subagent_jsonl(fake_projects, session_id, "agent-1", [
+            _asst("claude-sonnet-4-6", branch="main", ts=_TS_FIXED, sidechain=True, content=[
+                _skill_use("s2", "plan-review"),
+            ]),
+        ])
+        _mod.cmd_skill_pair(_skill_pair_args())
+        out = capsys.readouterr().out
+        lines = [ln for ln in out.splitlines() if "2026-W20" in ln]
+        assert len(lines) == 1
+        cols = lines[0].split()
+        assert cols[1] == "1"   # Lead=1
+        assert cols[2] == "0"   # Main=0
+        assert cols[3] == "1"   # Side=1
+
+
+# ---------------------------------------------------------------------------
+# format-drift canary
+# ---------------------------------------------------------------------------
+
+
+class TestFormatDriftCanary:
+    def test_drift_warning_emitted_when_spawns_but_no_sidechain_turns(
+        self, fake_projects, capsys
+    ):
+        """Spawn tool_use with no subagent files → WARNING on stderr."""
+        _write_jsonl(fake_projects / "sess.jsonl", [
+            _asst("claude-opus-4-7", branch="main", content=[
+                _agent_use("a1", "staff-backend-engineer"),
+            ]),
+        ])
+        _mod.cmd_subagents(_subagents_args())
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+        assert "isSidechain" in captured.err
+        # The warning must not bleed into stdout table rows.
+        assert "WARNING" not in captured.out
+
+    def test_no_warning_when_no_spawns(self, fake_projects, capsys):
+        """No Agent/Task tool_uses → no drift warning."""
+        _write_jsonl(fake_projects / "sess.jsonl", [
+            _asst("claude-sonnet-4-6", branch="main"),
+        ])
+        _mod.cmd_subagents(_subagents_args())
+        assert "WARNING" not in capsys.readouterr().err
+
+    def test_no_warning_old_inlined_format(self, fake_projects, capsys):
+        """Agent spawn + isSidechain records inlined in the top-level file → no warning."""
+        _write_jsonl(fake_projects / "sess.jsonl", [
+            _asst("claude-opus-4-7", branch="main", content=[
+                _agent_use("a1", "staff-backend-engineer"),
+            ]),
+            _asst("claude-sonnet-4-6", branch="main", sidechain=True),
+        ])
+        _mod.cmd_subagents(_subagents_args())
+        assert "WARNING" not in capsys.readouterr().err
+
+    def test_drift_warning_also_fires_in_skill_pair(self, fake_projects, capsys):
+        """cmd_skill_pair also emits the drift warning when spawns have no sidechain turns."""
+        _write_jsonl(fake_projects / "sess.jsonl", [
+            _asst("claude-sonnet-4-6", branch="main", ts=_TS_FIXED, content=[
+                _skill_use("s1", "plan-it"),
+                _agent_use("a1", "staff-backend-engineer"),
+            ]),
+        ])
+        _mod.cmd_skill_pair(_skill_pair_args())
+        assert "WARNING" in capsys.readouterr().err
+
+    def test_subagent_records_without_issidechain_field_treated_as_main_thread(
+        self, fake_projects, capsys
+    ):
+        """Subagent records missing the isSidechain field are counted as main-thread.
+
+        This documents the failure mode if the transcript format drifts to drop
+        isSidechain — subagent turns silently appear in the main row, not sidechain.
+        """
+        session_id = "sess-no-sidechain-field"
+        _write_jsonl(fake_projects / f"{session_id}.jsonl", [
+            _asst("claude-opus-4-7", branch="main", content=[
+                _agent_use("a1", "check-runner"),
+            ]),
+        ])
+        # Subagent file record WITHOUT isSidechain field.
+        subdir = fake_projects / session_id / _mod.SUBAGENT_SUBDIR
+        subdir.mkdir(parents=True, exist_ok=True)
+        rec = _asst("claude-sonnet-4-6", branch="main", sidechain=True)
+        del rec["isSidechain"]  # simulate format drift
+        (subdir / "agent-drifted.jsonl").write_text(json.dumps(rec) + "\n")
+        _mod.cmd_subagents(_subagents_args())
+        captured = capsys.readouterr()
+        sidechain_lines = [ln for ln in captured.out.splitlines() if "sidechain" in ln]
+        # Without isSidechain=True, the subagent record is not a sidechain turn.
+        assert not sidechain_lines, (
+            "subagent records without isSidechain field must not appear in sidechain row"
+        )
+        # The drift canary fires: spawns=1 (main-thread Agent), sidechain_turns=0
+        # (subagent record has no isSidechain field → not counted as sidechain).
+        assert "WARNING" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# subagent format contract
+# ---------------------------------------------------------------------------
+
+
+class TestSubagentFormatContract:
+    """Pin the on-disk subagent transcript format the reader depends on.
+
+    These assertions describe what the code EXPECTS from the JSONL on disk.
+    If any of these fail on a real corpus run (not in CI), the transcript format
+    has drifted — update the reader (and iter_sessions) before trusting metric output.
+    """
+
+    def test_subagent_dir_path_convention(self, fake_projects):
+        """Subagent files live at <session_id>/subagents/*.jsonl relative to project dir."""
+        session_id = "abc123"
+        agent_id = "agent-xyz"
+        _write_subagent_jsonl(
+            fake_projects, session_id, agent_id,
+            [_asst("claude-sonnet-4-6", sidechain=True)]
+        )
+        subdir = fake_projects / session_id / _mod.SUBAGENT_SUBDIR
+        assert subdir.is_dir(), f"Expected subagent dir at {subdir}"
+        files = list(subdir.glob("*.jsonl"))
+        assert len(files) == 1
+
+    def test_subagent_assistant_record_carries_required_fields(self, fake_projects):
+        """Assistant-type subagent records carry isSidechain, gitBranch, type, message.model
+        when read back through iter_sessions with include_subagents=True."""
+        session_id = "contract-sess"
+        _write_jsonl(fake_projects / f"{session_id}.jsonl", [
+            _asst("claude-opus-4-7", branch="feat"),
+        ])
+        _write_subagent_jsonl(
+            fake_projects, session_id, "agent-contract",
+            [_asst("claude-sonnet-4-6", branch="feat", sidechain=True)]
+        )
+        results = list(_mod.iter_sessions(fake_projects.parent, include_subagents=True))
+        assert len(results) == 1
+        _path, records = results[0]
+        sidechain_records = [r for r in records if r.get("isSidechain")]
+        assert len(sidechain_records) == 1, "expected one sidechain record from subagent file"
+        rec = sidechain_records[0]
+        assert rec.get("isSidechain") is True
+        assert rec.get("gitBranch") == "feat"
+        assert rec.get("type") == "assistant"
+        assert (rec.get("message") or {}).get("model") == "claude-sonnet-4-6"
+
+    def test_user_msg_helper_has_no_message_model(self):
+        """User-type records from _user_msg() have no message.model.
+
+        This documents the helper's shape, not an iter_sessions invariant — user
+        records in subagent files are not relied on by the script's analysis paths.
+        """
+        rec = _user_msg("some content", branch="feat")
+        # isSidechain may be absent on user records; message.model must not be asserted on them
+        assert rec.get("type") == "user"
+        assert (rec.get("message") or {}).get("model") is None

--- a/claude/.claude/scripts/transcript-analysis.py
+++ b/claude/.claude/scripts/transcript-analysis.py
@@ -311,8 +311,19 @@ def _fmt_date(epoch: float) -> str:
     return datetime.fromtimestamp(epoch, tz=UTC).strftime("%Y-%m-%d")
 
 
-def iter_sessions(projects_dir: Path, projects_glob: str = "*") -> Iterator[tuple[Path, list[dict]]]:
-    """Yield (jsonl_path, records) for each transcript file matching the glob."""
+def iter_sessions(
+    projects_dir: Path,
+    projects_glob: str = "*",
+    include_subagents: bool = False,
+) -> Iterator[tuple[Path, list[dict]]]:
+    """Yield (jsonl_path, records) for each transcript file matching the glob.
+
+    When include_subagents=True, records from split subagent files under
+    <session_id>/subagents/*.jsonl are appended to the session's record list
+    before yielding. Those files carry isSidechain: true on assistant records
+    and represent subagent turns written to the SUBAGENT_SUBDIR layout by
+    Claude Code. Sessions with no subagents/ directory are yielded unchanged.
+    """
     for jsonl in sorted(projects_dir.glob(f"{projects_glob}/*.jsonl")):
         records: list[dict] = []
         try:
@@ -325,6 +336,22 @@ def iter_sessions(projects_dir: Path, projects_glob: str = "*") -> Iterator[tupl
                     records.append(rec)
         except OSError:
             continue
+
+        if include_subagents:
+            subagent_dir = jsonl.parent / jsonl.stem / SUBAGENT_SUBDIR
+            if subagent_dir.is_dir():
+                for sub_jsonl in sorted(subagent_dir.glob("*.jsonl")):
+                    try:
+                        with open(sub_jsonl) as fh:
+                            for raw in fh:
+                                try:
+                                    rec = json.loads(raw)
+                                except json.JSONDecodeError:
+                                    continue
+                                records.append(rec)
+                    except OSError:
+                        continue
+
         if records:
             yield jsonl, records
 
@@ -547,6 +574,51 @@ def cmd_duration(args: argparse.Namespace) -> None:
         )
 
 
+def _count_subagent_spawns(records: list[dict]) -> int:
+    """Count main-thread subagent spawn tool_uses (Agent/Task) across all records.
+
+    Used corpus-wide (ignoring branch filter) as one side of the format-drift
+    cross-check: spawns > 0 with zero isSidechain turns read is the drift signature.
+    Note: isSidechain records (from subagent files) are excluded by design — nested
+    subagent spawns are not counted here.
+    """
+    count = 0
+    for rec in records:
+        if rec.get("type") != "assistant" or bool(rec.get("isSidechain")):
+            continue
+        for block in ((rec.get("message") or {}).get("content") or []):
+            if (
+                isinstance(block, dict)
+                and block.get("type") == "tool_use"
+                and block.get("name") in _SPAWN_TOOL_NAMES
+            ):
+                count += 1
+    return count
+
+
+def _warn_if_subagent_format_drift(total_spawns: int, total_sidechain_turns: int) -> None:
+    """Emit a stderr warning when the drift signature is detected.
+
+    Drift signature: spawns recorded in the main thread but zero isSidechain
+    assistant turns read after include_subagents merge. Catches both failure
+    modes — the subagents/ path relocating (files never read → 0 turns) and a
+    field rename (files read but the filter matches 0).
+
+    This is the runtime half of the two-layer guard:
+      - Contract test (CI): pins what our code expects from fixtures.
+      - This canary (runtime): validates expectation against live on-disk data.
+    """
+    if total_spawns > 0 and total_sidechain_turns == 0:
+        print(
+            "WARNING: subagent spawns detected in main thread but zero isSidechain "
+            f"assistant turns were read from '{SUBAGENT_SUBDIR}/' subdirectories. "
+            "The Claude Code transcript format may have drifted — check that "
+            f"subagent files still live under <session>/{SUBAGENT_SUBDIR}/*.jsonl "
+            "and that records still carry 'isSidechain': true.",
+            file=sys.stderr,
+        )
+
+
 def cmd_subagents(args: argparse.Namespace) -> None:
     projects_glob = _projects_glob(args)
     branch_filter = _branch_filter(args)
@@ -554,17 +626,24 @@ def cmd_subagents(args: argparse.Namespace) -> None:
     branch_data: dict[str, dict[str, dict[str, int]]] = defaultdict(
         lambda: {"main": defaultdict(int), "sidechain": defaultdict(int)}
     )
+    corpus_spawns = 0
+    corpus_sidechain_turns = 0
 
-    for _jsonl, records in iter_sessions(PROJECTS_DIR, projects_glob):
+    for _jsonl, records in iter_sessions(PROJECTS_DIR, projects_glob, include_subagents=True):
+        corpus_spawns += _count_subagent_spawns(records)
         for rec in records:
             if rec.get("type") != "assistant":
                 continue
+            if bool(rec.get("isSidechain")):
+                corpus_sidechain_turns += 1
             branch = rec.get("gitBranch") or ""
             if not branch or (branch_filter and branch not in branch_filter):
                 continue
             fam = _fam((rec.get("message") or {}).get("model", ""))
             thread = "sidechain" if bool(rec.get("isSidechain")) else "main"
             branch_data[branch][thread][fam] += 1
+
+    _warn_if_subagent_format_drift(corpus_spawns, corpus_sidechain_turns)
 
     if not branch_data:
         print("No data found.")
@@ -587,6 +666,12 @@ def cmd_subagents(args: argparse.Namespace) -> None:
 
 
 REVIEW_SKILLS: tuple[str, ...] = ("code-review", "plan-review", "ready-for-review")
+
+# Subdirectory name where Claude Code writes split subagent transcripts.
+SUBAGENT_SUBDIR = "subagents"
+
+# Tool names that spawn a subagent in the main thread.
+_SPAWN_TOOL_NAMES = ("Agent", "Task")
 
 # Skills counted as review invocations in review-trace.
 REVIEW_TRACE_SKILLS: frozenset[str] = frozenset(
@@ -953,7 +1038,7 @@ def cmd_subagent_mix(args: argparse.Namespace) -> None:
                     continue
                 name = block.get("name")
                 inp = block.get("input") or {}
-                if name in ("Agent", "Task"):
+                if name in _SPAWN_TOOL_NAMES:
                     stype = inp.get("subagent_type") or "unknown"
                     session_data[branch]["spawns"][stype] += 1
                 elif name == "Skill":
@@ -1005,11 +1090,15 @@ def cmd_skill_pair(args: argparse.Namespace) -> None:
     data: dict[str, dict[str, int]] = defaultdict(
         lambda: {"leader_sessions": 0, "follower_main": 0, "follower_sidechain_only": 0}
     )
+    corpus_spawns = 0
+    corpus_sidechain_turns = 0
 
-    for jsonl, records in iter_sessions(PROJECTS_DIR, projects_glob):
+    for jsonl, records in iter_sessions(PROJECTS_DIR, projects_glob, include_subagents=True):
         # --exclude-projects: skip project dirs whose basename matches the glob
         if exclude_glob and fnmatch.fnmatchcase(jsonl.parent.name, exclude_glob):
             continue
+
+        corpus_spawns += _count_subagent_spawns(records)
 
         has_leader_hit = False
         leader_first_ts: float | None = None
@@ -1019,6 +1108,8 @@ def cmd_skill_pair(args: argparse.Namespace) -> None:
         for rec in records:
             if rec.get("type") != "assistant":
                 continue
+            if bool(rec.get("isSidechain")):
+                corpus_sidechain_turns += 1
             branch = rec.get("gitBranch") or ""
             if branch_filter and branch not in branch_filter:
                 continue
@@ -1054,6 +1145,8 @@ def cmd_skill_pair(args: argparse.Namespace) -> None:
         elif has_sidechain_follower:
             # sidechain-only: sidechain follower present AND no main-thread follower
             d["follower_sidechain_only"] += 1
+
+    _warn_if_subagent_format_drift(corpus_spawns, corpus_sidechain_turns)
 
     if not data:
         print("No data found.")


### PR DESCRIPTION
## Summary

- `iter_sessions` never descended into `<session>/subagents/*.jsonl`, so `subagents` and `skill-pair` reported 0 sidechain turns — a trusted-but-wrong zero that caused a real post-hoc analysis to conclude no subagent check-runners were dispatched.
- Fix: add `include_subagents=False` opt-in to `iter_sessions`; the two sidechain consumers pass `True`. All 15 other callers keep the default (zero blast radius).
- Adds a corpus-wide format-drift canary in both consumers: warns to stderr when main-thread Agent/Task spawns are present but zero isSidechain turns were read, so the next format change is caught at point-of-use rather than producing another silent trusted zero.
- Two new module-scope constants (`SUBAGENT_SUBDIR`, `_SPAWN_TOOL_NAMES`) single-source the discriminators shared between the reader, the canary, and `cmd_subagent_mix`.

## Test plan

- [x] `../../../.venv/bin/pytest claude/.claude/` — 223 tests pass
- [x] `../../../.venv/bin/ruff check claude/.claude/` — clean
- [x] End-to-end: `day-285-sentry-edge-pr1` now shows 25 Sonnet + 156 Haiku sidechain turns (was 0). `fail-seq` and `struggle` output unchanged.
- [x] Canary smoke check: clean corpus emits no warning; corpus with Agent spawns but no subagent files emits WARNING to stderr, not stdout.

## Notes for reviewer

- Constants `SUBAGENT_SUBDIR` and `_SPAWN_TOOL_NAMES` are defined at ~line 667 (near `REVIEW_SKILLS`) but first referenced in functions earlier in the file. Python resolves module-level names at call time, so there is no runtime issue — but hoisting them before `iter_sessions` is a cosmetic follow-up (GH-363 already tracks the `TestSkillPair` column-index counterpart).
- A full sweep of the ~14 `isSidechain`/`gitBranch` string literals to named constants was explicitly deferred; introducing only the two discriminators the new code and canary share avoids a partial spelling where neither form is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)