### PR TITLE
GH-367: bash 3.2 portability for scripts and nudge hook

### DIFF
--- a/.claude/plans/https-github-com-jcdendrite-claude-confi-melodic-flurry.md
+++ b/.claude/plans/https-github-com-jcdendrite-claude-confi-melodic-flurry.md
@@ -1,0 +1,109 @@
+# Plan: macOS bash 3.2 compatibility for two scripts + one hook
+
+Closes #367.
+
+## Context
+
+Stock macOS ships **bash 3.2.57** at `/bin/bash` (frozen at the last GPLv2 release in 2007). Three shell files in this repo use bash-4.0+ features — `declare -A` associative arrays and `mapfile` — so they hard-error or silently no-op for macOS stow users. CI runs on Ubuntu (bash 5) and never caught it. Because `claude/` is stowed to every user who clones this repo, the macOS audience is real, not hypothetical.
+
+The most insidious case is the hook `nudge-handoff-near-context-cap.sh`: its `2>/dev/null || true` fail-open guard swallows the `mapfile` error, so the handoff nudge **silently never fires** on macOS rather than erroring visibly.
+
+Intended outcome: rewrite all three files to bash-3.2-portable constructs (no version-bump requirement, so they work out-of-the-box), and add a pytest regression guard so the constructs can't creep back in. Plan review surfaced a fourth macOS incompatibility of the same theme in a file already being rewritten — `sort -V` (a GNU-only flag) in `update-claude-config-plugins.sh` — folded in as an in-scope sibling fix so the script is actually correct on macOS, not merely non-crashing.
+
+## Approach
+
+Rewrite to portable constructs, preserving observable behavior exactly. The codebase already demonstrates the target pattern — `update-claude-config-plugins.sh` uses lockstep parallel indexed arrays (`OUTDATED_NAMES` + siblings, lines 151–155), and `cleanup-merged-branches.sh` already maintains an indexed companion (`MERGED_BRANCHES`, `SKIPPED_IN_USE`) alongside each associative map. So the rewrite mostly adds value-parallel arrays beside keys that are already tracked, plus a small linear-search helper for lookups.
+
+**Substitution rules:**
+
+- `mapfile -t arr < <(cmd)` → `arr=(); while IFS= read -r line; do arr+=("$line"); done < <(cmd)`
+- `declare -A MAP` → a parallel indexed value array, keyed off the already-existing companion key array; lookups become a linear search with **exact-string** comparison (`[ "$x" = "$key" ]`, never `[[ … == … ]]` glob matching — branch-name keys may contain `/`).
+
+Rationale for parallel-arrays-over-associative: it's already the house pattern in both scripts, N is tiny (handful of plugins / merged branches), keys can contain `/` (slash-safe under exact `=`), and it needs no bash version bump. Alternatives set aside: (a) requiring Homebrew bash 4+ — breaks the out-of-the-box stow contract, the explicit non-goal in the issue's root-cause note; (b) a `bash --version` guard that errors early — still leaves macOS users unable to run the scripts.
+
+### File 1 — `claude/.claude/scripts/update-claude-config-plugins.sh`
+
+Two maps keyed by plugin name. Replace `LATEST_VERSION` / `PLUGIN_DESCRIPTION` (decl 100–101) with three lockstep arrays mirroring the existing `OUTDATED_*` style, e.g. `PLUGIN_NAMES` / `PLUGIN_LATEST` / `PLUGIN_DESC`:
+- Population (121–122): append to all three in lockstep.
+- Emptiness check (137): change `[ "${#LATEST_VERSION[@]}" -eq 0 ]` → `[ "${#PLUGIN_NAMES[@]}" -eq 0 ]` (count the new key array, not a value array).
+- Lookup at 164 (`LATEST_VERSION[$entry_name]`) and 227 (`PLUGIN_DESCRIPTION[$plugin_name]`): linear search over `PLUGIN_NAMES` returning the parallel slot. Extract one small `_lookup_by_name` helper (name array + value array + key → echo value or empty) so both call sites share it — preserves the existing `:-` empty-default semantics. Use exact `=` comparison (a plugin name could be a prefix of another).
+
+**Sibling macOS fix — `sort -V` (line 175).** Same file, same macOS-portability theme as the issue but a distinct mechanism: `lower=$(printf '%s\n%s' "$installed_version" "$latest_version" | sort -V | head -1)` uses the GNU-coreutils `-V` flag, which BSD/macOS `sort` does not support — on macOS it errors or silently mis-sorts, producing a wrong "outdated" verdict. Replace the `sort -V | head -1` pipeline with a portable version comparison via `python3`, which this script **already depends on** (the installed-list parser at the bottom of the same loop shells to `python3`). Compare the two dotted-numeric versions as integer tuples and print the lower, e.g. a `python3 -c` that splits each on `.`, maps to `int`, and emits the smaller — matching `sort -V`'s ordering for the semver shapes these plugin versions take. Keep the surrounding `if [ "$lower" = "$installed_version" ]` outdated logic unchanged. Reuse the existing `python3` dependency rather than adding a tool or hand-rolling a bash version-compare. This is flagged as an in-scope sibling fix in the PR description (Incidental edits).
+
+### File 2 — `claude/.claude/scripts/cleanup-merged-branches.sh`
+
+- `mapfile -t ALL_BRANCHES` (197): branch names have no spaces → `while IFS= read -r` append loop. Iteration sites (207, 220, 336, 586) unchanged.
+- `MERGED_PR_INFO` + `TIER` (decl 202–203): add two value arrays parallel to the existing `MERGED_BRANCHES` (201), appended in lockstep at the two write sites (247–250, 256–258). Lookups at 274 (`TIER`), 319 (`MERGED_PR_INFO`), 364/366 (`TIER`) → linear search over `MERGED_BRANCHES`.
+- `SKIPPED_IN_USE_REASON` (decl 401): add a value array parallel to the existing `SKIPPED_IN_USE` (400), written at 457/462, looked up at 570 → linear search over `SKIPPED_IN_USE`.
+- Use exact `=` comparison in every linear search (branch names may contain `/`).
+- No change to the `BASH_REMATCH` / `[[ … =~ ]]` blocks (444–445, 294–306) or the `${arr[@]+"…"}` empty-safe expansions (128, 565, 569) — all bash-3.2 compatible already.
+
+### File 3 — `claude/.claude/hooks/nudge-handoff-near-context-cap.sh`
+
+Single `mapfile -t _FIELDS` (33). Per the issue, prefer direct sequential reads over an intermediate array for the 4-field case:
+
+```bash
+SESSION_ID=""; AGENT_TYPE=""; PERMISSION_MODE=""; TRANSCRIPT_PATH=""
+{
+  IFS= read -r SESSION_ID
+  IFS= read -r AGENT_TYPE
+  IFS= read -r PERMISSION_MODE
+  IFS= read -r TRANSCRIPT_PATH
+} < <(
+  printf '%s\n' "$INPUT" \
+    | jq -r '(.session_id // ""),(.agent_type // ""),(.permission_mode // ""),(.transcript_path // "")' \
+    2>/dev/null
+) 2>/dev/null || true
+```
+
+Must preserve the fail-open `2>/dev/null || true` wrapper and empty-default semantics (a failed `read` leaves the pre-initialized empty value). Update the line-32 comment (currently references `mapfile`) to describe the `read` approach — otherwise the regression test's prose-safe match aside, the comment would be stale.
+
+### Regression guard — new test
+
+New file `claude/.claude/scripts/tests/test_no_bash4_constructs.py`, modeled on `claude/.claude/hooks/tests/test_hook_alignment.py` (the only existing test that globs `.sh` files):
+- `_REPO_ROOT = Path(__file__).resolve().parents[4]`.
+- Enumerate `sorted((_REPO_ROOT / "claude" / ".claude").rglob("*.sh"))`, **excluding any path with a `/tests/` path segment** (match the segment `tests`, not the substring — a future `scripts/testsuite.sh` must not be silently excluded). Test fixtures may legitimately contain these constructs and are never executed as stowed user tooling; only shipped scripts/hooks are scanned. Scanning the whole `claude/.claude/` tree — not just `scripts/` — is required so the hook regression under `hooks/` is actually guarded.
+- Parametrize over the file list with `ids=[p.name for p in …]`.
+- **Vacuous-pass guard:** add a separate non-parametrized test asserting `len(discovered) >= SENTINEL` (a committed floor, e.g. the current count of in-scope `.sh` files). An empty parametrize list collects zero tests and reports green, so a `parents[4]` drift or mistyped root would silently stop guarding — the floor assertion makes that failure loud.
+- **Matcher:** for each file, scan lines; skip lines whose first non-whitespace char is `#` (handles the one real false-positive — the hook's line-32 prose comment naming `mapfile`); on the remaining lines match `\bdeclare\s+-A\b` and `\b(mapfile|readarray)\b` as **whole words anywhere on the line** — do *not* anchor to `^\s*`, which would let `x=1; declare -A y` escape. Document in the test docstring that the matcher does not parse heredoc/string-literal bodies (the simplest robust scope; no such literal exists in the tree today) and that the test guards only those three named tokens — it is not a full bash-3.2 compatibility proof.
+
+CI: `.github/workflows/tests.yml`'s path regex (line 58) already lists `scripts`, and the run invokes `pytest claude/.claude/` on the whole tree — the new test is auto-collected, no workflow edit needed.
+
+### Hook fail-open behavioral test
+
+The hook is the silent-failure case the issue calls "most insidious," so guard its rewritten parse with a behavioral test, not just the static grep. Add to the hook's existing test module (or a co-located `claude/.claude/hooks/tests/` test) a case that pipes empty and malformed JSON to `nudge-handoff-near-context-cap.sh` and asserts **fail-open** (exits 0, emits no blocking output) — reusing the Layer-2 invocation pattern already in `test_hook_alignment.py`. This exercises the four-`read` rewrite under the degenerate input that the original `mapfile` masked, on a path bash-5 CI does run.
+
+The existing per-script suites already cover the linear-search replacements' realistic branches — `test_cleanup_merged_branches.py` fixtures use slash-containing branch names (`feat/foo`, `feat/alpha`) and multiple merged branches; `test_update_claude_config_plugins.py` uses multiple plugins, a locally-ahead (no-flag) case, and lookup-miss cases. So behavior-equivalence on bash-5 CI covers slash-keys, multi-entry iteration, and misses without new cases; no redundant lookup tests are added.
+
+## Critical files
+
+| File | Change |
+|------|--------|
+| `claude/.claude/scripts/update-claude-config-plugins.sh` | 2 `declare -A` → 3 lockstep parallel arrays + `_lookup_by_name` helper; **`sort -V` (175) → portable `python3` version-compare** |
+| `claude/.claude/scripts/cleanup-merged-branches.sh` | 1 `mapfile` → read-loop; 3 `declare -A` → value arrays parallel to existing `MERGED_BRANCHES` / `SKIPPED_IN_USE` |
+| `claude/.claude/hooks/nudge-handoff-near-context-cap.sh` | 1 `mapfile` → 4 sequential `IFS= read -r`; preserve fail-open; update line-32 comment |
+| `claude/.claude/scripts/tests/test_no_bash4_constructs.py` | **new** — regression grep, parametrized per `.sh` file, + vacuous-pass floor assertion |
+| hook test (in `claude/.claude/hooks/tests/`) | **new case** — empty/malformed JSON → assert hook fail-open |
+
+All file changes land in **one PR** (plan files included per the repo's plan-in-PR rule). The regression grep must land with-or-after the rewrites, never in an earlier standalone commit, or it fails on the still-present constructs.
+
+**Reuse opportunities:**
+- `update-claude-config-plugins.sh` lines 151–155 / 177–181 — copy the existing `OUTDATED_*` lockstep-array + `"${!arr[@]}"` iteration idiom for the new plugin arrays.
+- `cleanup-merged-branches.sh` lines 201, 400 — `MERGED_BRANCHES` / `SKIPPED_IN_USE` already track the map keys in lockstep; reuse them as the search arrays.
+- `claude/.claude/hooks/tests/test_hook_alignment.py` lines 28–44, 96–97 — copy the repo-root resolution, `.glob`/`rglob` enumeration, and `@pytest.mark.parametrize(... ids=…)` shape for the new test.
+
+## Verification
+
+1. **Logic-equivalence (Linux/bash 5):** `.venv/bin/pytest claude/.claude/scripts/tests/ claude/.claude/hooks/tests/` — the existing `test_update_claude_config_plugins.py`, `test_cleanup_merged_branches.py`, and the hook's tests run the rewritten code; all must still pass, proving the rewrite preserved behavior.
+2. **Regression guard:** the new `test_no_bash4_constructs.py` passes after the rewrite, and (sanity) fails if reverted on any one file.
+3. **Lint:** `.venv/bin/ruff check claude/.claude/`.
+4. **Static portability check:** `bash -n` parses cleanly on each rewritten file; grep confirms zero `declare -A` / `mapfile` / `readarray` outside `tests/`; grep confirms no remaining `sort -V`.
+5. **macOS bash 3.2 + BSD userland (user-side):** on stock macOS run the two scripts with `--dry-run` under `/bin/bash`, confirm the outdated-version comparison returns correct verdicts (the `sort -V` path), and confirm the handoff hook now fires near the context cap. Linux can't easily host bash 3.2 / BSD `sort`, so steps 1–4 are the gating checks and step 5 is the real-environment confirmation of both the bash-version and BSD-userland dimensions.
+
+## Out of scope
+
+- No bash version-bump requirement / Homebrew dependency (explicit non-goal).
+- No changes to the `BASH_REMATCH`/`[[ =~ ]]` regex blocks — already 3.2-compatible.
+- No broadening of the regression test to `plugins/` (none currently contain these constructs; can be added later if plugin shell scripts grow).
+- **No bash-3.2 container in CI.** A real bash-3.2 (and BSD `sort`) CI job would catch the language/userland dimension automatically, but it's heavier than warranted for developer tooling. The static grep guards the named-construct creep risk; the BSD-userland dimension (e.g. future `sort -V` reintroduction) relies on the manual macOS step. Revisit only if these scripts grow or macOS regressions recur.
+- **`sort -V` portable-compare edge cases.** The `python3` integer-tuple compare matches `sort -V` for the dotted-numeric semver these plugin versions use; it is not a general semver parser (no pre-release/build-metadata ordering). That's sufficient for the marketplace's version shapes and avoids a third-party dependency.

--- a/claude/.claude/hooks/nudge-handoff-near-context-cap.sh
+++ b/claude/.claude/hooks/nudge-handoff-near-context-cap.sh
@@ -29,16 +29,24 @@
 INPUT=$(cat 2>/dev/null)
 
 # Extract all four fields in a single jq pass to avoid four separate subshell spawns.
-# mapfile with newline-separated output handles empty fields and paths with spaces correctly.
-mapfile -t _FIELDS < <(
+# Sequential reads from the jq output: each field on its own line handles
+# empty values and paths with spaces correctly. Pre-initialize to "" so a
+# failed read (e.g. jq unavailable or INPUT invalid) leaves empty strings
+# rather than unbound variables. The || true preserves fail-open semantics.
+SESSION_ID=""
+AGENT_TYPE=""
+PERMISSION_MODE=""
+TRANSCRIPT_PATH=""
+{
+  IFS= read -r SESSION_ID
+  IFS= read -r AGENT_TYPE
+  IFS= read -r PERMISSION_MODE
+  IFS= read -r TRANSCRIPT_PATH
+} < <(
   printf '%s\n' "$INPUT" \
     | jq -r '(.session_id // ""),(.agent_type // ""),(.permission_mode // ""),(.transcript_path // "")' \
     2>/dev/null
 ) 2>/dev/null || true
-SESSION_ID="${_FIELDS[0]:-}"
-AGENT_TYPE="${_FIELDS[1]:-}"
-PERMISSION_MODE="${_FIELDS[2]:-}"
-TRANSCRIPT_PATH="${_FIELDS[3]:-}"
 [ -z "$SESSION_ID" ] && exit 0
 
 # Kill-switch: suppress nudge for automated pipelines or user opt-out.

--- a/claude/.claude/hooks/tests/test_nudge_handoff_near_context_cap.py
+++ b/claude/.claude/hooks/tests/test_nudge_handoff_near_context_cap.py
@@ -301,3 +301,39 @@ class TestNudgeHandoffNearContextCap:
         assert result.stdout.strip() == ""
         # No log: below threshold produces no log line (skip line was removed; schema-drift not triggered).
         assert not _log_path(tmp_path).exists()
+
+    def test_empty_json_object_input_is_fail_open(self, tmp_path):
+        """Empty JSON object ({}) as INPUT: exit 0, no blocking stdout.
+
+        Verifies the four-read rewrite preserves fail-open semantics when
+        session_id is absent — the hook exits silently without emitting any
+        output that could block a user prompt.
+        """
+        result = subprocess.run(
+            [str(NUDGE_HOOK)],
+            input="{}",
+            capture_output=True,
+            text=True,
+            env={**os.environ, "HOME": str(tmp_path)},
+            check=False,
+        )
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_malformed_input_is_fail_open(self, tmp_path):
+        """Non-JSON string as INPUT: exit 0, no blocking stdout.
+
+        Verifies the four-read rewrite preserves the || true fail-open guard
+        when jq cannot parse the input — the hook exits silently rather than
+        crashing or emitting output that could block a user prompt.
+        """
+        result = subprocess.run(
+            [str(NUDGE_HOOK)],
+            input="not json at all",
+            capture_output=True,
+            text=True,
+            env={**os.environ, "HOME": str(tmp_path)},
+            check=False,
+        )
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""

--- a/claude/.claude/scripts/cleanup-merged-branches.sh
+++ b/claude/.claude/scripts/cleanup-merged-branches.sh
@@ -194,13 +194,16 @@ fi
 
 CURRENT_HEAD=$(git rev-parse --abbrev-ref HEAD)
 
-mapfile -t ALL_BRANCHES < <(
+ALL_BRANCHES=()
+while IFS= read -r _branch_line; do
+  ALL_BRANCHES+=("$_branch_line")
+done < <(
   git for-each-ref --format='%(refname:short)' refs/heads
 )
 
 declare -a MERGED_BRANCHES=()
-declare -A MERGED_PR_INFO=()
-declare -A TIER=()
+declare -a MERGED_PR_INFO_VALUES=()
+declare -a TIER_VALUES=()
 declare -a SKIPPED_BRANCHES=()
 
 CANDIDATE_COUNT=0
@@ -246,16 +249,16 @@ else:
 
   if [ -n "$PR_NUMBER" ]; then
     MERGED_BRANCHES+=("$BRANCH")
-    MERGED_PR_INFO["$BRANCH"]="PR #${PR_NUMBER}, merged ${PR_MERGED_AT}"
-    TIER["$BRANCH"]="A"
+    MERGED_PR_INFO_VALUES+=("PR #${PR_NUMBER}, merged ${PR_MERGED_AT}")
+    TIER_VALUES+=("A")
     continue
   fi
 
   if git merge-base --is-ancestor "$BRANCH" \
        "refs/remotes/origin/${DEFAULT_BRANCH}" 2>/dev/null; then
     MERGED_BRANCHES+=("$BRANCH")
-    MERGED_PR_INFO["$BRANCH"]="reachable from origin/${DEFAULT_BRANCH}; no merged PR for this name"
-    TIER["$BRANCH"]="B"
+    MERGED_PR_INFO_VALUES+=("reachable from origin/${DEFAULT_BRANCH}; no merged PR for this name")
+    TIER_VALUES+=("B")
   fi
 done
 clear_progress
@@ -270,11 +273,11 @@ collect_process_cwds
 if [ "$DRY_RUN" -eq 1 ]; then
   declare -a _DRY_TIER_A=()
   declare -a _DRY_TIER_B=()
-  for BRANCH in "${MERGED_BRANCHES[@]}"; do
-    if [ "${TIER[$BRANCH]}" = "A" ]; then
-      _DRY_TIER_A+=("$BRANCH")
+  for _mb_i in "${!MERGED_BRANCHES[@]}"; do
+    if [ "${TIER_VALUES[$_mb_i]}" = "A" ]; then
+      _DRY_TIER_A+=("${MERGED_BRANCHES[$_mb_i]}")
     else
-      _DRY_TIER_B+=("$BRANCH")
+      _DRY_TIER_B+=("${MERGED_BRANCHES[$_mb_i]}")
     fi
   done
 
@@ -316,7 +319,14 @@ if [ "$DRY_RUN" -eq 1 ]; then
         _tag=" [locked — will unlock and remove]"
       fi
     fi
-    echo "  ${_branch} (${MERGED_PR_INFO[$_branch]})${_tag}"
+    _branch_info=""
+    for _mb_i in "${!MERGED_BRANCHES[@]}"; do
+      if [ "${MERGED_BRANCHES[$_mb_i]}" = "$_branch" ]; then
+        _branch_info="${MERGED_PR_INFO_VALUES[$_mb_i]}"
+        break
+      fi
+    done
+    echo "  ${_branch} (${_branch_info})${_tag}"
   }
 
   if [ "${#_DRY_TIER_A[@]}" -gt 0 ]; then
@@ -360,10 +370,12 @@ fi
 declare -a TO_DELETE=()
 declare -a SKIPPED_NEEDS_PROMPT=()
 
-for BRANCH in "${MERGED_BRANCHES[@]}"; do
-  if [ "${TIER[$BRANCH]}" = "A" ]; then
+for _mb_i in "${!MERGED_BRANCHES[@]}"; do
+  BRANCH="${MERGED_BRANCHES[$_mb_i]}"
+  _branch_tier="${TIER_VALUES[$_mb_i]}"
+  if [ "$_branch_tier" = "A" ]; then
     TO_DELETE+=("$BRANCH")
-  elif [ "${TIER[$BRANCH]}" = "B" ]; then
+  elif [ "$_branch_tier" = "B" ]; then
     if [ "$ASSUME_YES" -eq 1 ]; then
       TO_DELETE+=("$BRANCH")
     elif [ -t 0 ]; then
@@ -398,7 +410,7 @@ fi
 
 declare -a SKIPPED_LIVE_LOCK=()
 declare -a SKIPPED_IN_USE=()
-declare -A SKIPPED_IN_USE_REASON=()
+declare -a SKIPPED_IN_USE_REASON_VALUES=()
 
 echo "Cleaned up:"
 
@@ -454,12 +466,12 @@ for BRANCH in "${TO_DELETE[@]}"; do
     if [ "$WORKTREE_IN_USE" -eq 0 ]; then
       echo "    worktree:       skipped (in use by a live process)"
       SKIPPED_IN_USE+=("$BRANCH")
-      SKIPPED_IN_USE_REASON["$BRANCH"]="worktree in use by a live process"
+      SKIPPED_IN_USE_REASON_VALUES+=("worktree in use by a live process")
       continue
     elif [ "$WORKTREE_IN_USE" -eq 2 ]; then
       echo "    worktree:       skipped (cannot verify it is idle)"
       SKIPPED_IN_USE+=("$BRANCH")
-      SKIPPED_IN_USE_REASON["$BRANCH"]="worktree idle state unverifiable"
+      SKIPPED_IN_USE_REASON_VALUES+=("worktree idle state unverifiable")
       continue
     fi
     if [ "$WORKTREE_LOCKED" -eq 1 ]; then
@@ -566,8 +578,8 @@ for BRANCH in "${SKIPPED_LIVE_LOCK[@]+"${SKIPPED_LIVE_LOCK[@]}"}"; do
   echo "Skipped (live agent lock): ${BRANCH}"
 done
 
-for BRANCH in "${SKIPPED_IN_USE[@]+"${SKIPPED_IN_USE[@]}"}"; do
-  echo "Skipped (${SKIPPED_IN_USE_REASON[$BRANCH]}): ${BRANCH}"
+for _su_i in "${!SKIPPED_IN_USE[@]}"; do
+  echo "Skipped (${SKIPPED_IN_USE_REASON_VALUES[$_su_i]}): ${SKIPPED_IN_USE[$_su_i]}"
 done
 
 if [ "${#SKIPPED_NEEDS_PROMPT[@]}" -gt 0 ]; then

--- a/claude/.claude/scripts/tests/test_no_bash4_constructs.py
+++ b/claude/.claude/scripts/tests/test_no_bash4_constructs.py
@@ -1,0 +1,83 @@
+"""Regression guard: no shipped .sh file under claude/.claude/ may use bash-4+
+constructs that break on macOS bash 3.2.57.
+
+Guarded tokens: ``declare -A`` (including compound-flag forms like ``declare -xA``
+or ``declare -Ax``), ``mapfile``, ``readarray``, ``sort -V`` / ``sort --version-sort``.
+
+Scope: all *.sh files under claude/.claude/ that are NOT under a tests/
+path segment (test fixtures run only under the CI interpreter and are never
+stowed to a user's machine).
+
+Limitations: this test scans file text; it does not parse heredoc or
+string-literal bodies. A construct inside a heredoc body would produce a
+false-positive failure. Suppress with ``# noqa-bash4`` on the offending line.
+This test is a named-token creep guard, not a full bash-3.2 compatibility proof.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_CLAUDE_DIR = _REPO_ROOT / "claude" / ".claude"
+
+_BASH4_PATTERNS = re.compile(
+    r'\bdeclare\b[^#\n]*\s-\w*A\w*'       # declare with -A flag in any position/combination
+    r'|\b(?:mapfile|readarray)\b'
+    r'|\bsort\b[^#\n]*(?:-V\b|--version-sort\b)'  # sort -V (GNU-only, not available on BSD/macOS)
+)
+
+
+def _is_tests_path(p: Path) -> bool:
+    """Return True if any path segment is exactly 'tests'."""
+    return "tests" in p.parts
+
+
+def _discover_shell_files() -> list[Path]:
+    return sorted(
+        p for p in _CLAUDE_DIR.rglob("*.sh")
+        if not _is_tests_path(p)
+    )
+
+
+_SHELL_FILES = _discover_shell_files()
+
+# Sentinel: fail loudly if discovery is broken rather than vacuously passing.
+# Floor chosen conservatively at the count of in-scope .sh files at the time
+# of writing; update downward intentionally if scripts are removed.
+_MIN_SHELL_FILE_COUNT = 10
+
+
+def test_discovery_is_non_empty() -> None:
+    """Guard against a broken rglob root silently collecting zero files."""
+    assert len(_SHELL_FILES) >= _MIN_SHELL_FILE_COUNT, (
+        f"Expected at least {_MIN_SHELL_FILE_COUNT} .sh files under {_CLAUDE_DIR}, "
+        f"found {len(_SHELL_FILES)}. "
+        "If the repo structure changed, update _MIN_SHELL_FILE_COUNT."
+    )
+    # Spot-anchor: verify a known-stable script is present so a restructure that
+    # moves scripts to a different subtree can't reach the floor via unrelated files.
+    assert any("deny-private-project-refs.sh" in str(p) for p in _SHELL_FILES), (
+        "deny-private-project-refs.sh not found in discovered shell files — "
+        f"check that _CLAUDE_DIR ({_CLAUDE_DIR}) resolves to the right location."
+    )
+
+
+@pytest.mark.parametrize("script", _SHELL_FILES, ids=[str(p.relative_to(_CLAUDE_DIR)) for p in _SHELL_FILES])
+def test_no_bash4_constructs(script: Path) -> None:
+    """Each shipped .sh file must be free of bash-4+ constructs."""
+    violations = []
+    for lineno, line in enumerate(script.read_text().splitlines(), start=1):
+        if "# noqa-bash4" in line:
+            continue
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            continue  # skip full-comment lines (e.g. explanatory prose naming mapfile)
+        if _BASH4_PATTERNS.search(line):
+            violations.append(f"  line {lineno}: {line.rstrip()}")
+    assert not violations, (
+        f"{script.relative_to(_REPO_ROOT)} contains bash-4+ constructs:\n"
+        + "\n".join(violations)
+    )

--- a/claude/.claude/scripts/update-claude-config-plugins.sh
+++ b/claude/.claude/scripts/update-claude-config-plugins.sh
@@ -97,8 +97,9 @@ if [ ! -f "$MARKETPLACE_MANIFEST" ]; then
   exit 1
 fi
 
-declare -A LATEST_VERSION=()
-declare -A PLUGIN_DESCRIPTION=()
+declare -a PLUGIN_NAMES=()
+declare -a PLUGIN_LATEST=()
+declare -a PLUGIN_DESC=()
 
 while read -r plugin_name plugin_source_rel; do
   [ -z "$plugin_name" ] && continue
@@ -118,8 +119,9 @@ print(desc)
   plugin_version=$(printf '%s' "$parsed" | sed -n '1p')
   plugin_desc=$(printf '%s' "$parsed" | sed -n '2p')
   if [ -n "$plugin_version" ]; then
-    LATEST_VERSION["$plugin_name"]="$plugin_version"
-    PLUGIN_DESCRIPTION["$plugin_name"]="$plugin_desc"
+    PLUGIN_NAMES+=("$plugin_name")
+    PLUGIN_LATEST+=("$plugin_version")
+    PLUGIN_DESC+=("$plugin_desc")
   fi
 done < <(python3 -c "
 import json, re, sys
@@ -134,7 +136,7 @@ for p in d.get('plugins', []):
         print(name, source)
 " "$MARKETPLACE_MANIFEST" 2>/dev/null || true)
 
-if [ "${#LATEST_VERSION[@]}" -eq 0 ]; then
+if [ "${#PLUGIN_NAMES[@]}" -eq 0 ]; then
   echo "No plugins found in the claude-config marketplace manifest." >&2
   exit 0
 fi
@@ -161,7 +163,13 @@ while IFS=$'\t' read -r entry_name installed_version entry_scope entry_project_p
     continue
   fi
 
-  latest_version="${LATEST_VERSION[$entry_name]:-}"
+  latest_version=""
+  for _pi in "${!PLUGIN_NAMES[@]}"; do
+    if [ "${PLUGIN_NAMES[$_pi]}" = "$entry_name" ]; then
+      latest_version="${PLUGIN_LATEST[$_pi]}"
+      break
+    fi
+  done
   if [ -z "$latest_version" ]; then
     continue
   fi
@@ -172,7 +180,12 @@ while IFS=$'\t' read -r entry_name installed_version entry_scope entry_project_p
 
   # Flag as outdated only when marketplace version sorts strictly higher.
   # A locally-ahead dev copy (installed > latest) is silently skipped.
-  lower=$(printf '%s\n%s' "$installed_version" "$latest_version" | sort -V | head -1)
+  lower=$(python3 -c "
+import sys
+a = tuple(int(x) for x in sys.argv[1].split('.') if x.isdigit())
+b = tuple(int(x) for x in sys.argv[2].split('.') if x.isdigit())
+print(sys.argv[1] if a <= b else sys.argv[2])
+" "$installed_version" "$latest_version")
   if [ "$lower" = "$installed_version" ]; then
     OUTDATED_NAMES+=("$entry_name")
     OUTDATED_INSTALLED_VERSIONS+=("$installed_version")
@@ -224,7 +237,13 @@ for i in "${!OUTDATED_NAMES[@]}"; do
   entry_project_path="${OUTDATED_PROJECT_PATHS[$i]}"
   installed_ver="${OUTDATED_INSTALLED_VERSIONS[$i]}"
   latest_ver="${OUTDATED_LATEST_VERSIONS[$i]}"
-  description="${PLUGIN_DESCRIPTION[$plugin_name]:-}"
+  description=""
+  for _pi in "${!PLUGIN_NAMES[@]}"; do
+    if [ "${PLUGIN_NAMES[$_pi]}" = "$plugin_name" ]; then
+      description="${PLUGIN_DESC[$_pi]}"
+      break
+    fi
+  done
 
   if [ "$entry_scope" = "project" ]; then
     echo "  ${plugin_name}  ${installed_ver} → ${latest_ver}  (scope: project, path: ${entry_project_path})"


### PR DESCRIPTION
## Summary

- Replaces `declare -A`, `mapfile`, and `sort -V` (all bash-4+/GNU-only) with bash-3.2-portable equivalents in `cleanup-merged-branches.sh`, `update-claude-config-plugins.sh`, and `nudge-handoff-near-context-cap.sh`
- The nudge hook's silent macOS failure was the most insidious: `|| true` swallowed the `mapfile` error, so the handoff nudge never fired without any visible signal
- Adds `test_no_bash4_constructs.py` — parametrized regression grep over all shipped `.sh` files with vacuous-pass guard and `# noqa-bash4` escape hatch
- Adds two fail-open behavioral tests to the nudge hook's test module
- Folds in sibling macOS fix: `sort -V → python3` integer-tuple version compare (same file, same portability theme)

## Incidental edits

- `sort -V` fix in `update-claude-config-plugins.sh` (line 175): same macOS-portability theme as the issue but a distinct mechanism — GNU-only flag replaced with portable `python3 -c` version compare using the existing `python3` dependency.

## Test plan

- [x] `pytest claude/.claude/` — 1725 passed, 19 skipped
- [x] `ruff check claude/.claude/` — clean
- [x] `test_no_bash4_constructs.py` passes on the rewritten tree (and sanity: fails if one file is reverted)
- [ ] Manual macOS verification: run `cleanup-merged-branches.sh --dry-run` and `update-claude-config-plugins.sh` under `/bin/bash` (bash 3.2.57) to confirm correct behavior; confirm nudge hook fires near the context cap

<!-- code-review:deferred:start -->
## Deferred review findings

| Finding | Source | DEFER criterion | Rationale |
|---------|--------|-----------------|-----------|
| Hook tests: `session_id`-absent-but-fields-present case not covered | staff-sdet | Contract pinned at another layer | Existing `test_empty_json_object_input_is_fail_open` covers the absent-session_id case; `{}` produces empty string for all four fields |
| Plugin version compare: `a <= b` treats `installed == latest` as outdated (same behavior as original `sort -V`) | staff-backend-engineer | Orthogonal scope | Pre-existing behavior faithfully preserved; the inline comment "strictly higher" predates this change; semantic fix is a separate concern |
| Plugin lookup: two identical 7-line linear search loops not extracted to a helper as the plan prescribed | staff-backend-engineer | Orthogonal scope | bash 3.2 lacks namerefs making a clean helper non-trivial; portability-only scope |
| Nudge hook: `mkdir`/`touch` on fired-marker path has no timeout; can block on NFS-mounted `$HOME` | staff-platform-engineer | Orthogonal scope | Pre-existing behavior, not introduced by this change |
| Nudge hook: INPUT parse `jq` in group redirect has no timeout | staff-platform-engineer | Orthogonal scope | Pre-existing behavior, not introduced by this change; payload is structurally small |
<!-- code-review:deferred:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)