### PR TITLE
test: add $HOME isolation to test_agent_reviews_directory_itself_not_exempt

### DIFF
--- a/claude/.claude/hooks/tests/test_require_plan_review.py
+++ b/claude/.claude/hooks/tests/test_require_plan_review.py
@@ -209,7 +209,7 @@ class TestRequirePlanReview:
             == "deny"
         )
 
-    def test_agent_reviews_directory_itself_not_exempt(self, plan_review_repo):
+    def test_agent_reviews_directory_itself_not_exempt(self, plan_review_repo, plan_review_home):
         """A write to the agent-reviews/ directory itself (no filename) is NOT exempt.
 
         The hook glob pattern is `agent-reviews/*` — a bare directory path with no


### PR DESCRIPTION
## Summary

- `require-plan-review.sh` runs its marker checks (active-marker read + potential `rm -f` on orphaned markers) at lines 95–109, **before** the path-glob deny at line 139 that this test asserts. Without a sandboxed `$HOME`, those checks read and may mutate the developer's real `~/.claude/.plan-review-active.d/` on each run.
- Every other gate-arming deny test in `TestRequirePlanReview` carries `plan_review_home` (which monkeypatches `$HOME` to a tmp sandbox) for exactly this reason. `test_agent_reviews_directory_itself_not_exempt` was the lone outlier — introduced in PR #368 as an oversight; its two sibling `*_not_exempt` tests (lines 173, 192) both carry the fixture.
- This PR adds `plan_review_home` to that one test, restoring a uniform invariant: all gate-arming deny tests sandbox `$HOME`. No assertions change; tests are green.

## Background: what the brief got wrong

A prior-session brief proposed the opposite: *removing* `plan_review_home` from `test_missing_file_path_denies` on the grounds that the fixture was "unused." After tracing the hook, the brief's premise was found to be incorrect — `plan_review_home` is a side-effecting fixture depended on for `monkeypatch.setenv("HOME", ...)`, not for a return value. The brief's logic, applied consistently, would de-isolate the entire deny suite. The actual defect was the single outlier test identified above.

## Test plan

- `pytest claude/.claude/hooks/tests/test_require_plan_review.py -v` — all tests green (verified locally)
- `ruff check claude/.claude/` — clean (verified locally)

<!-- code-review:deferred:start -->
## Deferred review findings

| Finding | Source | DEFER criterion | Rationale |
|---|---|---|---|
| No test guards the isolation invariant on the `rm -f` eviction path — a future fixture-scope change could silently cause the hook to `rm -f` a file in the real developer's `~/.claude/.plan-review-active.d/` with no failing test to signal it. (`test_require_plan_review.py:455`) | staff-sdet | Orthogonal scope | Concerns `test_dead_pid_active_marker_evicts_and_denies`, which this diff does not modify. Pre-existing gap. |
<!-- code-review:deferred:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)