### PR TITLE
fix(hooks): allow trailing 2>/dev/null on valid marker.sh commands

### DIFF
--- a/.claude/plans/marker-sh-allow-devnull-suffix.md
+++ b/.claude/plans/marker-sh-allow-devnull-suffix.md
@@ -1,0 +1,184 @@
+# Allow trailing `2>/dev/null` on valid marker.sh commands
+
+## Context
+
+**Goal:** Stop `enforce-marker-script-shape.sh` from denying an otherwise-valid
+marker.sh invocation that has a trailing `2>/dev/null` redirect, so agents stop
+spending a self-correcting retry turn on it.
+
+`~/.claude/scripts/marker.sh` writes skill-lifecycle gate markers; the hook
+`claude/.claude/hooks/enforce-marker-script-shape.sh` enforces a strict
+invocation-shape allowlist to prevent marker forgery via command injection. PR
+#362 already blessed `&&`-joined `write X && deactivate X` chains for
+`plan-review`/`ready-for-review` — the dominant friction case. One residual form
+remains: agents reflexively append `2>/dev/null` to suppress stderr, and the
+allowlist permits no suffix after the skill name, so the command is denied. The
+intended outcome is to bless that single neutral suffix on the existing valid
+shapes, with no new chaining or redirect-to-arbitrary-path surface.
+
+**Engineer decisions (this session):**
+- **Form 1 (`2>/dev/null`):** widen the hook, matching `2>/dev/null` as a fixed
+  literal. The hook is the uniform surface across *all* marker.sh calls; per-skill
+  prose would cover only two skills against a generic agent habit.
+- **Form 2 (`;` separator):** **leave denied — no change.** `&&` is already blessed
+  and is the correct idiom; `;` does not propagate exit codes (a failed `write`
+  would still run `deactivate`, leaving an active marker), so blessing it would
+  bless a semantically-worse form. A denied agent simply retries with `&&`.
+
+Because Form 2 is dropped and Form 1 is hook-only, **no SKILL.md files are
+edited.** The brief's §2 concern about Axis-3 `HOOK_TEST_FIXTURE` preserved
+content is therefore moot, and `/skill-review` is not triggered.
+
+## Approach
+
+Append an optional, literally-matched ` 2>/dev/null` to the trailing boundary of
+the two regexes that govern the friction forms:
+
+- **`VALID_PATTERN`** (line 75) — single-command shapes (`write`/`activate`/
+  `deactivate`/`clear-stale`).
+- **`VALID_CHAINED_MARKER_PATTERN`** (line 113) — the blessed write↔deactivate
+  `&&` chain; redirect goes on the whole chain's trailing boundary, matching the
+  observed form `write X && deactivate X 2>/dev/null`.
+
+The edit, in both patterns, replaces the trailing `[[:space:]]*$` with:
+
+```
+([[:space:]]+2>/dev/null)?[[:space:]]*$
+```
+
+`2>/dev/null` is a fixed literal — every character (`2 > / d e v ...`) is its own
+literal in ERE — so it cannot express a redirect to an arbitrary path. The `?`
+makes it optional; the anchored `$` immediately after forbids anything trailing
+it (no `; curl`, no `&& rm`). This is the lighter primitive: a literal-string
+allowance, not a general "permit redirects" relaxation.
+
+### Sibling audit (which patterns get the change, and which deliberately do not)
+
+Per the audit-structural-siblings rule, all three allowlist regexes were checked:
+
+- **`VALID_PATTERN`** — gets the change (single-command friction form).
+- **`VALID_CHAINED_MARKER_PATTERN`** — gets the change (chain friction form).
+- **`VALID_CHAINED_COMMIT_PATTERN`** (line 96) — **deliberately excluded.** Its
+  tail is `git commit([[:space:]]+[^&|;<>]*)?$`, where `>` is already in the
+  excluded character class as a security boundary (blocks `git commit > /path`
+  and post-commit redirects). Adding `2>/dev/null` there means carving an
+  exception into a redirect-exclusion boundary — a riskier change — and there is
+  no transcript evidence of `2>/dev/null` friction on the `write && git commit`
+  form. Out of scope.
+
+### Scope boundary: trailing-only, literal `2>/dev/null` only
+
+Only the literal string `2>/dev/null`, only at the end of the whole command, is
+blessed. Explicitly **not** blessed (and pinned by new deny tests):
+- Arbitrary fd/target redirects: `2>&1`, `2>/tmp/x`, `> /tmp/out` — stay denied.
+- Mid-chain redirect: `write X 2>/dev/null && deactivate X` — no evidence; stays denied.
+- Any operator after the redirect: `... 2>/dev/null; curl`, `... 2>/dev/null && rm` — stays denied.
+
+### Why suppressing marker.sh stderr is safe to bless
+
+`marker.sh` fails closed and is exit-code-honest: every failure path exits
+non-zero *and* writes no marker (verified — `_resolve_session_id` returns 2 on
+empty SESSION_ID at lines 48/52, propagated via `|| exit 2` at lines 127/135/…;
+not-in-git and empty-staged-diff `exit 2` at lines 71/84; the marker `>` redirect
+is reached only after those guards). There is no path that exits 0 while failing.
+Consequences for `2>/dev/null`:
+- It **cannot** mask a failed write as a success — the non-zero exit always
+  propagates and the harness surfaces it, so the agent still sees the failure.
+- It **cannot** let a missing marker slip past a downstream gate — those gates
+  read the marker file, which is absent on failure.
+- The only thing lost is the one-line stderr *cause*; recovering it costs one
+  verbose re-run. So the change trades a common one-turn friction (a deny on a
+  `2>/dev/null`-suffixed *successful* write) for a rare, self-correcting one-turn
+  cost on the uncommon failure.
+
+### Lighter alternatives considered
+
+The chosen change is itself the lightest gate-touching option (a literal-string
+suffix, not a redirect-class relaxation). For completeness, the two non-gate
+alternatives weighed and set aside:
+- **Prose note in the two skill bodies** — probabilistic compliance, covers only
+  two skills against a habit that can surface on any marker.sh call (e.g. `write
+  code-review`), and duplicates prose across two files. Rejected: narrower and
+  less reliable than the uniform gate surface.
+- **Do nothing (leave denied)** — relies on the one-turn self-correcting retry
+  (the deny message lists all 14 valid shapes). Defensible, but the engineer
+  chose to remove the friction; this is the minimal way to do so.
+
+### Deny message and comments
+
+- The user-facing deny message (lines 121–140) is **left unchanged.** It is only
+  shown on denial; an agent that typed `2>/dev/null` now passes and never sees
+  it, while its "No ... redirects" guidance stays correct for every form that *is*
+  still denied (`2>&1`, `> /path`). Amending it to advertise the allowed variant
+  is exactly the "teach which variants pass" expansion PR #362 reverted (brief §7).
+- The **code comments** at lines 13–18 and 71–74 say "No redirects" / "no
+  redirect" describing current behavior. Those describe behavior (not a preserved
+  record), so update them minimally to note the single `2>/dev/null` exception,
+  keeping comment and code in sync.
+
+## Critical files
+
+- **`claude/.claude/hooks/enforce-marker-script-shape.sh`** — edit `VALID_PATTERN`
+  (line 75) and `VALID_CHAINED_MARKER_PATTERN` (line 113) trailing boundaries;
+  update the descriptive comments at lines 13–18 and 71–74. Do **not** touch
+  `VALID_CHAINED_COMMIT_PATTERN` (line 96) or the deny message (lines 121–140).
+- **`claude/.claude/hooks/tests/test_enforce_marker_script_shape.py`** —
+  **additive only**; no existing test flips. Verified by inspection: the literal
+  `2>/dev/null` carries no newline (so the per-grep newline guard at lines 77/98/115
+  is unaffected), and every existing redirect deny test uses a form the literal
+  cannot match — `test_redirect_denied` (line 237, `> /tmp/out`),
+  `test_chain_marker_pair_trailing_redirect_denied` (line 220, `2>&1`),
+  `test_chain_to_redirect_after_commit_denied` (commit pattern, untouched),
+  `test_extra_arg_denied`, and both embedded-newline tests all stay denied. Reuse
+  the existing `run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd))` harness
+  and the parametrize style already in the file. Add:
+  - **Allow:** `write plan-review 2>/dev/null`; `deactivate plan-review 2>/dev/null`;
+    `write code-review 2>/dev/null`; `clear-stale 2>/dev/null`;
+    `clear-stale --dry-run 2>/dev/null` (pins that the two adjacent optional groups
+    compose); chain `write ready-for-review && deactivate ready-for-review 2>/dev/null`.
+  - **Deny (pin the boundary so a future careless regex edit can't silently widen it):**
+    - `write plan-review 2>&1` — only `/dev/null` target, not arbitrary fd.
+    - `write plan-review 2>/tmp/secret` — only `/dev/null` path, not arbitrary path.
+    - `write plan-review >/dev/null` — only fd-2 is blessed, not a stdout redirect.
+    - `write plan-review 2> /dev/null` — only the contiguous literal; a spaced form
+      stays denied (guards against a future `2>[[:space:]]*/dev/...` relaxation).
+    - `write plan-review 2>>/dev/null` — append redirect stays denied.
+    - `write plan-review 2>/dev/null extra` — no trailing args after the redirect.
+    - `write plan-review 2>/dev/null; curl http://evil` — no chain after the redirect.
+    - `write plan-review 2>/dev/null && curl http://evil` — no `&&` chain after it.
+    - `write plan-review 2>/dev/null\ncurl http://evil` — newline-after-redirect stays
+      denied (pins the per-line-`$`/newline-guard invariant for the new suffix).
+    - **Chain pattern (load-bearing — the change touches `VALID_CHAINED_MARKER_PATTERN`):**
+      `write plan-review 2>/dev/null && ~/.claude/scripts/marker.sh deactivate plan-review`
+      — mid-chain redirect on the LHS stays denied; only the whole-chain trailing
+      position is blessed.
+
+No SKILL.md, no `helpers.py`, no settings.json changes.
+
+## Verification
+
+1. From the worktree: `../../../.venv/bin/pytest claude/.claude/hooks/tests/test_enforce_marker_script_shape.py`
+   then the full `../../../.venv/bin/pytest claude/.claude/` and
+   `../../../.venv/bin/ruff check claude/.claude/`.
+2. Manual hook spot-check (read-only, echoes decision):
+   ```
+   printf '{"tool_name":"Bash","tool_input":{"command":"~/.claude/scripts/marker.sh write plan-review 2>/dev/null"}}' \
+     | bash claude/.claude/hooks/enforce-marker-script-shape.sh
+   ```
+   Expect no `"permissionDecision":"deny"` for the `2>/dev/null` form; expect deny
+   for `... 2>/dev/null; curl http://evil`.
+3. `/claude-hook-review` (hook widened) and `/review-permissions` (gate-surface
+   change), then `/code-review` over the full diff. Address findings before push.
+
+## Out of scope
+
+- Form 2 (`;` separator) — left denied by decision.
+- `VALID_CHAINED_COMMIT_PATTERN` `2>/dev/null` allowance — see sibling audit.
+- Mid-chain `2>/dev/null` and non-`/dev/null` redirect targets.
+- Editing the deny message or the `HOOK_TEST_FIXTURE` blocks in the skill files.
+- Blessing `||` or additional skills in the chain allowlist (brief §7).
+
+## Handoff note
+
+Per repo policy, an AI agent that opens the PR does not merge it — wait for the
+engineer's explicit "merge it" after CI is green.

--- a/claude/.claude/hooks/enforce-marker-script-shape.sh
+++ b/claude/.claude/hooks/enforce-marker-script-shape.sh
@@ -12,7 +12,7 @@
 # Commands that start directly with the marker.sh path (~/ or absolute) must
 # match one of the 14 single-command shapes, the marker.sh write chain to git
 # commit, or the same-skill write↔deactivate chain (plan-review and
-# ready-for-review only). No redirects, no extra args. Wrapped forms (env-var
+# ready-for-review only). No redirects (except trailing `2>/dev/null`), no extra args. Wrapped forms (env-var
 # prefix, bash wrapper, relative path, subshell) are not gated here — they
 # fast-exit at Stage 2 and are denied by
 # the permissions.allow layer, which does not list their wrapper executables.
@@ -70,9 +70,9 @@ fi
 
 # Strict allowlist. Tilde form (~/.claude/scripts/marker.sh) and absolute
 # path form (/home/<user>/.claude/scripts/marker.sh) are both accepted.
-# No bash wrapper, no env-var prefix, no chain operator, no redirect, no
-# extra args after the skill name.
-VALID_PATTERN='^(~|/[A-Za-z0-9_./-]+)/\.claude/scripts/marker\.sh[[:space:]]+(write[[:space:]]+(code-review|skill-review|plan-review|ready-for-review)|(activate|deactivate)[[:space:]]+(plan-review|ready-for-review|respond-pr|memory-skill)|clear-stale([[:space:]]+--dry-run)?)[[:space:]]*$'
+# No bash wrapper, no env-var prefix, no chain operator, no redirect (except
+# trailing `2>/dev/null`), no extra args after the skill name.
+VALID_PATTERN='^(~|/[A-Za-z0-9_./-]+)/\.claude/scripts/marker\.sh[[:space:]]+(write[[:space:]]+(code-review|skill-review|plan-review|ready-for-review)|(activate|deactivate)[[:space:]]+(plan-review|ready-for-review|respond-pr|memory-skill)|clear-stale([[:space:]]+--dry-run)?)([[:space:]]+2>/dev/null)?[[:space:]]*$'
 
 if [[ "$TRIMMED" != *$'\n'* ]] && printf '%s' "$TRIMMED" | grep -qE "$VALID_PATTERN"; then
   exit 0
@@ -110,7 +110,7 @@ fi
 # NOTE: This pattern depends on the line-51 traversal guard running first — that
 # check is the sole validator of the RHS path (Stage 2's anchor at line 65 only
 # checks position 0 = the LHS). Do not move this block above line 51.
-VALID_CHAINED_MARKER_PATTERN='^((~|/[A-Za-z0-9_./-]+)/\.claude/scripts/marker\.sh[[:space:]]+write[[:space:]]+plan-review[[:space:]]*&&[[:space:]]*(~|/[A-Za-z0-9_./-]+)/\.claude/scripts/marker\.sh[[:space:]]+deactivate[[:space:]]+plan-review|(~|/[A-Za-z0-9_./-]+)/\.claude/scripts/marker\.sh[[:space:]]+deactivate[[:space:]]+plan-review[[:space:]]*&&[[:space:]]*(~|/[A-Za-z0-9_./-]+)/\.claude/scripts/marker\.sh[[:space:]]+write[[:space:]]+plan-review|(~|/[A-Za-z0-9_./-]+)/\.claude/scripts/marker\.sh[[:space:]]+write[[:space:]]+ready-for-review[[:space:]]*&&[[:space:]]*(~|/[A-Za-z0-9_./-]+)/\.claude/scripts/marker\.sh[[:space:]]+deactivate[[:space:]]+ready-for-review|(~|/[A-Za-z0-9_./-]+)/\.claude/scripts/marker\.sh[[:space:]]+deactivate[[:space:]]+ready-for-review[[:space:]]*&&[[:space:]]*(~|/[A-Za-z0-9_./-]+)/\.claude/scripts/marker\.sh[[:space:]]+write[[:space:]]+ready-for-review)[[:space:]]*$'
+VALID_CHAINED_MARKER_PATTERN='^((~|/[A-Za-z0-9_./-]+)/\.claude/scripts/marker\.sh[[:space:]]+write[[:space:]]+plan-review[[:space:]]*&&[[:space:]]*(~|/[A-Za-z0-9_./-]+)/\.claude/scripts/marker\.sh[[:space:]]+deactivate[[:space:]]+plan-review|(~|/[A-Za-z0-9_./-]+)/\.claude/scripts/marker\.sh[[:space:]]+deactivate[[:space:]]+plan-review[[:space:]]*&&[[:space:]]*(~|/[A-Za-z0-9_./-]+)/\.claude/scripts/marker\.sh[[:space:]]+write[[:space:]]+plan-review|(~|/[A-Za-z0-9_./-]+)/\.claude/scripts/marker\.sh[[:space:]]+write[[:space:]]+ready-for-review[[:space:]]*&&[[:space:]]*(~|/[A-Za-z0-9_./-]+)/\.claude/scripts/marker\.sh[[:space:]]+deactivate[[:space:]]+ready-for-review|(~|/[A-Za-z0-9_./-]+)/\.claude/scripts/marker\.sh[[:space:]]+deactivate[[:space:]]+ready-for-review[[:space:]]*&&[[:space:]]*(~|/[A-Za-z0-9_./-]+)/\.claude/scripts/marker\.sh[[:space:]]+write[[:space:]]+ready-for-review)([[:space:]]+2>/dev/null)?[[:space:]]*$'
 
 if [[ "$TRIMMED" != *$'\n'* ]] && printf '%s' "$TRIMMED" | grep -qE "$VALID_CHAINED_MARKER_PATTERN"; then
   exit 0
@@ -136,5 +136,5 @@ Valid shapes:
   ~/.claude/scripts/marker.sh clear-stale
   ~/.claude/scripts/marker.sh clear-stale --dry-run
 
-No chains (&&, ||, ;), redirects, or extra args. Env-var prefix, bash wrapper,
+No chains (&&, ||, ;), arbitrary redirects, or extra args. Env-var prefix, bash wrapper,
 and relative-path forms are not gated here — they are denied by permissions.allow."

--- a/claude/.claude/hooks/enforce-marker-script-shape.sh
+++ b/claude/.claude/hooks/enforce-marker-script-shape.sh
@@ -140,5 +140,5 @@ Valid shapes:
   ~/.claude/scripts/marker.sh clear-stale
   ~/.claude/scripts/marker.sh clear-stale --dry-run
 
-No chains (&&, ||, ;), redirects other than 2>/dev/null, or extra args. Env-var prefix, bash wrapper,
+No chains (&&, ||, ;), redirects, or extra args. Env-var prefix, bash wrapper,
 and relative-path forms are not gated here — they are denied by permissions.allow."

--- a/claude/.claude/hooks/enforce-marker-script-shape.sh
+++ b/claude/.claude/hooks/enforce-marker-script-shape.sh
@@ -93,6 +93,10 @@ fi
 # containing them are uncommon enough that denying would be more disruptive than
 # the marginal forge-vector they represent, and substitution is itself gated
 # elsewhere.
+# Note: 2>/dev/null is intentionally NOT blessed here. The tail class [^&|;<>]
+# already excludes '>' as a security boundary (prevents post-commit redirects like
+# `git commit > /path`). A 2>/dev/null exception would require carving out of that
+# class with no observed agent friction on the commit-chain form to justify it.
 VALID_CHAINED_COMMIT_PATTERN='^((~|/[A-Za-z0-9_./-]+)/\.claude/scripts/marker\.sh[[:space:]]+write[[:space:]]+(code-review|skill-review|plan-review|ready-for-review)[[:space:]]*&&[[:space:]]*)+git[[:space:]]+commit([[:space:]]+[^&|;<>]*)?$'
 
 if [[ "$TRIMMED" != *$'\n'* ]] && printf '%s' "$TRIMMED" | grep -qE "$VALID_CHAINED_COMMIT_PATTERN"; then

--- a/claude/.claude/hooks/enforce-marker-script-shape.sh
+++ b/claude/.claude/hooks/enforce-marker-script-shape.sh
@@ -136,5 +136,5 @@ Valid shapes:
   ~/.claude/scripts/marker.sh clear-stale
   ~/.claude/scripts/marker.sh clear-stale --dry-run
 
-No chains (&&, ||, ;), arbitrary redirects, or extra args. Env-var prefix, bash wrapper,
+No chains (&&, ||, ;), redirects other than 2>/dev/null, or extra args. Env-var prefix, bash wrapper,
 and relative-path forms are not gated here — they are denied by permissions.allow."

--- a/claude/.claude/hooks/tests/test_enforce_marker_script_shape.py
+++ b/claude/.claude/hooks/tests/test_enforce_marker_script_shape.py
@@ -400,3 +400,71 @@ class TestEnforceMarkerScriptShape:
         """
         cmd = "~/.claude/scripts/../scripts/marker.sh activate code-review"
         assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "deny"
+
+
+class TestDevNullRedirectAllowed:
+    """Trailing 2>/dev/null on an otherwise-valid shape is allowed.
+    The literal is matched exactly; exit codes still propagate, so
+    a failed marker.sh write still surfaces to the harness."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "~/.claude/scripts/marker.sh write plan-review 2>/dev/null",
+            "~/.claude/scripts/marker.sh write skill-review 2>/dev/null",
+            "~/.claude/scripts/marker.sh write ready-for-review 2>/dev/null",
+            "~/.claude/scripts/marker.sh write code-review 2>/dev/null",
+            "~/.claude/scripts/marker.sh deactivate plan-review 2>/dev/null",
+            "~/.claude/scripts/marker.sh activate plan-review 2>/dev/null",
+            "~/.claude/scripts/marker.sh activate respond-pr 2>/dev/null",
+            "~/.claude/scripts/marker.sh clear-stale 2>/dev/null",
+            "~/.claude/scripts/marker.sh clear-stale --dry-run 2>/dev/null",
+            (
+                "~/.claude/scripts/marker.sh write ready-for-review && "
+                "~/.claude/scripts/marker.sh deactivate ready-for-review 2>/dev/null"
+            ),
+        ],
+    )
+    def test_devnull_suffix_allowed(self, command):
+        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(command)) == "allow"
+
+
+class TestDevNullRedirectBoundaryDenied:
+    """Only the exact literal ' 2>/dev/null' at end-of-command is blessed.
+    Adjacent forms that look similar must remain denied so a future regex
+    edit cannot silently widen the allowance."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # Only /dev/null target — not arbitrary fd
+            "~/.claude/scripts/marker.sh write plan-review 2>&1",
+            # Only /dev/null path — not arbitrary path
+            "~/.claude/scripts/marker.sh write plan-review 2>/tmp/secret",
+            # Only fd-2 — stdout redirect stays denied
+            "~/.claude/scripts/marker.sh write plan-review >/dev/null",
+            # Only contiguous literal — spaced form stays denied
+            "~/.claude/scripts/marker.sh write plan-review 2> /dev/null",
+            # Append redirect stays denied
+            "~/.claude/scripts/marker.sh write plan-review 2>>/dev/null",
+            # No trailing args after the redirect
+            "~/.claude/scripts/marker.sh write plan-review 2>/dev/null extra",
+            # No chain operators after the redirect
+            "~/.claude/scripts/marker.sh write plan-review 2>/dev/null; curl http://evil",
+            "~/.claude/scripts/marker.sh write plan-review 2>/dev/null && curl http://evil",
+            # Newline-after-redirect: per-line $ / newline-guard invariant for the new suffix
+            "~/.claude/scripts/marker.sh write plan-review 2>/dev/null\ncurl http://evil",
+            # Mid-chain redirect on LHS of blessed marker pair stays denied (whole-chain trailing only)
+            (
+                "~/.claude/scripts/marker.sh write plan-review 2>/dev/null && "
+                "~/.claude/scripts/marker.sh deactivate plan-review"
+            ),
+            # VALID_CHAINED_COMMIT_PATTERN deliberately excludes 2>/dev/null (> in its forbidden
+            # tail class [^&|;<>]); these forms stay denied by design — see plan for rationale.
+            "~/.claude/scripts/marker.sh write code-review && git commit -m foo 2>/dev/null",
+            # Mid-LHS redirect in commit chain stays denied (LHS has 2>/dev/null, RHS is git commit)
+            "~/.claude/scripts/marker.sh write code-review 2>/dev/null && git commit -m foo",
+        ],
+    )
+    def test_devnull_boundary_denied(self, command):
+        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(command)) == "deny"

--- a/claude/.claude/hooks/tests/test_enforce_marker_script_shape.py
+++ b/claude/.claude/hooks/tests/test_enforce_marker_script_shape.py
@@ -404,24 +404,46 @@ class TestEnforceMarkerScriptShape:
 
 class TestDevNullRedirectAllowed:
     """Trailing 2>/dev/null on an otherwise-valid shape is allowed.
-    The literal is matched exactly; exit codes still propagate, so
-    a failed marker.sh write still surfaces to the harness."""
+    The literal is matched exactly; stderr is suppressed by shell fd-2
+    redirect semantics, which do not affect exit-code propagation."""
 
     @pytest.mark.parametrize(
         "command",
         [
+            # write — all four targets
             "~/.claude/scripts/marker.sh write plan-review 2>/dev/null",
             "~/.claude/scripts/marker.sh write skill-review 2>/dev/null",
             "~/.claude/scripts/marker.sh write ready-for-review 2>/dev/null",
             "~/.claude/scripts/marker.sh write code-review 2>/dev/null",
+            # deactivate — all four targets
             "~/.claude/scripts/marker.sh deactivate plan-review 2>/dev/null",
+            "~/.claude/scripts/marker.sh deactivate ready-for-review 2>/dev/null",
+            "~/.claude/scripts/marker.sh deactivate respond-pr 2>/dev/null",
+            "~/.claude/scripts/marker.sh deactivate memory-skill 2>/dev/null",
+            # activate — all four targets
             "~/.claude/scripts/marker.sh activate plan-review 2>/dev/null",
+            "~/.claude/scripts/marker.sh activate ready-for-review 2>/dev/null",
             "~/.claude/scripts/marker.sh activate respond-pr 2>/dev/null",
+            "~/.claude/scripts/marker.sh activate memory-skill 2>/dev/null",
+            # clear-stale — both forms
             "~/.claude/scripts/marker.sh clear-stale 2>/dev/null",
             "~/.claude/scripts/marker.sh clear-stale --dry-run 2>/dev/null",
+            # chained-marker pairs — all four orderings (two skills × write-first/deactivate-first)
+            (
+                "~/.claude/scripts/marker.sh write plan-review && "
+                "~/.claude/scripts/marker.sh deactivate plan-review 2>/dev/null"
+            ),
+            (
+                "~/.claude/scripts/marker.sh deactivate plan-review && "
+                "~/.claude/scripts/marker.sh write plan-review 2>/dev/null"
+            ),
             (
                 "~/.claude/scripts/marker.sh write ready-for-review && "
                 "~/.claude/scripts/marker.sh deactivate ready-for-review 2>/dev/null"
+            ),
+            (
+                "~/.claude/scripts/marker.sh deactivate ready-for-review && "
+                "~/.claude/scripts/marker.sh write ready-for-review 2>/dev/null"
             ),
         ],
     )
@@ -454,10 +476,22 @@ class TestDevNullRedirectBoundaryDenied:
             "~/.claude/scripts/marker.sh write plan-review 2>/dev/null && curl http://evil",
             # Newline-after-redirect: per-line $ / newline-guard invariant for the new suffix
             "~/.claude/scripts/marker.sh write plan-review 2>/dev/null\ncurl http://evil",
-            # Mid-chain redirect on LHS of blessed marker pair stays denied (whole-chain trailing only)
+            # Mid-chain redirect on LHS stays denied (whole-chain trailing only) — all four orderings
             (
                 "~/.claude/scripts/marker.sh write plan-review 2>/dev/null && "
                 "~/.claude/scripts/marker.sh deactivate plan-review"
+            ),
+            (
+                "~/.claude/scripts/marker.sh deactivate plan-review 2>/dev/null && "
+                "~/.claude/scripts/marker.sh write plan-review"
+            ),
+            (
+                "~/.claude/scripts/marker.sh write ready-for-review 2>/dev/null && "
+                "~/.claude/scripts/marker.sh deactivate ready-for-review"
+            ),
+            (
+                "~/.claude/scripts/marker.sh deactivate ready-for-review 2>/dev/null && "
+                "~/.claude/scripts/marker.sh write ready-for-review"
             ),
             # VALID_CHAINED_COMMIT_PATTERN deliberately excludes 2>/dev/null (> in its forbidden
             # tail class [^&|;<>]); these forms stay denied by design — see plan for rationale.

--- a/claude/.claude/hooks/tests/test_enforce_marker_script_shape.py
+++ b/claude/.claude/hooks/tests/test_enforce_marker_script_shape.py
@@ -215,6 +215,11 @@ class TestEnforceMarkerScriptShape:
         cmd = "~/.claude/scripts/marker.sh activate plan-review && ~/.claude/scripts/marker.sh deactivate plan-review"
         assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "deny"
 
+    def test_chain_activate_write_pair_denied(self):
+        """activate+write is not a blessed pair; only write↔deactivate is."""
+        cmd = "~/.claude/scripts/marker.sh activate plan-review && ~/.claude/scripts/marker.sh write plan-review"
+        assert run_hook(ENFORCE_MARKER_SCRIPT_SHAPE_HOOK, bash_input(cmd)) == "deny"
+
     def test_chain_marker_pair_trailing_redirect_denied(self):
         """Trailing redirect; anchored pattern must reject any suffix after the pair."""
         cmd = "~/.claude/scripts/marker.sh write plan-review && ~/.claude/scripts/marker.sh deactivate plan-review 2>&1"
@@ -428,6 +433,8 @@ class TestDevNullRedirectAllowed:
             # clear-stale — both forms
             "~/.claude/scripts/marker.sh clear-stale 2>/dev/null",
             "~/.claude/scripts/marker.sh clear-stale --dry-run 2>/dev/null",
+            # absolute-path form — confirms path parity under the 2>/dev/null arm
+            "/home/testuser/.claude/scripts/marker.sh write code-review 2>/dev/null",
             # chained-marker pairs — all four orderings (two skills × write-first/deactivate-first)
             (
                 "~/.claude/scripts/marker.sh write plan-review && "


### PR DESCRIPTION
## Summary

- Agents reflexively append `2>/dev/null` to suppress stderr, but `enforce-marker-script-shape.sh` denied any suffix after the skill name, costing a one-turn recovery retry on every such invocation.
- Extended `VALID_PATTERN` and `VALID_CHAINED_MARKER_PATTERN` to accept an optional trailing ` 2>/dev/null` as a fixed ERE literal. `VALID_CHAINED_COMMIT_PATTERN` is deliberately excluded — its `[^&|;<>]*` tail already treats `>` as a forbidden boundary character, and there is no transcript evidence of friction on the `write && git commit` form (documented via comment at the pattern site).
- `marker.sh` is exit-code-honest on all failure paths (every guard exits 2 before reaching the marker write), so suppressing stderr cannot mask a failed write; the non-zero exit still propagates and downstream gates still deny.

## What changed

**`claude/.claude/hooks/enforce-marker-script-shape.sh`**
- `VALID_PATTERN` (line 75): `([[:space:]]+2>/dev/null)?` appended before trailing `[[:space:]]*$`
- `VALID_CHAINED_MARKER_PATTERN` (line 113): same trailing extension
- `VALID_CHAINED_COMMIT_PATTERN` (line 96): comment added noting the intentional `2>/dev/null` exclusion and why
- Two comment blocks updated to note the `2>/dev/null` exception

**`claude/.claude/hooks/tests/test_enforce_marker_script_shape.py`**
- Additive only — no existing tests flip
- `TestDevNullRedirectAllowed` (19 allow cases): all write/activate/deactivate targets, both `clear-stale` forms, absolute-path parity case, all four chained-marker orderings
- `TestDevNullRedirectBoundaryDenied` (16 deny cases): pins the boundary against `2>&1`, `2>/tmp/x`, `>/dev/null`, spaced `2> /dev/null`, `2>>/dev/null`, trailing args, chain operators after the suffix, newline injection, all four LHS-redirect orderings in the marker-pair pattern, and both commit-chain forms
- `test_chain_activate_write_pair_denied`: pins that `activate+write` is not a blessed chain pair

## Security review

Reviewed by `ciso-reviewer` and `staff-platform-engineer`:
- `2>/dev/null` in ERE is a fixed literal; `/` and `>` carry no metacharacter meaning in ERE context. The `$` anchor immediately after the optional group prevents anything from riding after it.
- The newline guard (`[[ "$TRIMMED" != *$'\n'* ]] &&`) runs before every grep call, fully closing the per-line-`$` interaction.
- Only the exact byte sequence ` 2>/dev/null` passes; `2>&1`, `2>/tmp/x`, `>/dev/null`, and `2> /dev/null` all continue to be denied.
- No latency, blocking, or operational footprint change.

## Test plan

- [x] `pytest claude/.claude/hooks/tests/test_enforce_marker_script_shape.py` — 105 passed
- [x] Full suite: 1770 passed, 19 skipped
- [x] `ruff check claude/.claude/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)