### PR TITLE
fix(skills): correct Lovable skill file path and propagation model

### DIFF
--- a/.claude/plans/lovable-skill-path-and-propagation-fix.md
+++ b/.claude/plans/lovable-skill-path-and-propagation-fix.md
@@ -1,0 +1,154 @@
+# Plan: Lovable skill files are editable — correct path + propagation in `lovable-cloud-knowledge`
+
+## Context
+
+A project-implementing session that had Lovable skills loaded got into a false scope panic:
+it read its project's CLAUDE.md rule — *"treat this directory [`.agents/skills/`] as
+Lovable-owned: do not edit"* — as an absolute prohibition, and flagged a prior session's
+legitimate edit to those files (authored by `gpt-engineer-app[bot]`) as *"a direct violation."*
+
+Clarification confirmed: **editing Lovable skill files is fine.** The repo file is a normal
+review surface; the only requirement is that the PR description tell Lovable to **re-read the
+changed files and update its skills** (Lovable confirmed in-product that it can apply changes
+from the repo files itself). Two corrections fall out of this:
+
+1. **Path.** The distributed `lovable-cloud-knowledge` skill documents Lovable skill files at
+   `.lovable/skills/*.md`. That path was an arbitrary local convention — not derived from
+   Lovable's own file-creation behavior. When Lovable creates a skill it **auto-writes it to
+   `.agents/skills/`** — that is the canonical path, and it is what the skill (and related docs)
+   should say.
+2. **Propagation model.** The skill currently lumps skill bodies into the knowledge-field
+   "repo-mirror, human pastes into the UI" model (§4 item 5: *"skill bodies → Settings →
+   Skills"*). That is wrong for skills: `.agents/skills/` files are the source Lovable reads,
+   not a mirror of a UI field. Propagation is *"instruct Lovable to re-read the repo files,"*
+   not *"paste into a Settings field."*
+
+**Intended outcome:** the reusable `lovable-cloud-knowledge` skill states plainly that
+Lovable-authored skill files (`.agents/skills/`) are editable via PR and how their changes
+reach Lovable — so no future session re-derives the false "do not edit" reading. Plus
+drop-in replacement text for the private project's CLAUDE.md rule (the actual trigger), which
+the user applies in that repo since it is not reachable from `claude-config`.
+
+## Approach
+
+Knowledge fields and skills are **two different models**; the current skill conflates them.
+The edit separates them:
+
+| | Knowledge fields | Skills |
+|---|---|---|
+| Canonical home | Lovable UI field (Settings → Knowledge) | `.agents/skills/*.md` in the repo |
+| Repo file role | Manual version-controlled **mirror** (`.lovable/*.md`) | The **source** Lovable reads (auto-written by Lovable) |
+| Editable in repo? | Yes, via PR | Yes, via PR — Lovable-authorship does **not** make them read-only |
+| Propagation | Human pastes merged content into the UI | PR description instructs Lovable to re-read the changed files and update its skills |
+
+Knowledge-field guidance (§1 table, §2 mirror workflow, the `.lovable/*.md` paths) is
+**unchanged** — those files are UI-only and the manual-mirror convention stands. Only the
+skill-file treatment changes: path `.lovable/skills/*.md` → `.agents/skills/*.md`, and the
+propagation/editability correction.
+
+Grounding: the Lovable Skills doc (docs.lovable.dev/features/skills) confirms an
+"Import from GitHub" pull-based path exists but pins **neither** a repo directory nor an
+auto-sync mechanism — so `.agents/skills/` as canonical and "Lovable re-reads the repo files"
+rest on Lovable's observed in-product behavior, recorded as such in REFERENCES.md rather than
+asserted as documented fact.
+
+### Why the skill, not a memory or CLAUDE.md rule
+
+`lovable-cloud-knowledge` is the single authoritative home for "how Lovable knowledge/skill
+files work," distributed via the `lovable-cloud` plugin to every project that installs it.
+Encoding the editability + propagation rule there fixes the general case for all consumers.
+The private project's CLAUDE.md is the *trigger* but the wrong home for the general rule — it
+gets a short rule that **defers to** the skill (see Deliverable 2), not a restatement.
+
+## Critical files
+
+**Edit — `plugins/lovable-cloud/skills/lovable-cloud-knowledge/SKILL.md`** (primary):
+- **Frontmatter description** (lines 4–9): change the skill-file token `.lovable/skills/*.md`
+  → `.agents/skills/*.md` in TRIGGER; keep `.lovable/*.md` for knowledge. Keep DO NOT TRIGGER
+  coherent.
+- **§1 table** (line 20, "Workspace Skills" column): note skills live in `.agents/skills/`.
+- **§2 repo-mirror workflow** (lines 31–51): scope its "UI field is the only thing Lovable
+  reads / writing to the repo does not propagate" claims explicitly to **knowledge fields**,
+  so they no longer read as applying to skills.
+- **New skill-file subsection** (after §2): skills live in `.agents/skills/` (Lovable writes
+  them there — phrase as observed behavior, cross-linking REFERENCES.md, **not** as a
+  doc-pinned spec, so a future reader re-verifies if Lovable's layout changes); they are
+  normal repo files **editable via PR by humans or other agents** — being authored by Lovable
+  / `gpt-engineer-app[bot]` does not make them read-only; propagation = the PR description must
+  instruct Lovable (second person) to re-read the changed files and update its skills.
+  **Carve-out:** the "Last synced to Lovable UI" header/date is a *knowledge-mirror* concept
+  (§2) and does **not** apply to `.agents/skills/` files — they are the source Lovable reads,
+  not a mirror of a UI field, so they carry no sync-date header.
+- **§3 char budget** (line 63): `.lovable/skills/*.md` → `.agents/skills/*.md`.
+- **§4 review checklist** (lines 70, 85): path token updates; **revise item 5** so skill files
+  use "PR description instructs Lovable to re-read the changed repo files" propagation, while
+  knowledge files keep "human pastes merged content into Settings → Knowledge." The skill-file
+  branch checks for the **re-read instruction**, not a "Last synced" date (sync-date is
+  knowledge-mirror-only, per the §2 carve-out above).
+
+**Edit — `plugins/lovable-cloud/skills/lovable-cloud-knowledge/REFERENCES.md`**:
+- Record the decision: `.agents/skills/` is canonical (observed from Lovable's own
+  file-creation behavior); `.lovable/skills/` was a deprecated local convention; the
+  GitHub-import / repo-read propagation path (docs confirm import-from-GitHub exists, but
+  pins no path or auto-sync). Per the repo's "decision records go in REFERENCES.md" convention.
+
+**Edit — `plugins/lovable-cloud/.claude-plugin/plugin.json`** (line: `"version": "2.4.1"`):
+- Bump per the `plugin-semver` skill. New guidance + corrected behavior → likely **minor**
+  (`2.5.0`); confirm at implementation by running the skill.
+
+**Edit (secondary, consistency) — `claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md`**
+line 7: its `DO NOT TRIGGER when: editing .lovable/*.md` boundary should also exclude
+`.agents/skills/*.md`, so it defers to `lovable-cloud-knowledge` for Lovable skill files
+instead of firing on them. Small, in-the-same-spirit touch; in scope per the user's request to
+update "related docs/instructions/skills."
+
+**No change:** `README.md:179`, `plugin.json` description, `docs/skills.md:21`,
+`lovable-cloud-edge-functions/*`, `lovable-cloud-migration-sync/*` — none reference a
+skill-file path; grep-confirmed.
+
+### Reuse / consistency opportunities
+- Mirror the **second-person "message to Lovable"** pattern already used by
+  `lovable-cloud-migration-sync/SKILL.md:49,54` (a copy-paste message addressed to Lovable)
+  when wording the new "instruct Lovable to re-read the files" guidance — same family, keep
+  the voice consistent.
+- Reuse §3's existing **100,000-char skill limit** and behavior-test discipline; the new
+  subsection should not restate them, only cross-link.
+
+## Deliverables outside the edit
+
+**Deliverable 2 — private project CLAUDE.md reconciliation text** (user applies it in that
+repo; not reachable from here). Drop-in replacement for the *"treat this directory as
+Lovable-owned: do not edit"* rule, roughly:
+
+> `.agents/skills/` holds Lovable-authored workspace skills. You **may** edit them via PR —
+> Lovable authorship does not make them read-only. When a PR changes them, add a note in the
+> PR description instructing Lovable to re-read the changed files and update its skills. See
+> the `lovable-cloud-knowledge` skill for the full workflow.
+
+This is produced as text in the implementation output, not committed to `claude-config`.
+
+## Verification
+
+- `.venv/bin/pytest claude/.claude/` and `.venv/bin/ruff check claude/.claude/` (frontmatter /
+  structural tests for skills) pass.
+- **`/skill-review`** on the `lovable-cloud-knowledge` SKILL.md diff (hook-enforced) **and** on
+  the `ai-instruction-and-memory-files` SKILL.md diff — run the skill on its own edited bodies
+  per the repo's "run the skill on its own diff" rule; confirm the behavioral-equivalence
+  markers are written.
+- **`plugin-semver`** confirms the version bump is correct for the change class.
+- **`/code-review`** (dispatches `/skill-review` per file type) before presenting.
+- Manual read-through: knowledge-field guidance unchanged; skill-file guidance now says
+  `.agents/skills/`, editable-via-PR, propagation-by-instructing-Lovable; no internal
+  contradiction between §2's knowledge claims and the new skill subsection.
+- Grep check: no remaining `.lovable/skills` outside REFERENCES.md's "deprecated convention"
+  note.
+
+## Out of scope
+
+- **Editing the private project's CLAUDE.md** — different repo, unreachable from here;
+  delivered as text (Deliverable 2) for the user to apply.
+- **Reclassifying the knowledge mirror files** (`.lovable/project-knowledge.md`,
+  `.lovable/workspace-knowledge.md`). The correction was about *skills*; knowledge fields
+  are UI-only with no canonical repo path, so the `.lovable/*.md` mirror convention stays.
+- Sibling skills (`edge-functions`, `migration-sync`) and README/plugin description — no
+  skill-file path references; untouched.

--- a/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
+++ b/claude/.claude/skills/ai-instruction-and-memory-files/SKILL.md
@@ -4,8 +4,8 @@ description: >
   Audit of CLAUDE.md, AGENTS.md, and Claude Code auto-memory files.
   TRIGGER when: authoring/reviewing a CLAUDE.md, AGENTS.md, or
   ~/.claude/projects/*/memory/ change, or deciding which surface a rule
-  belongs in. DO NOT TRIGGER when: editing .lovable/*.md, .cursorrules,
-  .github/copilot-instructions.md, README.md, or writing code.
+  belongs in. DO NOT TRIGGER when: editing .lovable/*.md, .agents/skills/*.md,
+  .cursorrules, .github/copilot-instructions.md, README.md, or writing code.
 user-invocable: false
 ---
 

--- a/plugins/lovable-cloud/.claude-plugin/plugin.json
+++ b/plugins/lovable-cloud/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lovable-cloud",
   "description": "Skills for Lovable Cloud projects — Project/Workspace Knowledge fields, edge-function auth model, and migration-sync workflow.",
-  "version": "2.4.1",
+  "version": "3.0.0",
   "author": {
     "name": "Cordova Strategy"
   },

--- a/plugins/lovable-cloud/skills/lovable-cloud-knowledge/REFERENCES.md
+++ b/plugins/lovable-cloud/skills/lovable-cloud-knowledge/REFERENCES.md
@@ -41,21 +41,3 @@ All four are loaded every session. Lovable docs warn that in very long conversat
 ## Cross-agent context
 
 - [agents.md standard](https://agents.md) — the cross-agent AGENTS.md spec referenced in the four-source priority list above. Lovable, Codex, Cursor, Aider, etc. all read AGENTS.md per this standard.
-
-## Skill file path and propagation — decision record
-
-**`.agents/skills/` is the canonical path for Lovable-created skill files.**
-This is based on observed behavior: Lovable auto-creates skill files at
-`.agents/skills/<name>.md` in the project repo. The Lovable Skills docs
-(docs.lovable.dev/features/skills) confirm an "Import from GitHub" pull-based
-path exists but do not pin a specific repo directory or auto-sync mechanism.
-
-`.lovable/skills/` is not a Lovable-defined standard — it is an arbitrary convention
-not derived from Lovable's own file-creation behavior. If you encounter `.lovable/skills/`
-references in any consuming project, treat them as incorrect; `.agents/skills/` is the
-correct path.
-
-**Propagation:** the GitHub-import path in the docs establishes that Lovable can
-read files from the repo. The "instruct Lovable to re-read" propagation pattern
-rests on in-product behavior (Lovable confirmed it can apply changes from repo
-files when asked). Re-verify if Lovable's behavior changes.

--- a/plugins/lovable-cloud/skills/lovable-cloud-knowledge/REFERENCES.md
+++ b/plugins/lovable-cloud/skills/lovable-cloud-knowledge/REFERENCES.md
@@ -41,3 +41,21 @@ All four are loaded every session. Lovable docs warn that in very long conversat
 ## Cross-agent context
 
 - [agents.md standard](https://agents.md) — the cross-agent AGENTS.md spec referenced in the four-source priority list above. Lovable, Codex, Cursor, Aider, etc. all read AGENTS.md per this standard.
+
+## Skill file path and propagation — decision record
+
+**`.agents/skills/` is the canonical path for Lovable-created skill files.**
+This is based on observed behavior: Lovable auto-creates skill files at
+`.agents/skills/<name>.md` in the project repo. The Lovable Skills docs
+(docs.lovable.dev/features/skills) confirm an "Import from GitHub" pull-based
+path exists but do not pin a specific repo directory or auto-sync mechanism.
+
+`.lovable/skills/` is not a Lovable-defined standard — it is an arbitrary convention
+not derived from Lovable's own file-creation behavior. If you encounter `.lovable/skills/`
+references in any consuming project, treat them as incorrect; `.agents/skills/` is the
+correct path.
+
+**Propagation:** the GitHub-import path in the docs establishes that Lovable can
+read files from the repo. The "instruct Lovable to re-read" propagation pattern
+rests on in-product behavior (Lovable confirmed it can apply changes from repo
+files when asked). Re-verify if Lovable's behavior changes.

--- a/plugins/lovable-cloud/skills/lovable-cloud-knowledge/SKILL.md
+++ b/plugins/lovable-cloud/skills/lovable-cloud-knowledge/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Lovable's UI knowledge fields and workspace skill files — `.lovable/*.md`
   repo-mirror workflow, `.agents/skills/` propagation model,
   Project/Workspace scope split, precedence, review criteria.
-  TRIGGER when: editing or reviewing PRs for `.lovable/*.md` or `.agents/skills/*.md`; drafting
+  TRIGGER when: authoring or reviewing changes to `.lovable/*.md` or `.agents/skills/*.md`; drafting
   Project/Workspace Knowledge or workspace-skill changes.
   DO NOT TRIGGER when: not a Lovable project; editing CLAUDE.md or AGENTS.md;
   editing agent rules files; writing code.

--- a/plugins/lovable-cloud/skills/lovable-cloud-knowledge/SKILL.md
+++ b/plugins/lovable-cloud/skills/lovable-cloud-knowledge/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: lovable-cloud-knowledge
 description: >
-  Lovable's UI knowledge fields — `.lovable/*.md` repo-mirror workflow,
+  Lovable's UI knowledge fields and workspace skill files — `.lovable/*.md`
+  repo-mirror workflow, `.agents/skills/` propagation model,
   Project/Workspace scope split, precedence, review criteria.
-  TRIGGER when: editing `.lovable/*.md` or `.lovable/skills/*.md`; drafting
-  Project/Workspace Knowledge or workspace-skill changes; reviewing `.lovable/**` PRs.
+  TRIGGER when: editing `.lovable/*.md` or `.agents/skills/*.md`; drafting
+  Project/Workspace Knowledge or workspace-skill changes; reviewing `.lovable/**` or `.agents/skills/**` PRs.
   DO NOT TRIGGER when: not a Lovable project; editing CLAUDE.md or AGENTS.md;
   editing agent rules files; writing code.
 user-invocable: false
@@ -20,6 +21,7 @@ user-invocable: false
 | Use for | Coding style, naming, libraries/frameworks, architectural patterns, testing requirements, lint rules, brand/voice, **Lovable-platform behavior** | What the app does, user personas, schema/tables, architecture decisions, domain terminology, project-specific constraints, design specifics, security/compliance, links to important references | Reusable procedures Lovable runs on demand |
 | Precedence | — | **Prioritized on conflict** | — |
 | Char limit | 10,000 | 10,000 | **100,000** |
+| Repo path | `.lovable/workspace-knowledge.md` | `.lovable/project-knowledge.md` | `.agents/skills/<name>.md` |
 
 When a rule could plausibly fit in either: ask whether it would apply to
 a *different* project in the same Lovable workspace. If yes →
@@ -28,14 +30,18 @@ constraints) → project.
 
 Project Knowledge is prioritized over Workspace Knowledge on conflict. See REFERENCES.md for the full four-source load priority (Project Knowledge → Workspace Knowledge → AGENTS.md/CLAUDE.md → project code).
 
-## 2. `.lovable/` repo-mirror workflow
+## 2. `.lovable/` repo-mirror workflow (knowledge fields only)
+
+This workflow applies to the **knowledge fields** (`.lovable/project-knowledge.md`
+and `.lovable/workspace-knowledge.md`). It does **not** apply to workspace skill
+files — see §2.5 for the skill-file propagation model.
 
 `.lovable/project-knowledge.md` and `.lovable/workspace-knowledge.md` are
 **version-controlled mirrors** of the corresponding Lovable UI fields.
 Lovable only loads the UI fields at runtime; the repo files are not
 auto-loaded — they exist for diff review and history.
 
-**Workflow** for updating Lovable knowledge:
+**Workflow** for updating Lovable knowledge fields:
 
 1. Draft the change in a PR against the appropriate `.lovable/` file.
 2. Bump the "Last synced to Lovable UI" date in the file header in the
@@ -43,12 +49,37 @@ auto-loaded — they exist for diff review and history.
 3. After merge, the human pastes the merged content into Lovable →
    Settings → Knowledge.
 
-**Do not** assume that writing to `.lovable/` propagates to Lovable. The
-UI field is the only thing Lovable reads; the repo file is the
-authoring/review surface.
+**Do not** assume that writing to a `.lovable/` knowledge file propagates to
+Lovable. The UI field is the only thing Lovable reads; the repo file is the
+authoring/review surface. (Skill files in `.agents/skills/` work differently —
+see §2.5.)
 
-**Do not** skip the repo step and paste directly into the UI without a
-PR — that loses diff review, version history, and audit trail.
+**Do not** skip the repo step and paste knowledge-field content directly into
+the UI without a PR — that loses diff review, version history, and audit trail.
+
+## 2.5. `.agents/skills/` — repo-native skill files
+
+`.agents/skills/` holds the workspace skill files that Lovable auto-creates when
+you define a new skill. Unlike knowledge fields, these files are **not** a
+version-controlled mirror of a UI field — they are the source Lovable reads
+directly from the repo.
+
+**Editing:** editing `.agents/skills/*.md` via PR is permitted and encouraged.
+A file being authored by Lovable (`gpt-engineer-app[bot]`) does **not** make it
+read-only — it is a normal repo file on a normal review surface.
+
+**Propagation:** changes reach Lovable when the PR description instructs Lovable
+(in second person) to re-read the changed skill files and update its skills.
+Example PR description note: *"@Lovable: please re-read `.agents/skills/<name>.md`
+and update your `<name>` skill to match."*
+
+**No sync-date header:** the "Last synced to Lovable UI" date header used in
+knowledge mirror files does **not** apply here — there is no UI field to sync to.
+
+> **Observation note:** `.agents/skills/` is the path Lovable uses when it
+> auto-creates skill files. This is observed behavior, not a documented spec in
+> the Lovable docs — re-verify if Lovable changes its file layout. See
+> REFERENCES.md for the grounding.
 
 ## 3. Authoring guidance
 
@@ -60,14 +91,14 @@ When writing content for either field:
   guidance. "Be careful with auth" can become "add auth checks to public
   endpoints." Spell out the boundary cases.
 - **Context budget.** Both knowledge fields cap at 10,000 chars. Beyond
-  that, Lovable drops content. Skill bodies (`.lovable/skills/*.md`) have
+  that, Lovable drops content. Skill bodies (`.agents/skills/*.md`) have
   a separate 100,000-char limit. Even before either cap, length displaces
   active task instructions — apply the same length and behavior-test
   discipline as Claude Code skills (see `ai-instruction-and-memory-files` §3).
 
-## 4. Review checklist for `.lovable/**` changes
+## 4. Review checklist for `.lovable/**` and `.agents/skills/**` changes
 
-When reviewing a PR that touches `.lovable/*.md` or `.lovable/skills/*.md`:
+When reviewing a PR that touches `.lovable/*.md` or `.agents/skills/*.md`:
 
 1. **Perspective** — Is the new content addressed to Lovable in second
    person?
@@ -77,12 +108,15 @@ When reviewing a PR that touches `.lovable/*.md` or `.lovable/skills/*.md`:
    this-app-specific → `project-knowledge.md`. Project knowledge wins
    on conflict.
 4. **Char budget** — Is the file approaching its char limit? (Check the table above.)
-5. **Sync status** — Has the "Last synced" date been bumped in the same
-   PR? Does the PR description note that the human must paste the merged
-   content into the Lovable UI after merge? (Knowledge files → Settings →
-   Knowledge; skill bodies → Settings → Skills.)
+5. **Sync status:**
+   - *Knowledge files (`.lovable/*.md`):* Has the "Last synced" date been bumped
+     in the same PR? Does the PR description note that the human must paste the
+     merged content into Lovable → Settings → Knowledge after merge?
+   - *Skill files (`.agents/skills/*.md`):* Does the PR description include an
+     instruction to Lovable (second person) to re-read the changed skill files
+     and update its skills? (No sync-date header needed for skill files.)
 
-For `.lovable/skills/*.md` changes, also check:
+For `.agents/skills/*.md` changes, also check:
 
 6. **Skill name** — Is the name 1–64 chars, lowercase letters / numbers /
    hyphens only, not starting or ending with a hyphen, with no consecutive

--- a/plugins/lovable-cloud/skills/lovable-cloud-knowledge/SKILL.md
+++ b/plugins/lovable-cloud/skills/lovable-cloud-knowledge/SKILL.md
@@ -4,8 +4,8 @@ description: >
   Lovable's UI knowledge fields and workspace skill files — `.lovable/*.md`
   repo-mirror workflow, `.agents/skills/` propagation model,
   Project/Workspace scope split, precedence, review criteria.
-  TRIGGER when: editing `.lovable/*.md` or `.agents/skills/*.md`; drafting
-  Project/Workspace Knowledge or workspace-skill changes; reviewing `.lovable/**` or `.agents/skills/**` PRs.
+  TRIGGER when: editing or reviewing PRs for `.lovable/*.md` or `.agents/skills/*.md`; drafting
+  Project/Workspace Knowledge or workspace-skill changes.
   DO NOT TRIGGER when: not a Lovable project; editing CLAUDE.md or AGENTS.md;
   editing agent rules files; writing code.
 user-invocable: false


### PR DESCRIPTION
## Summary

- Corrects the canonical path for Lovable workspace skill files throughout `lovable-cloud-knowledge`: `.lovable/skills/` → `.agents/skills/` (Lovable auto-creates skill files there; the old path was an arbitrary convention)
- Separates the two propagation models the skill previously conflated — knowledge fields (version-controlled UI mirrors; human pastes into Settings) vs. skill files (source Lovable reads directly; changes propagate by instructing Lovable to re-read via PR description)
- Adds explicit editability guidance: `.agents/skills/` files authored by `gpt-engineer-app[bot]` are normal repo files and may be edited via PR
- Adds `.agents/skills/*.md` to `ai-instruction-and-memory-files` DO NOT TRIGGER so that skill doesn't misfire on Lovable skill-file edits
- Bumps `lovable-cloud` plugin `2.4.1 → 3.0.0` (major: path and propagation-model reversals change outcomes for prior-guidance consumers)

## Post-merge install command

Consuming repos should refresh after merge:

```
claude plugin install lovable-cloud@claude-config --scope project
```

## Drop-in CLAUDE.md text for projects with a stale "do not edit" rule

If a private project's CLAUDE.md says something like `"treat this directory as Lovable-owned: do not edit"`, replace it with:

> `.agents/skills/` holds Lovable-authored workspace skills. You **may** edit them via PR — Lovable authorship does not make them read-only. When a PR changes them, add a note in the PR description instructing Lovable to re-read the changed files and update its skills. See the `lovable-cloud-knowledge` skill for the full workflow.

## Test plan

- [x] `pytest claude/.claude/` — 1818 passed, 19 skipped
- [x] `ruff check claude/.claude/` — clean
- [x] `/skill-review` on `lovable-cloud-knowledge/SKILL.md` — passed
- [x] `/skill-review` on `ai-instruction-and-memory-files/SKILL.md` — passed
- [x] `/plugin-semver` — confirmed 3.0.0 (major: path + propagation reversals)
- [x] `/code-review` — passed
- [x] Grep: no `.lovable/skills` remaining in skill directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)