### PR TITLE
fix(skills): add UUID guard and no-restore note to migration-sync Step 6

### DIFF
--- a/plugins/lovable-cloud/skills/lovable-cloud-migration-sync/SKILL.md
+++ b/plugins/lovable-cloud/skills/lovable-cloud-migration-sync/SKILL.md
@@ -147,9 +147,22 @@ Suite-level reruns route through the subagent.
 
 ### 6. Delete originals
 
+**Guard against deleting a Lovable emit instead of a human original.** You are
+deleting human-authored slug-named files, never the UUID-named files Lovable
+emitted. For each path you pass to `git rm`, extract that filename's segment
+between the first `_` and `.sql`; if it matches a UUID shape
+(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`), abort — the
+file is a Lovable UUID emit, not a human original. Delete the human-authored
+slug-named file instead, then wait for Lovable to re-emit.
+
 ```bash
 git rm supabase/migrations/ORIGINAL_1.sql supabase/migrations/ORIGINAL_2.sql ...
 ```
+
+**Do not manually restore a deleted emit.** Re-adding a deleted UUID file by
+hand races Lovable's own re-emit and lands two identical UUID files on `main`.
+If an emit was deleted in error, delete the human original instead and let
+Lovable re-emit on its own.
 
 ### 7. Commit and PR
 


### PR DESCRIPTION
## Summary

- Adds a pre-`git rm` guard to Step 6 of `lovable-cloud-migration-sync`: extracts the filename segment between the first `_` and `.sql` for each deletion target; if it matches the UUID shape, aborts with an explanation — preventing wrong-direction deletion of a Lovable-emitted file
- Adds an explicit "do not manually restore a deleted emit" note below the `git rm` command, with a one-sentence rationale explaining the race condition it prevents
- Bumps `lovable-cloud` plugin version `3.0.0` → `3.1.0` (minor — backward-compatible new capability)

## Test plan

- [ ] Read Step 6 of `plugins/lovable-cloud/skills/lovable-cloud-migration-sync/SKILL.md` and confirm: guard prose is above the `git rm` block, the bare `git rm` command is unchanged, and the restore note is below
- [ ] Confirm no private project names, tracker IDs, or structural fingerprints in the added text

## Post-merge install

Consuming repos should refresh the plugin after merge:

```
claude plugin install lovable-cloud@claude-config --scope project
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)