### PR TITLE
chore(plugin): bump lovable-cloud version 3.0.0 → 3.1.0

### DIFF
--- a/plugins/lovable-cloud/.claude-plugin/plugin.json
+++ b/plugins/lovable-cloud/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lovable-cloud",
   "description": "Skills for Lovable Cloud projects — Project/Workspace Knowledge fields, edge-function auth model, and migration-sync workflow.",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "author": {
     "name": "Cordova Strategy"
   },


### PR DESCRIPTION
## Summary

- Bumps `lovable-cloud` plugin `version` from `3.0.0` to `3.1.0` (minor — backward-compatible)
- Follows the skill/behavior addition landed in #378: UUID guard + no-manual-restore note added to `lovable-cloud-migration-sync` Step 6

## Test plan

- [ ] Confirm `plugins/lovable-cloud/.claude-plugin/plugin.json` has `"version": "3.1.0"`
- [ ] Confirm no `version` field in the `lovable-cloud` entry of `.claude-plugin/marketplace.json`

## Post-merge install

Consuming repos should refresh the plugin after merge:

```
claude plugin install lovable-cloud@claude-config --scope project
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)