### PR TITLE
feat(skills): add error propagation & capture axis to error-handling skill

### DIFF
--- a/.claude/plans/error-handling-propagation-axis.md
+++ b/.claude/plans/error-handling-propagation-axis.md
@@ -1,0 +1,110 @@
+# Extend the `error-handling` skill with a propagation & capture axis
+
+## Context
+
+The global `error-handling` skill (`claude/.claude/skills/error-handling/`) today has
+eight rules and three anti-patterns, all governing the **response envelope** — the shape
+that crosses the wire to a consumer. It is silent on the orthogonal axis: how an error
+travels from origin to response (throw vs. return), where telemetry capture lives, and how
+serverless/edge runtimes must flush before termination. That silence let a real system ship
+a wrong design (telemetry capture wired into a pure response formatter instead of a handler
+boundary). This change adds a second, primary-source-backed axis so future work has one
+authoritative reference for both the error *envelope* and the error *propagation/capture*
+model. The content is engineer-approved as drafted and vendor-neutral — no project names,
+no secrets (this repo is public).
+
+Scope is two files in one skill directory plus its frontmatter description.
+
+## Approach
+
+Add the new axis as a distinct top-level section so it reads as orthogonal to the eight
+envelope rules, not as more envelope rules. Section placement and the frontmatter
+description update were confirmed with the user.
+
+Line numbers below are pre-edit locators for the current file; anchor each Edit on the
+surrounding heading text, not absolute line numbers (editing the frontmatter in step 4 shifts
+every line below it).
+
+**1. `SKILL.md` — new `## Error propagation & capture (server-side)` section.**
+Insert immediately after "The eight rules" (ends ~line 72) and before "## Anti-patterns"
+(~line 74). Four rules **P1–P4** as `### P1` … `### P4` to match the existing `### Rule N`
+heading level. The operational-vs-programmer-error distinction is cited under **P2** (triage),
+not P1.
+
+**2. `SKILL.md` — fold anti-patterns D–F into the existing `## Anti-patterns` section.**
+Append `### D`, `### E`, `### F` after the current `### C` (line 97).
+
+**3. `SKILL.md` — seven new Review-checklist items (13–19).** Append after the current
+item 12 (line 112). P1–P4 and anti-patterns D, E, F each get a corresponding checklist item.
+
+**4. `SKILL.md` — extend the frontmatter `description:`.** The description is the skill's
+trigger surface, loaded every session. It currently names only the envelope axis, so the
+skill would not surface for propagation/capture/telemetry-flush prompts despite now covering
+them. Reword to add the propagation axis (throw-vs-return, centralized capture boundary,
+serverless flush) alongside the existing envelope phrasing. No change to envelope wording.
+
+**5. `REFERENCES.md` — append the citation dossier.** Add the 16-source dossier matching
+the file's existing per-source block format (`## Source`, `**URL:**`,
+`**Status:**`, verbatim quote, `**Cited for**`). Mark Joyent/Node.js **PARTIAL** (canonical
+host is JS-gated; verbatim confirmed via author Dave Pacheco's blog mirror + corroborating
+sources); all others **VERIFIED**. Map each quote to the rule it grounds (P1–P4).
+
+Why this shape rather than alternatives: a separate section (vs. extending "The eight rules"
+to a ninth+ rule) keeps the two axes visually and conceptually distinct — envelope = what
+crosses the wire, propagation = how the error gets there and where it's reported. Folding
+D–F into the existing Anti-patterns block (vs. a second anti-patterns block) keeps one
+anti-pattern list the reader scans once.
+
+## Critical files
+
+- `claude/.claude/skills/error-handling/SKILL.md` — new section (after line 72), three
+  anti-patterns (after line 97), checklist items 13–19 (after line 112), frontmatter
+  `description:` reword (lines 3–5). **Do not touch** the eight envelope rules or their
+  wording.
+- `claude/.claude/skills/error-handling/REFERENCES.md` — append 16-source dossier after the
+  current last block (line 86). **Do not reword** the existing envelope citations.
+
+Edit the **repo source** under `claude/.claude/skills/...`, never the stowed mirror at
+`~/.claude/skills/error-handling/` (it's a symlink into this repo; the worktree path resolves
+to the linked worktree, not the main tree).
+
+Reuse: the new content mirrors the file's existing idioms — `### Rule N` heading level for
+`### PN`, the numbered checklist continuation, and the REFERENCES per-source block format. No
+new files; no shared partials (this repo forbids cross-skill `_shared/`).
+
+## Verification
+
+- `../../../.venv/bin/pytest claude/.claude/` — skill/hook test suite passes (run from the
+  worktree; the `.venv` lives at the main worktree root, three levels up).
+- `../../../.venv/bin/ruff check claude/.claude/` — lint clean.
+- Manual read-through: confirm P1–P4 and D–F contain no PR-defined terminology or "used to
+  be X" framing, and that every internal cross-ref (Rule 1, Rule 4, Rule 8, Anti-pattern C)
+  resolves within the file.
+- Invoke `/skill-review` against the SKILL.md diff and address findings. This is
+  **hook-enforced** (`require-skill-review.sh` blocks `git commit` on a SKILL.md change until
+  the behavioral-equivalence marker is written). Watch for a verbosity finding — the body
+  grows ~50 lines; each rule must earn its place or skill-review will flag it.
+- Run `/code-review`; it dispatches `/skill-review` for the SKILL.md file automatically.
+
+## Execution order (post-approval)
+
+1. `branch-creation` skill → slug, then `git worktree add .claude/worktrees/<slug> -b <slug>`
+   from the main tree (worktree enforcement is active).
+2. Move this plan into the worktree's **repo-root** `.claude/plans/<slug>.md` (tracked — see
+   `.gitignore`: `.claude/plans/` ships with the PR). Do **not** leave it at
+   `~/.claude/plans/` → that resolves to the stow-package path `claude/.claude/plans/`, which
+   is gitignored; a plan left there is an orphaned scratch file the PR won't include (B17).
+3. Edits 1–5 above, targeting the worktree path under `claude/.claude/skills/error-handling/`.
+4. `/skill-review` → fix findings; `/code-review` → fix findings.
+5. Run pytest + ruff from the worktree.
+6. **Confirm with the engineer before pushing / opening the PR** (external action; shared
+   state). PR per repo conventions; vendor-neutral, no project names/secrets.
+7. **Do not merge** — engineer-only (repo rule: AI agent that opens a PR does not merge it).
+
+## Out of scope
+
+- Project-specific implementation (a concrete error-boundary wrapper or typed error class for
+  any particular codebase) — belongs in the consuming repo, not this vendor-neutral skill.
+- The existing eight envelope rules and their REFERENCES citations — not reworded.
+- Adding a pointer to P1–P4 from the `lovable-cloud` plugin's edge-functions skill — kept
+  out of scope; file separately if desired.

--- a/claude/.claude/skills/error-handling/REFERENCES.md
+++ b/claude/.claude/skills/error-handling/REFERENCES.md
@@ -83,3 +83,181 @@ Supporting reference for the same consumer-UX principle as NN/g: no raw codes in
 **Status:** URL not verified via automated fetch.
 
 Supporting reference for the same consumer-UX principle as NN/g: no raw codes in user-facing copy; plain-language messages.
+
+---
+
+## Microsoft .NET — Best Practices for Exceptions
+
+**URL:** https://learn.microsoft.com/en-us/dotnet/standard/exceptions/best-practices-for-exceptions
+**Status:** VERIFIED
+
+"Use exception handling if the event doesn't occur often, that is, if the event is truly exceptional and indicates an error, such as an unexpected end-of-file." / "A common error case can be considered a normal flow of control."
+
+Also: custom exceptions should include "a constructor that takes a string message and an inner exception"; "An alternative is to throw a new exception and include the original exception as the inner exception."
+
+**Cited for P1** (throw the unexpected, return the expected) **and P3** (carry the underlying cause as inner exception).
+
+---
+
+## Microsoft .NET — Exceptions and Performance
+
+**URL:** https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/exceptions-and-performance
+**Status:** VERIFIED
+
+Try-Parse pattern: "If the member fails for any reason other than the well-defined try, the member must still throw a corresponding exception."
+
+**Cited for P1.** Expected failure modes have a Try-Parse return; all other failures throw.
+
+---
+
+## Oracle — Java Tutorials (Unchecked Exceptions — The Controversy)
+
+**URL:** https://docs.oracle.com/javase/tutorial/essential/exceptions/runtime.html
+**Status:** VERIFIED
+
+"If a client can reasonably be expected to recover from an exception, make it a checked exception. If a client cannot do anything to recover from the exception, make it an unchecked exception." / "Runtime exceptions represent problems that are the result of a programming problem."
+
+**Cited for P1.** Recoverable conditions → return (checked equivalent); programmer errors → throw unchecked.
+
+---
+
+## Python — Glossary (EAFP)
+
+**URL:** https://docs.python.org/3/glossary.html
+**Status:** VERIFIED
+
+"Easier to ask for forgiveness than permission. This common Python coding style assumes the existence of valid keys or attributes and catches exceptions if the assumption proves false."
+
+**Cited for P1.** Expected outcomes use exception handling; unexpected failures propagate up.
+
+---
+
+## Joyent / Node.js — Error Handling in Node.js (PARTIAL)
+
+**URL:** https://www.tritondatacenter.com/node-js/production/design/errors (mirror: https://www.davepacheco.net/blog/2014/error-handling-nodejs/)
+**Status:** PARTIAL — canonical host is JavaScript-gated; verbatim quotes confirmed via author Dave Pacheco's blog mirror and multiple corroborating sources.
+
+"Operational errors represent run-time problems experienced by correctly-written programs. These are not bugs in the program." / "Programmer errors are bugs in the program. These are things that can always be avoided by changing the code."
+
+**Cited for P2** (triage at the boundary — operational failure vs. programmer error). This is the primary source for the triage vocabulary used in P2.
+
+---
+
+## Microsoft — ASP.NET Core, Handle Errors
+
+**URL:** https://learn.microsoft.com/en-us/aspnet/core/fundamentals/error-handling
+**Status:** VERIFIED
+
+UseExceptionHandler middleware "Catches and logs unhandled exceptions"; IExceptionHandler "gives the developer a callback for handling known exceptions in a central location."
+
+**Cited for P2.** Centralized handler boundary is the framework-idiomatic capture point; scatter across catch blocks is the anti-pattern the middleware is designed to replace.
+
+---
+
+## Express — Error Handling
+
+**URL:** https://expressjs.com/en/guide/error-handling.html
+**Status:** VERIFIED
+
+"You define error-handling middleware last, after other app.use() and routes calls"; signature `(err, req, res, next)`; "If synchronous code throws an error, then Express will catch and process it."
+
+**Cited for P2.** Error-handling middleware is the canonical single boundary in Express; per-route catch blocks are the anti-pattern.
+
+---
+
+## Sentry — Handler Wrappers (Lambda / Cloudflare)
+
+**URL:** https://docs.sentry.io/platforms/javascript/guides/aws-lambda/ (Sentry.wrapHandler) and https://docs.sentry.io/platforms/javascript/guides/cloudflare/ (Sentry.withSentry)
+**Status:** VERIFIED
+
+Wrapper functions are the SDK's recommended integration point for serverless handler boundaries.
+
+**Cited for P2.** SDK-provided handler wrappers are the preferred capture boundary in serverless runtimes.
+
+---
+
+## Go (Google) — Working with Errors in Go 1.13
+
+**URL:** https://go.dev/blog/go1.13-errors
+**Status:** VERIFIED
+
+`%w` wrapping — the wrapped error "will have an Unwrap method returning the argument"; "Wrap an error to expose it to callers. Do not wrap an error when doing so would expose implementation details."
+
+**Cited for P3.** Wrapping preserves the original error and its stack through error chains; `%w` is Go's typed-cause idiom.
+
+---
+
+## Google Cloud AIP-193 — ErrorInfo
+
+**URL:** https://google.aip.dev/193
+**Status:** VERIFIED
+
+Structured `ErrorInfo` (reason + domain + metadata) as machine-readable error carrier.
+
+**Cited for P3.** Typed, structured error payload carries the registry code and cause as machine-readable fields — not stringified into a message.
+
+---
+
+## MDN — Error.cause / Custom Error Types
+
+**URL:** https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+**Status:** VERIFIED
+
+"define your own error types deriving from Error … throw new MyError() … cleaner and more consistent error handling"; `cause` gives "access to the original error."
+
+**Cited for P3.** JavaScript's `Error.cause` is the standard mechanism for preserving the original exception when re-throwing a typed subclass.
+
+---
+
+## AWS Lambda — Execution Environment Lifecycle
+
+**URL:** https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtime-environment.html
+**Status:** VERIFIED
+
+"Lambda freezes the execution environment when the runtime and each extension have completed and there are no pending events." / "Make sure that any background processes or callbacks in your code are complete before the code exits."
+
+**Cited for P4.** The execution environment is frozen on response return; async telemetry not awaited before that point is lost.
+
+---
+
+## Cloudflare Workers — context.waitUntil
+
+**URL:** https://developers.cloudflare.com/workers/runtime-apis/context/
+**Status:** VERIFIED
+
+`waitUntil` "extends the lifetime of your Worker … may continue after a response is returned … for work that can run after the response is sent, such as logging, analytics."
+
+**Cited for P4.** `waitUntil` is appropriate for fire-and-forget analytics; error capture that requires delivery confirmation must be awaited before the response is returned, not deferred into `waitUntil`.
+
+---
+
+## Google Cloud Run — CPU Allocation
+
+**URL:** https://cloud.google.com/run/docs/configuring/cpu-allocation
+**Status:** VERIFIED
+
+"With request-based billing, CPU is only allocated during request processing."
+
+**Cited for P4.** CPU (and therefore async work) is suspended when the response is returned; telemetry must flush within the request window.
+
+---
+
+## Sentry — Lambda Wrapper flushTimeout
+
+**URL:** https://docs.sentry.io/platforms/javascript/guides/aws-lambda/configuration/lambda-wrapper/
+**Status:** VERIFIED
+
+"Sentry keeps the lambda function thread alive for up to 2 seconds to ensure reported errors are sent." (configurable `flushTimeout`)
+
+**Cited for P4.** The ~2000 ms vendor default for telemetry flush is the grounding citation for the numeric value mentioned in P4.
+
+---
+
+## Sentry — flush() API
+
+**URL:** https://docs.sentry.io/platforms/javascript/configuration/apis/
+**Status:** VERIFIED
+
+"Flushes all pending events." / timeout: "the client should wait to flush its event queue … wait until all events are sent before resolving the promise."
+
+**Cited for P4.** `flush()` is the explicit API for awaiting telemetry delivery; the `timeout` parameter maps to the vendor-default value cited in the Lambda wrapper doc above.

--- a/claude/.claude/skills/error-handling/SKILL.md
+++ b/claude/.claude/skills/error-handling/SKILL.md
@@ -2,7 +2,8 @@
 name: error-handling
 description: >
   Standard error-handling: single code namespace, RFC 9457–derived envelope,
-  developer-only message fields, and anti-patterns for call-site drift.
+  developer-only message fields, throw-vs-return propagation, centralized
+  capture boundary, serverless telemetry flush, and anti-patterns for call-site and capture drift.
 ---
 
 # Error Handling Standard
@@ -71,6 +72,22 @@ Decision test: would the client or support team act differently on this code tha
 
 Never override the response status so it diverges from what the code's registry entry maps to. If a path needs a new status, mint the code that owns that status (including any protocol-required headers, e.g. `Allow` for 405 per RFC 9110 §15.5.6).
 
+## Error propagation & capture (server-side)
+
+The eight rules above govern the response *envelope* — what crosses the wire to the consumer. These four govern the orthogonal axis: how an error travels from its origin to the response, and where it is reported to telemetry.
+
+### P1 — Throw the unexpected; return the expected
+Expected, recoverable conditions (invalid input, unauthorized, not found, conflict) are normal control flow — return the structured envelope. Genuinely unexpected failures (a query that should have succeeded, a broken dependency, an unreachable branch) are exceptions — throw them and let the boundary (P2) report and format. Reserve exceptions for the exceptional; do not use them for routine control flow, and do not swallow-and-return what the caller cannot act on.
+
+### P2 — Capture at one centralized boundary
+Telemetry capture (error tracker / APM) belongs in a single handler-boundary wrapper that every entry point routes through — not scattered across catch blocks, and not inside the response formatter (which stays pure: code → envelope). The boundary is where each error is triaged — an operational failure (a runtime problem in correct code, e.g. a dependency 500 or socket hang-up) versus a programmer error (a bug) — and where the capture-log-respond decision is made once.
+
+### P3 — Throw a typed error carrying the registry code + cause
+When you throw across a boundary, throw a typed error subclass carrying (a) the application error code from the single registry (Rule 1) so the boundary formats the correct envelope, and (b) the underlying cause so the original exception and its stack are preserved for capture. Do not discard the cause; do not stringify it into the user-facing message (Rule 4).
+
+### P4 — Flush telemetry before a serverless/edge runtime terminates
+In serverless and edge runtimes the execution environment is frozen or reclaimed once the response is returned, and telemetry events are sent asynchronously. The boundary must await the SDK's flush (vendor default ~2000 ms) before returning, or pending events are dropped. Background-task deferral APIs are for fire-and-forget work where delivery confirmation is not needed; error capture wants the flush completed before the response returns.
+
 ## Anti-patterns
 
 ### A — Hardcoded call-site copy
@@ -96,6 +113,18 @@ A code is a contract between a producer that emits it and a consumer that maps i
 
 Never override the HTTP status to diverge from what the code's registered status maps to (e.g., emitting a 400-class code but forcing the response to `405`). Mint the correct code that owns the intended status instead.
 
+### D — Capture inside the response formatter
+
+Couples telemetry to HTTP-body formatting; forces sync/async contortions, a status gate, and still misses any hand-rolled response that bypasses the formatter. Capture belongs at the boundary (P2).
+
+### E — Decide capture by inspecting the returned response status
+
+By the time a 5xx Response object exists, the original exception has been discarded — you capture a stack-less event. Throw (P1) so the boundary holds the real error.
+
+### F — Mask a captured failure as success via status override
+
+Forcing a registry-500 code to a 200 response to suppress a retry hides the failure from status-based observers. Mint the code that owns the intended status (cross-ref Rule 8 / Anti-pattern C).
+
 ## Review checklist
 
 1. **Single namespace** — Are infrastructure codes (DB SQLSTATE, vendor codes) logged only, never propagated as user-visible identifiers?
@@ -110,5 +139,12 @@ Never override the HTTP status to diverge from what the code's registered status
 10. **Anti-pattern B** — Are there codes in the registry that no server path ever emits?
 11. **Anti-pattern C** — Are there HTTP status overrides that diverge from the code's registered status?
 12. **Auth-conditional verbosity** — Does the error response vary in detail level based on caller authentication status? The same envelope shape and information content must be returned to all callers — richer detail belongs in server-side logs only, not in any authenticated response tier.
+13. **Throw vs. return** — Are unexpected failures thrown (not returned), and expected recoverable conditions returned as structured envelopes? (P1)
+14. **Capture boundary** — Is telemetry capture wired into a single handler-boundary wrapper rather than scattered across catch blocks or inside the response formatter? (P2)
+15. **Typed throw** — When throwing across a boundary, does the error carry (a) the application error code from the single registry and (b) the underlying cause? Is the cause preserved rather than stringified into the user-facing message? (P3)
+16. **Serverless flush** — In serverless/edge runtimes, does the boundary await the telemetry SDK's flush before returning? Are background-task deferral APIs reserved for fire-and-forget work rather than error capture? (P4)
+17. **Anti-pattern D** — Is telemetry capture co-located with or inside the response formatter? It must live at the handler boundary. (D)
+18. **Anti-pattern E** — Is there any code that decides whether to capture telemetry by inspecting the HTTP status of a returned Response object? That pattern discards the original exception; throw instead so the boundary holds the real error. (E)
+19. **Anti-pattern F** — Is any code forcing a registry-mapped-5xx error to a 200 response to suppress retries? Mint the code that owns the intended status. (Rule 8 / C / F)
 
 See `~/.claude/skills/error-handling/REFERENCES.md` for the research and primary-source citations behind these rules.

--- a/claude/.claude/skills/error-handling/SKILL.md
+++ b/claude/.claude/skills/error-handling/SKILL.md
@@ -1,9 +1,13 @@
 ---
 name: error-handling
 description: >
-  Standard error-handling: single code namespace, RFC 9457–derived envelope,
-  developer-only message fields, throw-vs-return propagation, centralized
-  capture boundary, serverless telemetry flush, and anti-patterns for call-site and capture drift.
+  Error-handling: envelope, propagation, and capture rules for server-side APIs.
+  TRIGGER when: reviewing server-side catch blocks, response formatters, telemetry
+  capture, or serverless error boundaries; defining or auditing application error
+  codes or the code registry; reviewing API error response shapes.
+  DO NOT TRIGGER when: reviewing client-side error display only with no server
+  path in diff; reviewing test assertions on error shapes without touching
+  production code.
 ---
 
 # Error Handling Standard


### PR DESCRIPTION
## Summary

- Adds a second axis to the `error-handling` skill: **propagation & capture** (P1–P4), orthogonal to the existing eight envelope rules
- Folds three new anti-patterns (D–F) into the existing anti-patterns section
- Extends the review checklist with items 13–19 (one per P1–P4, D, E, F)
- Adds a 16-source primary-source dossier to `REFERENCES.md` (Microsoft .NET, Oracle Java, Python, Joyent/Node.js, ASP.NET Core, Express, Sentry, Go, Google Cloud AIP-193, MDN, AWS Lambda, Cloudflare Workers, Google Cloud Run)
- Adds `TRIGGER when:` / `DO NOT TRIGGER when:` routing blocks to the frontmatter description

## What's new

| Rule | Summary |
|---|---|
| P1 | Throw the unexpected; return the expected |
| P2 | Capture at one centralized handler boundary |
| P3 | Throw a typed error carrying the registry code + cause |
| P4 | Flush telemetry before serverless/edge runtime terminates |
| D | Anti-pattern: capture inside the response formatter |
| E | Anti-pattern: decide capture by inspecting returned response status |
| F | Anti-pattern: mask a captured failure as success via status override |

## Test plan

- [ ] `../../../.venv/bin/pytest claude/.claude/` passes (no hook/skill test regressions)
- [ ] `../../../.venv/bin/ruff check claude/.claude/` lint clean
- [ ] Read SKILL.md and confirm all internal cross-refs (Rule 1, Rule 4, Rule 8, Anti-pattern C, P1, P2) resolve within the file
- [ ] Confirm no project names, private tracker IDs, or vendor-specific function tokens in the skill body

## Deferred (follow-up)

- Heading scheme unification (`### Rule N` vs `### PN`): informational, orthogonal to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)